### PR TITLE
feat: `RestControllerAdvice` 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.3'
+	id 'org.springframework.boot' version '3.2.4'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -33,6 +33,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/medicare_call/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/medicare_call/global/GlobalExceptionHandler.java
@@ -1,0 +1,101 @@
+package com.example.medicare_call.global;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice(
+    basePackages = {"com.example.medicare_call.controller"},
+    annotations = {RestController.class}
+)
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+            errors.put(error.getField(), error.getDefaultMessage())
+        );
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "잘못된 요청 (Validation)",
+                "입력값이 올바르지 않습니다.",
+                errors
+        );
+        log.warn("Validation failed: {}", errors);
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "잘못된 요청",
+                e.getMessage(),
+                null
+        );
+        log.error(e.getMessage(), e);
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleResourceNotFoundException(ResourceNotFoundException e) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.NOT_FOUND.value(),
+                "리소스를 찾을 수 없음",
+                e.getMessage(),
+                null
+        );
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGenericException(Exception e) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "서버 오류",
+                "내부 서버 오류가 발생했습니다.",
+                null
+        );
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+
+    public static class ErrorResponse {
+        private int status;
+        private String error;
+        private String message;
+        private Map<String, String> fieldErrors;
+
+        public ErrorResponse(int status, String error, String message, Map<String, String> fieldErrors) {
+            this.status = status;
+            this.error = error;
+            this.message = message;
+            this.fieldErrors = fieldErrors;
+        }
+
+        public int getStatus() {
+            return status;
+        }
+
+        public String getError() {
+            return error;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public Map<String, String> getFieldErrors() {
+            return fieldErrors;
+        }
+    }
+} 

--- a/src/main/java/com/example/medicare_call/global/ResourceNotFoundException.java
+++ b/src/main/java/com/example/medicare_call/global/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.medicare_call.global;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+} 


### PR DESCRIPTION
- controller에서 handle되지 않은 에러들을 받아서 처리하고, API 응답에 구체화하여 내려주는 handler을 추가하자
- 최신 스프링부트의 `RestControllerAdvice`와 Swagger을 같이 사용하면 발생하는 문제가 있으니 version을 내리자
  -  참고: https://dev-meung.tistory.com/entry/%ED%95%B4%EC%BB%A4%ED%86%A4-HY-THON-%ED%8A%B8%EB%9F%AC%EB%B8%94%EC%8A%88%ED%8C%85-Swagger-500-%EC%97%90%EB%9F%AC-Failed-to-load-API-definition