### PR TITLE
feat: 전화 데이터 키워드 추출 구현

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -58,6 +58,9 @@ jobs:
             SMS_NUMBER="${{ secrets.SMS_NUMBER }}"
             SMS_SECRET="${{ secrets.SMS_SECRET }}"
             CARE_CALL_URL="${{ secrets.CARE_CALL_URL }}"
+            OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}"
+            OPENAI_API_URL="${{ secrets.OPENAI_API_URL }}"
+            OPENAI_API_MODEL="${{ secrets.OPENAI_API_MODEL }}"
 
 
             echo "✋🏻 Stopping existing container"

--- a/src/main/java/com/example/medicare_call/controller/HealthDataController.java
+++ b/src/main/java/com/example/medicare_call/controller/HealthDataController.java
@@ -1,0 +1,61 @@
+package com.example.medicare_call.controller;
+
+import com.example.medicare_call.dto.HealthDataExtractionRequest;
+import com.example.medicare_call.dto.HealthDataExtractionResponse;
+import com.example.medicare_call.service.OpenAiHealthDataService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/health-data")
+@RequiredArgsConstructor
+@Tag(name = "Health Data", description = "건강 데이터 추출 API")
+public class HealthDataController {
+    
+    private final OpenAiHealthDataService openAiHealthDataService;
+
+    @Operation(
+        summary = "건강 데이터 추출",
+        description = "통화 내용에서 건강 관련 데이터를 추출합니다. (테스트용 엔드포인트)"
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "건강 데이터 추출 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = HealthDataExtractionResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류"
+        )
+    })
+    @PostMapping("/extract")
+    public ResponseEntity<HealthDataExtractionResponse> extractHealthData(
+        @RequestBody @Schema(
+            description = "건강 데이터 추출 요청",
+            example = """
+            {
+              "transcriptionText": "오늘 아침에 밥을 먹었고, 혈당을 측정했어요. 120이 나왔어요.",
+              "transcriptionLanguage": "ko",
+              "callDate": "2024-01-01"
+            }
+            """
+        ) HealthDataExtractionRequest request
+    ) {
+        log.info("건강 데이터 추출 요청: {}", request);
+        HealthDataExtractionResponse response = openAiHealthDataService.extractHealthData(request);
+        return ResponseEntity.ok(response);
+    }
+} 

--- a/src/main/java/com/example/medicare_call/dto/HealthDataExtractionRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/HealthDataExtractionRequest.java
@@ -1,0 +1,34 @@
+package com.example.medicare_call.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "건강 데이터 추출 요청")
+public class HealthDataExtractionRequest {
+    
+    @Schema(
+        description = "통화 내용 텍스트",
+        example = "오늘 아침에 밥을 먹었고, 혈당을 측정했어요. 120이 나왔어요."
+    )
+    private String transcriptionText;
+    
+    @Schema(
+        description = "통화 언어",
+        example = "ko",
+        allowableValues = {"ko", "en"}
+    )
+    private String transcriptionLanguage;
+    
+    @Schema(
+        description = "통화 날짜 (YYYY-MM-DD 형식)",
+        example = "2024-01-01"
+    )
+    private String callDate;
+} 

