### PR TITLE
sms인증, 회원등록 endpoint변경

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/MemberController.java
+++ b/src/main/java/com/example/medicare_call/controller/MemberController.java
@@ -21,7 +21,7 @@ public class MemberController {
 
     private final AuthService authService;
 
-    @PostMapping("/register")
+    @PostMapping("")
     public ResponseEntity<String> register(@Parameter(hidden = true) @AuthPhone String phone,
                                            @Valid @RequestBody RegisterRequest signUpDto) {
         String accessTokenResponse = authService.register(phone,signUpDto);

--- a/src/main/java/com/example/medicare_call/controller/SmsController.java
+++ b/src/main/java/com/example/medicare_call/controller/SmsController.java
@@ -23,14 +23,15 @@ import java.util.Map;
 @Tag(name = "Sms", description = "전화번호 인증 API")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/members/sms")
+@RequestMapping("/verifications")
 public class SmsController {
 
     private final SmsService smsService;
     private final AuthService authService;
 
     // 인증번호 발송
-    @PostMapping("/send")
+    @PostMapping("")
+    @Operation(summary = "인증번호 발송", description = "입력된 전화번호로 6자리 인증번호를 발송합니다.")
     public ResponseEntity<Map<String, String>> sendSms(@Valid @RequestBody SmsRequest request) {
         Map<String, String> response = new HashMap<>();
 
@@ -46,7 +47,7 @@ public class SmsController {
         }
     }
 
-    @PostMapping("/verify")
+    @PostMapping("/confirmation")
     @Operation(summary = "SMS 인증 및 회원 상태 확인", description = "인증번호 검증 후 회원 상태에 따른 다음 단계를 안내합니다.")
     public ResponseEntity<SmsVerificationResponse> verifySms(@Valid @RequestBody SmsVerifyDto request) {
 

--- a/src/main/java/com/example/medicare_call/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/medicare_call/global/config/SecurityConfig.java
@@ -31,8 +31,8 @@ public class SecurityConfig {
     private final String[] PUBLIC_POST = {
             "/users/signup",
             "/users/login",
-            "/members/sms/**",
-            "/members/register"
+            "/verifications/**",
+            "/members"
     };
 
     private final String[] PUBLIC_GET = {

--- a/src/test/java/com/example/medicare_call/controller/SmsControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/SmsControllerTest.java
@@ -52,7 +52,7 @@ class SmsControllerTest {
         SmsRequest request = new SmsRequest();
         request.setPhone(""); // 전화번호 누락
 
-        mockMvc.perform(post("/members/sms/send")
+        mockMvc.perform(post("/verifications")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
@@ -76,7 +76,7 @@ class SmsControllerTest {
                         .build()
         );
 
-        mockMvc.perform(post("/members/sms/verify")
+        mockMvc.perform(post("/verifications/confirmation")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -103,7 +103,7 @@ class SmsControllerTest {
                         .build()
         );
 
-        mockMvc.perform(post("/members/sms/verify")
+        mockMvc.perform(post("/verifications/confirmation")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -121,7 +121,7 @@ class SmsControllerTest {
 
         when(smsService.verifyCertificationNumber(anyString(), anyString())).thenReturn(false);
 
-        mockMvc.perform(post("/members/sms/verify")
+        mockMvc.perform(post("/verifications/confirmation")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())


### PR DESCRIPTION
API명세를 작성하며 Rest API설계에 대한 고민을 하였고 다음과 같이 엔드포인트를 변경

### SMS인증 
- 기존 `/members/sms ~` 는 도메인도 맞지 않고 RESTful한 설계가 아니라고 판단 
  - 행위 중심 URI: `.../send`, `.../verify`는 리소스가 아닌 동사(행위) > 이는 REST의 철학에서 벗어남
  - 모호한 리소스 위치: `.../members/sms/...`는 "멤버의 SMS"를 의미하는데, 이 시점에는 아직 '멤버'가 존재하지 않음. 논리적으로 어색한 구조
- 다음과 같이 변경
  - 리소스 이름: `verifications` (인증 행위들의 모음)
  - 하위 컨트롤러 리소스: `confirmation` (인증을 확인하는 행위)

### 회원 등록
- 기존: `POST /members/register` (행위 중심 URI)
- 개선: `POST /members` (리소스 중심 URI)