### PR TITLE
feat: 어르신 건강 정보 등록 API

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/ElderHealthInfoController.java
+++ b/src/main/java/com/example/medicare_call/controller/ElderHealthInfoController.java
@@ -1,0 +1,26 @@
+package com.example.medicare_call.controller;
+
+import com.example.medicare_call.dto.ElderHealthRegisterRequest;
+import com.example.medicare_call.service.ElderHealthInfoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "ElderHealthInfo", description = "어르신 건강정보(질환, 복약주기, 특이사항) 등록 API")
+@RestController
+@RequestMapping("/elders/{elderId}/health-info")
+@RequiredArgsConstructor
+public class ElderHealthInfoController {
+    private final ElderHealthInfoService elderHealthInfoService;
+
+    @Operation(summary = "어르신 건강정보 등록", description = "질환, 복약주기, 특이사항을 등록합니다.")
+    @PostMapping
+    public ResponseEntity<Void> registerElderHealthInfo(@PathVariable Integer elderId, @Valid @RequestBody ElderHealthRegisterRequest request) {
+        elderHealthInfoService.registerElderHealthInfo(elderId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+} 

--- a/src/main/java/com/example/medicare_call/domain/MedicationSchedule.java
+++ b/src/main/java/com/example/medicare_call/domain/MedicationSchedule.java
@@ -24,30 +24,17 @@ public class MedicationSchedule {
     @JoinColumn(name = "medication_id", nullable = false)
     private Medication medication;
 
-    @Column(name = "dosage", length = 50)
-    private String dosage;
-
     @Column(name = "schedule_time", nullable = false)
-    private java.time.LocalTime scheduleTime;
-
-    @Column(name = "frequency_type", nullable = false)
-    private Byte frequencyType;
-
-    @Column(name = "frequency_detail", length = 100)
-    private String frequencyDetail;
+    private String scheduleTime;
 
     @Column(name = "notes", length = 500)
     private String notes;
 
     @Builder
-    public MedicationSchedule(Integer id, Elder elder, Medication medication, String dosage, java.time.LocalTime scheduleTime, Byte frequencyType, String frequencyDetail, String notes) {
+    public MedicationSchedule(Integer id, Elder elder, Medication medication, String scheduleTime) {
         this.id = id;
         this.elder = elder;
         this.medication = medication;
-        this.dosage = dosage;
         this.scheduleTime = scheduleTime;
-        this.frequencyType = frequencyType;
-        this.frequencyDetail = frequencyDetail;
-        this.notes = notes;
     }
 } 

--- a/src/main/java/com/example/medicare_call/dto/ElderHealthRegisterRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/ElderHealthRegisterRequest.java
@@ -1,0 +1,51 @@
+package com.example.medicare_call.dto;
+
+import com.example.medicare_call.global.enums.ElderHealthNoteType;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ElderHealthRegisterRequest {
+    private List<String> diseaseNames;
+    private List<MedicationScheduleRequest> medicationSchedules;
+    @Schema(
+        description = "특이사항(여러 개 선택 가능)\n" +
+            "INSOMNIA: 불면증 / 수면장애\n" +
+            "FORGET_MEDICATION: 약 자주 잊음\n" +
+            "WALKING_DIFFICULTY: 보행 불편\n" +
+            "HEARING_LOSS: 청력 저하\n" +
+            "COGNITIVE_DECLINE: 인지저하 의심\n" +
+            "MOOD_SWINGS: 감정기복\n" +
+            "RECENT_SPOUSE_DEATH: 최근 배우자 사망\n" +
+            "SMOKING: 흡연\n" +
+            "DRINKING: 음주\n" +
+            "ALCOHOL_ADDICTION: 알콜중독\n" +
+            "VISUAL_IMPAIRMENT: 시각장애",
+        example = "[\"INSOMNIA\", \"FORGET_MEDICATION\"]"
+    )
+    private List<ElderHealthNoteType> notes;
+
+    @Getter
+    @NoArgsConstructor
+    public static class MedicationScheduleRequest {
+        private String medicationName;
+        private List<MedicationScheduleTime> scheduleTimes;
+
+        @Builder
+        public MedicationScheduleRequest(String medicationName, List<MedicationScheduleTime> scheduleTimes) {
+            this.medicationName = medicationName;
+            this.scheduleTimes = scheduleTimes;
+        }
+
+        public List<MedicationScheduleTime> getScheduleTimes() { return scheduleTimes; }
+    }
+} 

--- a/src/main/java/com/example/medicare_call/global/enums/ElderHealthNoteType.java
+++ b/src/main/java/com/example/medicare_call/global/enums/ElderHealthNoteType.java
@@ -1,0 +1,29 @@
+package com.example.medicare_call.global.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "어르신 특이사항 Enum")
+public enum ElderHealthNoteType {
+    @Schema(description = "불면증 / 수면장애")
+    INSOMNIA,
+    @Schema(description = "약 자주 잊음")
+    FORGET_MEDICATION,
+    @Schema(description = "보행 불편")
+    WALKING_DIFFICULTY,
+    @Schema(description = "청력 저하")
+    HEARING_LOSS,
+    @Schema(description = "인지저하 의심")
+    COGNITIVE_DECLINE,
+    @Schema(description = "감정기복")
+    MOOD_SWINGS,
+    @Schema(description = "최근 배우자 사망")
+    RECENT_SPOUSE_DEATH,
+    @Schema(description = "흡연")
+    SMOKING,
+    @Schema(description = "음주")
+    DRINKING,
+    @Schema(description = "알콜중독")
+    ALCOHOL_ADDICTION,
+    @Schema(description = "시각장애")
+    VISUAL_IMPAIRMENT
+} 

--- a/src/main/java/com/example/medicare_call/global/enums/MedicationScheduleTime.java
+++ b/src/main/java/com/example/medicare_call/global/enums/MedicationScheduleTime.java
@@ -1,0 +1,8 @@
+package com.example.medicare_call.global.enums;
+
+// 복약 시간대(아침, 점심, 저녁 등)
+public enum MedicationScheduleTime {
+    MORNING, // 아침
+    LUNCH,   // 점심
+    DINNER   // 저녁
+} 

--- a/src/main/java/com/example/medicare_call/repository/DiseaseRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/DiseaseRepository.java
@@ -3,5 +3,8 @@ package com.example.medicare_call.repository;
 import com.example.medicare_call.domain.Disease;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DiseaseRepository extends JpaRepository<Disease, Integer> {
+    Optional<Disease> findByName(String name);
 } 

--- a/src/main/java/com/example/medicare_call/repository/MedicationRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/MedicationRepository.java
@@ -3,5 +3,8 @@ package com.example.medicare_call.repository;
 import com.example.medicare_call.domain.Medication;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MedicationRepository extends JpaRepository<Medication, Integer> {
+    Optional<Medication> findByName(String name);
 } 

--- a/src/main/java/com/example/medicare_call/service/ElderHealthInfoService.java
+++ b/src/main/java/com/example/medicare_call/service/ElderHealthInfoService.java
@@ -1,0 +1,69 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.dto.ElderHealthRegisterRequest;
+import com.example.medicare_call.domain.*;
+import com.example.medicare_call.repository.*;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ElderHealthInfoService {
+    private final ElderRepository elderRepository;
+    private final ElderHealthInfoRepository elderHealthInfoRepository;
+    private final ElderDiseaseRepository elderDiseaseRepository;
+    private final DiseaseRepository diseaseRepository;
+    private final MedicationRepository medicationRepository;
+    private final MedicationScheduleRepository medicationScheduleRepository;
+
+    @Transactional
+    public void registerElderHealthInfo(Integer elderId, ElderHealthRegisterRequest request) {
+        // TODO : 이쪽 Exception에 대한 Monitoring 추가 필요. 데이터의 무결성이 깨졌을 확률이 높다
+       Elder elder = elderRepository.findById(elderId)
+               .orElseThrow(() -> new IllegalArgumentException("어르신을 찾을 수 없습니다. elderId: " + elderId));
+
+       // 질환 등록
+       for (String diseaseName : request.getDiseaseNames()) {
+           // 기획 변경: 사용자의 입력을 그대로 받는 방식으로 (데이터의 중복만 최소화하자)
+           Disease disease = diseaseRepository.findByName(diseaseName)
+                   .orElseGet(() -> diseaseRepository.save(Disease.builder().name(diseaseName).build()));
+
+           ElderDisease elderDisease = ElderDisease.builder()
+                   .elder(elder)
+                   .disease(disease)
+                   .build();
+           elderDiseaseRepository.save(elderDisease);
+       }
+
+       // 복약 주기 등록
+       for (ElderHealthRegisterRequest.MedicationScheduleRequest msReq : request.getMedicationSchedules()) {
+           // 기획 변경: 사용자의 입력을 그대로 받는 방식으로 (데이터의 중복만 최소화하자)
+           Medication medication = medicationRepository.findByName(msReq.getMedicationName())
+                   .orElseGet(() -> medicationRepository.save(Medication.builder().name(msReq.getMedicationName()).build()));
+
+           String scheduleTime = msReq.getScheduleTimes().stream()
+                   .map(Enum::name)
+                   .collect(Collectors.joining(","));
+
+           MedicationSchedule schedule = MedicationSchedule.builder()
+                   .elder(elder)
+                   .medication(medication)
+                   .scheduleTime(scheduleTime)
+                   .build();
+           medicationScheduleRepository.save(schedule);
+       }
+
+       // 특이사항 등록 (notes는 Enum 여러 개를 콤마로 join해서 저장)
+       String notes = request.getNotes() != null ?
+               request.getNotes().stream().map(Enum::name).collect(Collectors.joining(",")) : null;
+       ElderHealthInfo healthInfo = ElderHealthInfo.builder()
+               .elder(elder)
+               .notes(notes)
+               .build();
+       elderHealthInfoRepository.save(healthInfo);
+    }
+} 

--- a/src/main/resources/db/migration/V2__medication_schedule_time_to_string.sql
+++ b/src/main/resources/db/migration/V2__medication_schedule_time_to_string.sql
@@ -1,0 +1,2 @@
+ALTER TABLE MedicationSchedule
+MODIFY COLUMN schedule_time VARCHAR(50) NOT NULL;

--- a/src/test/java/com/example/medicare_call/controller/ElderHealthInfoControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/ElderHealthInfoControllerTest.java
@@ -1,0 +1,44 @@
+package com.example.medicare_call.controller;
+
+import com.example.medicare_call.dto.ElderHealthRegisterRequest;
+import com.example.medicare_call.global.enums.ElderHealthNoteType;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
+import com.example.medicare_call.service.ElderHealthInfoService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ElderHealthInfoController.class)
+class ElderHealthInfoControllerTest {
+    @Autowired MockMvc mockMvc;
+    @MockBean ElderHealthInfoService elderHealthInfoService;
+    @Autowired ObjectMapper objectMapper;
+
+    @Test
+    void registerElderHealthInfo_success() throws Exception {
+        ElderHealthRegisterRequest.MedicationScheduleRequest msReq = ElderHealthRegisterRequest.MedicationScheduleRequest.builder()
+                .medicationName("당뇨약")
+                .scheduleTimes(List.of(MedicationScheduleTime.MORNING, MedicationScheduleTime.DINNER))
+                .build();
+        ElderHealthRegisterRequest request = ElderHealthRegisterRequest.builder()
+                .diseaseNames(List.of("당뇨"))
+                .medicationSchedules(List.of(msReq))
+                .notes(List.of(ElderHealthNoteType.INSOMNIA))
+                .build();
+
+        mockMvc.perform(post("/elders/{elderId}/health-info", 1)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+    }
+} 

--- a/src/test/java/com/example/medicare_call/service/ElderHealthInfoServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/ElderHealthInfoServiceTest.java
@@ -1,0 +1,60 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.*;
+import com.example.medicare_call.dto.ElderHealthRegisterRequest;
+import com.example.medicare_call.global.enums.ElderHealthNoteType;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
+import com.example.medicare_call.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ElderHealthInfoServiceTest {
+    @Mock ElderRepository elderRepository;
+    @Mock ElderHealthInfoRepository elderHealthInfoRepository;
+    @Mock ElderDiseaseRepository elderDiseaseRepository;
+    @Mock DiseaseRepository diseaseRepository;
+    @Mock MedicationRepository medicationRepository;
+    @Mock MedicationScheduleRepository medicationScheduleRepository;
+    @InjectMocks ElderHealthInfoService elderHealthInfoService;
+
+    @BeforeEach
+    void setUp() { MockitoAnnotations.openMocks(this); }
+
+    @Test
+    void registerElderHealthInfo_success() {
+        Elder elder = Elder.builder().id(1).build();
+        Disease.builder().id(1).name("당뇨").build();
+        Medication.builder().id(1).name("당뇨약").build();
+
+        when(elderRepository.findById(1)).thenReturn(Optional.of(elder));
+        when(diseaseRepository.findByName("당뇨")).thenReturn(Optional.empty());
+        when(diseaseRepository.save(any(Disease.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(medicationRepository.findByName("당뇨약")).thenReturn(Optional.empty());
+        when(medicationRepository.save(any(Medication.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ElderHealthRegisterRequest.MedicationScheduleRequest msReq = ElderHealthRegisterRequest.MedicationScheduleRequest.builder()
+                .medicationName("당뇨약")
+                .scheduleTimes(List.of(MedicationScheduleTime.MORNING, MedicationScheduleTime.DINNER))
+                .build();
+        ElderHealthRegisterRequest request = ElderHealthRegisterRequest.builder()
+                .diseaseNames(List.of("당뇨"))
+                .medicationSchedules(List.of(msReq))
+                .notes(List.of(ElderHealthNoteType.INSOMNIA))
+                .build();
+
+        elderHealthInfoService.registerElderHealthInfo(1, request);
+
+        verify(elderDiseaseRepository, times(1)).save(any(ElderDisease.class));
+        verify(medicationScheduleRepository, times(1)).save(any(MedicationSchedule.class));
+        verify(elderHealthInfoRepository, times(1)).save(any(ElderHealthInfo.class));
+    }
+} 


### PR DESCRIPTION
- 어르신의 질병, 복약 정보, 특이사항 등 건강 정보를 등록하기 위한 엔드포인트
  - `POST /elders/{elderId}/health-info`
- 특이사항
  - 기존에는 약, 질병 데이터를 공공 기관에서 제공하는 데이터를 확보하여 사용하기로 논의함 (Medication, Disease)
  - 어플리케이션 사용 편의성을 위해, 어려운 이름에 대한 검색을 구현하기보다는, 단순하게 사용자가 입력한 값을 그대로 등록할 수 있도록 하자는 의견이 있었음
  - 설계가 끝난 뒤에 기획이 변경되어, 서비스에서는 입력받은 문자열 값을 가지고 그대로 Medication, Disease 레코드를 생성하되, 중복만 방지하는 방향으로 처리
- 복약 시간의 입력 필드에는 구체적인 시간이 아닌 `아침`, `점심`, `저녁` 정도의 옵션만을 지원하니, 이에 알맞게 컬럼 타입을 변경하는 마이그레이션 생성
- JPA Validation을 위해 미사용 컬럼은 도메인에서 제거함. 추후에 완전 미사용하는 컬럼은 후속 마이그레이션 생성 예정