--- a/src/main/java/com/example/medicare_call/dto/HealthDataExtractionResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/HealthDataExtractionResponse.java
@@ -1,0 +1,115 @@
+package com.example.medicare_call.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "건강 데이터 추출 응답")
+public class HealthDataExtractionResponse {
+    
+    @Schema(description = "날짜", example = "2024-01-01")
+    private String date;
+    
+    @Schema(description = "식사 데이터")
+    private MealData mealData;
+    
+    @Schema(description = "수면 데이터")
+    private SleepData sleepData;
+    
+    @Schema(description = "심리 상태 목록", example = "[\"기분이 좋음\", \"스트레스 없음\"]")
+    private List<String> psychologicalState;
+    
+    @Schema(description = "혈당 데이터")
+    private BloodSugarData bloodSugarData;
+    
+    @Schema(description = "복약 데이터")
+    private MedicationData medicationData;
+    
+    @Schema(description = "건강 징후 목록", example = "[\"혈당이 정상 범위\", \"수면 패턴 양호\"]")
+    private List<String> healthSigns;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "식사 데이터")
+    public static class MealData {
+        
+        @Schema(
+            description = "식사 종류",
+            example = "아침",
+            allowableValues = {"아침", "점심", "저녁"}
+        )
+        private String mealType;
+        
+        @Schema(description = "식사 요약", example = "아침 식사를 하였음")
+        private String mealSummary;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "수면 데이터")
+    public static class SleepData {
+        
+        @Schema(description = "취침 시작 시각", example = "22:00")
+        private String sleepStartTime;
+        
+        @Schema(description = "취침 종료 시각", example = "06:00")
+        private String sleepEndTime;
+        
+        @Schema(description = "총 수면 시간", example = "8시간")
+        private String totalSleepTime;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "혈당 데이터")
+    public static class BloodSugarData {
+        
+        @Schema(description = "측정 시각", example = "아침")
+        private String measurementTime;
+        
+        @Schema(
+            description = "식전/식후 여부",
+            example = "식후",
+            allowableValues = {"식전", "식후"}
+        )
+        private String beforeMeal;
+        
+        @Schema(description = "혈당 값 (mg/dL)", example = "120")
+        private Integer bloodSugarValue;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "복약 데이터")
+    public static class MedicationData {
+        
+        @Schema(description = "약 종류", example = "혈압약")
+        private String medicationType;
+        
+        @Schema(
+            description = "복용 여부",
+            example = "복용함",
+            allowableValues = {"복용함", "복용하지 않음"}
+        )
+        private String taken;
+        
+        @Schema(description = "복용 시간", example = "아침")
+        private String takenTime;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/dto/OpenAiRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/OpenAiRequest.java
@@ -1,0 +1,27 @@
+package com.example.medicare_call.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OpenAiRequest {
+    private String model;
+    private List<Message> messages;
+    private double temperature;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Message {
+        private String role;
+        private String content;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/dto/OpenAiResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/OpenAiResponse.java
@@ -1,0 +1,32 @@
+package com.example.medicare_call.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OpenAiResponse {
+    private List<Choice> choices;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Choice {
+        private Message message;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Message {
+        private String content;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/medicare_call/global/config/RestTemplateConfig.java
@@ -1,5 +1,6 @@
 package com.example.medicare_call.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -9,5 +10,10 @@ public class RestTemplateConfig {
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
+    }
+    
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 }

--- a/src/main/java/com/example/medicare_call/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/medicare_call/global/config/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
             "/users/login",
             "/verifications/**",
             "/members",
-            "/call-data"
+            "/call-data",
+            "/health-data/**" // 제거 예정
     };
 
     private final String[] PUBLIC_GET = {

--- a/src/main/java/com/example/medicare_call/service/OpenAiHealthDataService.java
+++ b/src/main/java/com/example/medicare_call/service/OpenAiHealthDataService.java
@@ -1,0 +1,180 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.dto.HealthDataExtractionRequest;
+import com.example.medicare_call.dto.HealthDataExtractionResponse;
+import com.example.medicare_call.dto.OpenAiRequest;
+import com.example.medicare_call.dto.OpenAiResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OpenAiHealthDataService {
+    
+    private static final int JSON_CODE_BLOCK_MARKER_LENGTH = 7; // "```json"
+    private static final int CODE_BLOCK_MARKER_LENGTH = 3; // "```"
+    
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    
+    @Value("${openai.api.key}")
+    private String openaiApiKey;
+
+    @Value("${openai.api.url:https://api.openai.com/v1/chat/completions}")
+    private String openaiApiUrl;
+    
+    @Value("${openai.model:gpt-4}")
+    private String openaiModel;
+
+    public HealthDataExtractionResponse extractHealthData(HealthDataExtractionRequest request) {
+        try {
+            log.info("OpenAI API를 통한 건강 데이터 추출 시작");
+            
+            String prompt = buildPrompt(request);
+            
+            OpenAiRequest openAiRequest = OpenAiRequest.builder()
+                    .model(openaiModel)
+                    .messages(List.of(
+                            // 기본 역할, 정의
+                            OpenAiRequest.Message.builder()
+                                    .role("system")
+                                    .content("당신은 의료 통화 내용에서 건강 데이터를 추출하는 전문가입니다. 주어진 통화 내용에서 건강 관련 정보를 정확히 추출하여 JSON 형태로 응답해주세요.")
+                                    .build(),
+                            // 전달하는 질문 및 요청
+                            OpenAiRequest.Message.builder()
+                                    .role("user")
+                                    .content(prompt)
+                                    .build()
+                    ))
+                    // temperature: 일관된 그리고 정확한 답변을 주도록 제어하는 파라미터
+                    // 0.0 ~ 2.0 -> 클 수록 같은 입력에 대해서도 무작위한 답변, 작을 수록 일관된 답변을 반환
+                    .temperature(0.1)
+                    .build();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(openaiApiKey);
+
+            HttpEntity<OpenAiRequest> entity = new HttpEntity<>(openAiRequest, headers);
+            
+            OpenAiResponse response = restTemplate.postForObject(openaiApiUrl, entity, OpenAiResponse.class);
+            
+            if (response != null && !response.getChoices().isEmpty()) {
+                String content = response.getChoices().get(0).getMessage().getContent();
+                log.info("OpenAI 응답: {}", content);
+                
+                return parseHealthDataResponse(content);
+            } else {
+                log.error("OpenAI API 응답이 비어있습니다");
+                return createEmptyResponse();
+            }
+            
+        } catch (Exception e) {
+            log.error("OpenAI API 호출 중 오류 발생", e);
+            return createEmptyResponse();
+        }
+    }
+
+    private String buildPrompt(HealthDataExtractionRequest request) {
+        return String.format("""
+            다음 통화 내용에서 건강 데이터를 추출하여 JSON 형태로 응답해주세요.
+            
+            통화 날짜: %s
+            통화 언어: %s
+            통화 내용:
+            %s
+            
+            다음 정보들을 추출해주세요. 추출할 수 없는 경우 null로 처리해주세요:
+            
+            1. 금일의 날짜
+            2. 식사 데이터
+               - 식사의 종류 (아침/점심/저녁)
+               - 식사 간단 요약
+            3. 수면 데이터
+               - 취침 시작 시각
+               - 취침 종료 시각
+               - 총 수면 시간
+            4. 심리 상태 요약 데이터 (짧은 문장들로 요약)
+            5. 혈당 데이터
+               - 측정한 시각
+               - 식전 여부
+               - 혈당 값 (mg/dL)
+            6. 복약 데이터
+               - 약의 종류
+               - 복약 여부
+               - 복용 시간
+            7. 건강 징후 데이터 (짧은 문장들로 요약)
+            
+            응답은 반드시 다음 JSON 구조로 해주세요:
+            {
+              "date": "날짜",
+              "mealData": {
+                "mealType": "아침/점심/저녁",
+                "mealSummary": "식사 요약"
+              },
+              "sleepData": {
+                "sleepStartTime": "취침 시작 시각",
+                "sleepEndTime": "취침 종료 시각",
+                "totalSleepTime": "총 수면 시간"
+              },
+              "psychologicalState": ["심리 상태 요약 1", "심리 상태 요약 2"],
+              "bloodSugarData": {
+                "measurementTime": "측정 시각",
+                "beforeMeal": "식전/식후",
+                "bloodSugarValue": 숫자값
+              },
+              "medicationData": {
+                "medicationType": "약 종류",
+                "taken": "복용 여부",
+                "takenTime": "복용 시간"
+              },
+              "healthSigns": ["건강 징후 1", "건강 징후 2"]
+            }
+            """, 
+            request.getCallDate(),
+            request.getTranscriptionLanguage(),
+            request.getTranscriptionText()
+        );
+    }
+
+    private HealthDataExtractionResponse parseHealthDataResponse(String content) {
+        try {
+            String jsonContent = content;
+            if (content.contains("```json")) {
+                jsonContent = content.substring(content.indexOf("```json") + JSON_CODE_BLOCK_MARKER_LENGTH, content.lastIndexOf("```"));
+            } else if (content.contains("```")) {
+                jsonContent = content.substring(content.indexOf("```") + CODE_BLOCK_MARKER_LENGTH, content.lastIndexOf("```"));
+            }
+            
+            jsonContent = jsonContent.trim();
+            return objectMapper.readValue(jsonContent, HealthDataExtractionResponse.class);
+            
+        } catch (JsonProcessingException e) {
+            log.error("JSON 파싱 오류", e);
+            return createEmptyResponse();
+        }
+    }
+
+    private HealthDataExtractionResponse createEmptyResponse() {
+        return HealthDataExtractionResponse.builder()
+                .date(null)
+                .mealData(null)
+                .sleepData(null)
+                .psychologicalState(null)
+                .bloodSugarData(null)
+                .medicationData(null)
+                .healthSigns(null)
+                .build();
+    }
+} 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,11 @@ spring:
       key: ${SMS_KEY}
       secret: ${SMS_SECRET}
       number: ${SMS_NUMBER}
+
+server:
+  servlet:
+    context-path: /api
+
 care-call:
   url: ${CARE_CALL_URL}
 
@@ -100,3 +105,9 @@ server:
 
 care-call:
   url: ${CARE_CALL_URL}
+
+openai:
+  api:
+    key: ${OPENAI_API_KEY}
+    url: ${OPENAI_API_URL}
+  model: ${OPENAI_API_MODEL}

--- a/src/test/java/com/example/medicare_call/service/HealthDataExtractionIntegrationTest.java
+++ b/src/test/java/com/example/medicare_call/service/HealthDataExtractionIntegrationTest.java
@@ -1,0 +1,219 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.dto.HealthDataExtractionRequest;
+import com.example.medicare_call.dto.HealthDataExtractionResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class HealthDataExtractionIntegrationTest {
+
+    @Autowired
+    private OpenAiHealthDataService openAiHealthDataService;
+
+    @MockBean
+    private RestTemplate restTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("통화 내용에서 식사 및 혈당 데이터를 성공적으로 추출한다")
+    void extractHealthData_extractsMealAndBloodSugarDataFromCallContent() throws Exception {
+        // given
+        HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
+                .transcriptionText("""
+//                    어르신: 오늘 아침에 밥을 먹었어요. 김치찌개랑 밥을 먹었는데 맛있었어요.
+                    상담사: 그렇군요. 혈당은 측정하셨나요?
+                    어르신: 네, 아침 식사 후에 측정했는데 120이 나왔어요.
+                    상담사: 좋은 수치네요. 기분은 어떠세요?
+                    어르신: 오늘은 기분이 좋아요. 잠도 잘 잤어요.
+                    """)
+                .transcriptionLanguage("ko")
+                .callDate("2024-01-01")
+                .build();
+
+        String mockOpenAiResponse = """
+            {
+              "date": "2024-01-01",
+              "mealData": {
+                "mealType": "아침",
+                "mealSummary": "김치찌개와 밥을 먹었음"
+              },
+              "sleepData": null,
+              "psychologicalState": ["기분이 좋음", "잠을 잘 잤음"],
+              "bloodSugarData": {
+                "measurementTime": "아침",
+                "beforeMeal": "식후",
+                "bloodSugarValue": 120
+              },
+              "medicationData": null,
+              "healthSigns": ["혈당이 정상 범위", "식사 후 혈당 측정"]
+            }
+            """;
+
+        // Mock OpenAI API response
+        when(restTemplate.postForObject(eq("https://api.openai.com/v1/chat/completions"), any(HttpEntity.class), eq(com.example.medicare_call.dto.OpenAiResponse.class)))
+                .thenReturn(createMockOpenAiResponse(mockOpenAiResponse));
+
+        // when
+        HealthDataExtractionResponse result = openAiHealthDataService.extractHealthData(request);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getDate()).isEqualTo("2024-01-01");
+
+        // 식사 데이터 검증
+        assertThat(result.getMealData()).isNotNull();
+        assertThat(result.getMealData().getMealType()).isEqualTo("아침");
+        assertThat(result.getMealData().getMealSummary()).contains("김치찌개");
+        
+        // 혈당 데이터 검증
+        assertThat(result.getBloodSugarData()).isNotNull();
+        assertThat(result.getBloodSugarData().getBloodSugarValue()).isEqualTo(120);
+        assertThat(result.getBloodSugarData().getBeforeMeal()).isEqualTo("식후");
+        
+        // 심리 상태 검증
+        assertThat(result.getPsychologicalState()).isNotNull();
+        assertThat(result.getPsychologicalState()).hasSize(2);
+        assertThat(result.getPsychologicalState()).contains("기분이 좋음");
+        
+        // 건강 징후 검증
+        assertThat(result.getHealthSigns()).isNotNull();
+        assertThat(result.getHealthSigns()).hasSize(2);
+        assertThat(result.getHealthSigns()).contains("혈당이 정상 범위");
+    }
+
+    @Test
+    @DisplayName("통화 내용에서 수면 및 복약 데이터를 성공적으로 추출한다")
+    void extractHealthData_extractsSleepAndMedicationDataFromCallContent() throws Exception {
+        // given
+        HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
+                .transcriptionText("""
+                    어르신: 어제 밤 10시에 잠들어서 오늘 아침 6시에 일어났어요.
+                    상담사: 8시간 잘 주무셨네요. 약은 복용하셨나요?
+                    어르신: 네, 혈압약을 아침에 복용했어요.
+                    상담사: 좋습니다. 컨디션은 어떠세요?
+                    어르신: 오늘은 머리가 좀 아파요.
+                    """)
+                .transcriptionLanguage("ko")
+                .callDate("2024-01-01")
+                .build();
+
+        String mockOpenAiResponse = """
+            {
+              "date": "2024-01-01",
+              "mealData": null,
+              "sleepData": {
+                "sleepStartTime": "22:00",
+                "sleepEndTime": "06:00",
+                "totalSleepTime": "8시간"
+              },
+              "psychologicalState": null,
+              "bloodSugarData": null,
+              "medicationData": {
+                "medicationType": "혈압약",
+                "taken": "복용함",
+                "takenTime": "아침"
+              },
+              "healthSigns": ["머리가 아픔"]
+            }
+            """;
+
+        // Mock OpenAI API response
+        when(restTemplate.postForObject(eq("https://api.openai.com/v1/chat/completions"), any(HttpEntity.class), eq(com.example.medicare_call.dto.OpenAiResponse.class)))
+                .thenReturn(createMockOpenAiResponse(mockOpenAiResponse));
+
+        // when
+        HealthDataExtractionResponse result = openAiHealthDataService.extractHealthData(request);
+
+        // then
+        assertThat(result).isNotNull();
+        
+        // 수면 데이터 검증
+        assertThat(result.getSleepData()).isNotNull();
+        assertThat(result.getSleepData().getSleepStartTime()).isEqualTo("22:00");
+        assertThat(result.getSleepData().getSleepEndTime()).isEqualTo("06:00");
+        assertThat(result.getSleepData().getTotalSleepTime()).isEqualTo("8시간");
+        
+        // 복약 데이터 검증
+        assertThat(result.getMedicationData()).isNotNull();
+        assertThat(result.getMedicationData().getMedicationType()).isEqualTo("혈압약");
+        assertThat(result.getMedicationData().getTaken()).isEqualTo("복용함");
+        assertThat(result.getMedicationData().getTakenTime()).isEqualTo("아침");
+        
+        // 건강 징후 검증
+        assertThat(result.getHealthSigns()).isNotNull();
+        assertThat(result.getHealthSigns()).hasSize(1);
+        assertThat(result.getHealthSigns()).contains("머리가 아픔");
+    }
+
+    @Test
+    @DisplayName("통화 내용이 비어있을 때 빈 응답을 반환한다")
+    void extractHealthData_returnsEmptyResponseWhenCallContentIsEmpty() throws Exception {
+        // given
+        HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
+                .transcriptionText("")
+                .transcriptionLanguage("ko")
+                .callDate("2024-01-01")
+                .build();
+
+        String mockOpenAiResponse = """
+            {
+              "date": null,
+              "mealData": null,
+              "sleepData": null,
+              "psychologicalState": null,
+              "bloodSugarData": null,
+              "medicationData": null,
+              "healthSigns": null
+            }
+            """;
+
+        // Mock OpenAI API response
+        when(restTemplate.postForObject(eq("https://api.openai.com/v1/chat/completions"), any(HttpEntity.class), eq(com.example.medicare_call.dto.OpenAiResponse.class)))
+                .thenReturn(createMockOpenAiResponse(mockOpenAiResponse));
+
+        // when
+        HealthDataExtractionResponse result = openAiHealthDataService.extractHealthData(request);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getDate()).isNull();
+        assertThat(result.getMealData()).isNull();
+        assertThat(result.getSleepData()).isNull();
+        assertThat(result.getPsychologicalState()).isNull();
+        assertThat(result.getBloodSugarData()).isNull();
+        assertThat(result.getMedicationData()).isNull();
+        assertThat(result.getHealthSigns()).isNull();
+    }
+
+    private com.example.medicare_call.dto.OpenAiResponse createMockOpenAiResponse(String content) {
+        return com.example.medicare_call.dto.OpenAiResponse.builder()
+                .choices(List.of(
+                        com.example.medicare_call.dto.OpenAiResponse.Choice.builder()
+                                .message(com.example.medicare_call.dto.OpenAiResponse.Message.builder()
+                                        .content(content)
+                                        .build())
+                                .build()
+                ))
+                .build();
+    }
+} 

--- a/src/test/java/com/example/medicare_call/service/OpenAiHealthDataServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/OpenAiHealthDataServiceTest.java
@@ -1,0 +1,222 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.dto.HealthDataExtractionRequest;
+import com.example.medicare_call.dto.HealthDataExtractionResponse;
+import com.example.medicare_call.dto.OpenAiRequest;
+import com.example.medicare_call.dto.OpenAiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OpenAiHealthDataServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private OpenAiHealthDataService openAiHealthDataService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(openAiHealthDataService, "openaiApiKey", "test-api-key");
+        ReflectionTestUtils.setField(openAiHealthDataService, "openaiApiUrl", "https://api.openai.com/v1/chat/completions");
+        ReflectionTestUtils.setField(openAiHealthDataService, "openaiModel", "gpt-4");
+    }
+
+    @Test
+    @DisplayName("OpenAI API를 통해 성공적으로 건강 데이터를 추출한다")
+    void extractHealthData_extractsHealthDataSuccessfully() throws Exception {
+        // given
+        HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
+                .transcriptionText("오늘 아침에 밥을 먹었고, 혈당을 측정했어요. 120이 나왔어요.")
+                .transcriptionLanguage("ko")
+                .callDate("2024-01-01")
+                .build();
+
+        String mockOpenAiResponse = """
+            {
+              "date": "2024-01-01",
+              "mealData": {
+                "mealType": "아침",
+                "mealSummary": "아침 식사를 하였음"
+              },
+              "sleepData": null,
+              "psychologicalState": ["기분이 좋음"],
+              "bloodSugarData": {
+                "measurementTime": "아침",
+                "beforeMeal": "식후",
+                "bloodSugarValue": 120
+              },
+              "medicationData": null,
+              "healthSigns": ["혈당이 정상 범위"]
+            }
+            """;
+
+        OpenAiResponse openAiResponse = OpenAiResponse.builder()
+                .choices(List.of(
+                        OpenAiResponse.Choice.builder()
+                                .message(OpenAiResponse.Message.builder()
+                                        .content(mockOpenAiResponse)
+                                        .build())
+                                .build()
+                ))
+                .build();
+
+        HealthDataExtractionResponse expectedResponse = HealthDataExtractionResponse.builder()
+                .date("2024-01-01")
+                .mealData(HealthDataExtractionResponse.MealData.builder()
+                        .mealType("아침")
+                        .mealSummary("아침 식사를 하였음")
+                        .build())
+                .bloodSugarData(HealthDataExtractionResponse.BloodSugarData.builder()
+                        .measurementTime("아침")
+                        .beforeMeal("식후")
+                        .bloodSugarValue(120)
+                        .build())
+                .psychologicalState(List.of("기분이 좋음"))
+                .healthSigns(List.of("혈당이 정상 범위"))
+                .build();
+
+        when(restTemplate.postForObject(eq("https://api.openai.com/v1/chat/completions"), any(HttpEntity.class), eq(OpenAiResponse.class)))
+                .thenReturn(openAiResponse);
+        // parseHealthDataResponse 메서드에서 trim()된 JSON 문자열을 사용하므로 Mock 설정을 수정
+        when(objectMapper.readValue(mockOpenAiResponse.trim(), HealthDataExtractionResponse.class))
+                .thenReturn(expectedResponse);
+
+        // when
+        HealthDataExtractionResponse result = openAiHealthDataService.extractHealthData(request);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getDate()).isEqualTo("2024-01-01");
+        assertThat(result.getMealData().getMealType()).isEqualTo("아침");
+        assertThat(result.getBloodSugarData().getBloodSugarValue()).isEqualTo(120);
+        assertThat(result.getPsychologicalState()).contains("기분이 좋음");
+    }
+
+    @Test
+    @DisplayName("OpenAI API 응답이 비어있을 때 빈 응답을 반환한다")
+    void extractHealthData_returnsEmptyResponseWhenOpenAiResponseIsNull() {
+        // given
+        HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
+                .transcriptionText("테스트 통화 내용")
+                .transcriptionLanguage("ko")
+                .callDate("2024-01-01")
+                .build();
+
+        when(restTemplate.postForObject(eq("https://api.openai.com/v1/chat/completions"), any(HttpEntity.class), eq(OpenAiResponse.class)))
+                .thenReturn(null);
+
+        // when
+        HealthDataExtractionResponse result = openAiHealthDataService.extractHealthData(request);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getDate()).isNull();
+        assertThat(result.getMealData()).isNull();
+        assertThat(result.getSleepData()).isNull();
+        assertThat(result.getPsychologicalState()).isNull();
+        assertThat(result.getBloodSugarData()).isNull();
+        assertThat(result.getMedicationData()).isNull();
+        assertThat(result.getHealthSigns()).isNull();
+    }
+
+    @Test
+    @DisplayName("JSON 파싱 오류 시 빈 응답을 반환한다")
+    void extractHealthData_returnsEmptyResponseWhenJsonParsingFails() throws Exception {
+        // given
+        HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
+                .transcriptionText("테스트 통화 내용")
+                .transcriptionLanguage("ko")
+                .callDate("2024-01-01")
+                .build();
+
+        OpenAiResponse openAiResponse = OpenAiResponse.builder()
+                .choices(List.of(
+                        OpenAiResponse.Choice.builder()
+                                .message(OpenAiResponse.Message.builder()
+                                        .content("잘못된 JSON 형식")
+                                        .build())
+                                .build()
+                ))
+                .build();
+
+        when(restTemplate.postForObject(eq("https://api.openai.com/v1/chat/completions"), any(HttpEntity.class), eq(OpenAiResponse.class)))
+                .thenReturn(openAiResponse);
+        when(objectMapper.readValue("잘못된 JSON 형식", HealthDataExtractionResponse.class))
+                .thenThrow(new RuntimeException("JSON 파싱 오류"));
+
+        // when
+        HealthDataExtractionResponse result = openAiHealthDataService.extractHealthData(request);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getDate()).isNull();
+        assertThat(result.getMealData()).isNull();
+    }
+
+    @Test
+    @DisplayName("통화 내용이 비어있을 때도 정상 처리한다")
+    void extractHealthData_processesEmptyTranscriptionText() throws Exception {
+        // given
+        HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
+                .transcriptionText("")
+                .transcriptionLanguage("ko")
+                .callDate("2024-01-01")
+                .build();
+
+        OpenAiResponse openAiResponse = OpenAiResponse.builder()
+                .choices(List.of(
+                        OpenAiResponse.Choice.builder()
+                                .message(OpenAiResponse.Message.builder()
+                                        .content("{}")
+                                        .build())
+                                .build()
+                ))
+                .build();
+
+        HealthDataExtractionResponse expectedResponse = HealthDataExtractionResponse.builder()
+                .date(null)
+                .mealData(null)
+                .sleepData(null)
+                .psychologicalState(null)
+                .bloodSugarData(null)
+                .medicationData(null)
+                .healthSigns(null)
+                .build();
+
+        when(restTemplate.postForObject(eq("https://api.openai.com/v1/chat/completions"), any(HttpEntity.class), eq(OpenAiResponse.class)))
+                .thenReturn(openAiResponse);
+        when(objectMapper.readValue("{}", HealthDataExtractionResponse.class))
+                .thenReturn(expectedResponse);
+
+        // when
+        HealthDataExtractionResponse result = openAiHealthDataService.extractHealthData(request);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getDate()).isNull();
+        assertThat(result.getMealData()).isNull();
+    }
+} 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -26,3 +26,9 @@ jwt:
   phoneTokenExpiration: 1
 care-call:
   url: test
+
+openai:
+  api:
+    key: test-openai-key
+    url: https://api.openai.com/v1/chat/completions
+  model: gpt-4


### PR DESCRIPTION
### Description
- `OpenAiHealthDataService`
  - 전화 chunk 데이터를 받아, OpenAI API로 전화 내용 분석을 요청
  - 미리 정의된 프롬프트에 따라 전화 데이터를 OpenAI에서는 키워드별로 분석하여 `HealthDataExtractionResponse` 형태로 반환
- 전화 서버로부터 `CallDataService`가 전화 데이터를 받고, DB에 저장하는 과정에서 이 API 호출도 함께 진행한다.
  - 특정 단계에서 오류가 발생했을 경우에 대한 fallback은 없어 분석이 안될 위험도 있어 추후 고민이 필요할 것 같다. 주기적으로 실행되는 background job으로 분석을 진행한다던지..
- `HealthDataExtractionResponse` 구조체를 DB에 저장하는 작업은 별도 작업으로 진행 예정. 사후 PR으로 올리겠습니다.
- 로컬에서 더미 전화 데이터에서 키워드별로 값을 잘 추출해내는 것을 테스트 완료
- 키워드별 데이터 추출 테스트용 엔드포인트를 생성 (will he deprecated)
  - `HealthDataController`

### Service Flow 정리
- 전화가 종료되면 전화 서버에서 `CallDataController`으로 전화 데이터 전체를 전송
- `CallDataController`에서는 전화 데이터를 저장하고, 키워드별로 데이터를 분류하기 위해 `OpenAiHealthDataService`를 호출
- (진행 필요) `OpenAiHealthDataService`에서 반환한 데이터 구조를 통해 통화내용 내 정보들을 DB에 저장