### PR TITLE
refactor: `transcription_language`제거

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/HealthDataController.java
+++ b/src/main/java/com/example/medicare_call/controller/HealthDataController.java
@@ -48,7 +48,6 @@ public class HealthDataController {
             example = """
             {
               "transcriptionText": "오늘 아침에 밥을 먹었고, 혈당을 측정했어요. 120이 나왔어요.",
-              "transcriptionLanguage": "ko",
               "callDate": "2024-01-01"
             }
             """

--- a/src/main/java/com/example/medicare_call/domain/CareCallRecord.java
+++ b/src/main/java/com/example/medicare_call/domain/CareCallRecord.java
@@ -51,15 +51,14 @@ public class CareCallRecord {
     @Column(name = "call_status")
     private String callStatus;
 
-    @Column(name = "transcription_language")
-    private String transcriptionLanguage;
+
 
     @Column(name = "transcription_text", columnDefinition = "TEXT")
     private String transcriptionText;
 
     @Builder
     public CareCallRecord(Integer id, Elder elder, CareCallSetting setting, LocalDateTime calledAt, Byte responded, LocalDateTime sleepStart, LocalDateTime sleepEnd, Byte healthStatus, Byte psychStatus,
-                          LocalDateTime startTime, LocalDateTime endTime, String callStatus, String transcriptionLanguage, String transcriptionText) {
+                          LocalDateTime startTime, LocalDateTime endTime, String callStatus, String transcriptionText) {
         this.id = id;
         this.elder = elder;
         this.setting = setting;
@@ -72,7 +71,6 @@ public class CareCallRecord {
         this.startTime = startTime;
         this.endTime = endTime;
         this.callStatus = callStatus;
-        this.transcriptionLanguage = transcriptionLanguage;
         this.transcriptionText = transcriptionText;
     }
 } 

--- a/src/main/java/com/example/medicare_call/dto/HealthDataExtractionRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/HealthDataExtractionRequest.java
@@ -19,12 +19,7 @@ public class HealthDataExtractionRequest {
     )
     private String transcriptionText;
     
-    @Schema(
-        description = "통화 언어",
-        example = "ko",
-        allowableValues = {"ko", "en"}
-    )
-    private String transcriptionLanguage;
+
     
     @Schema(
         description = "통화 날짜 (YYYY-MM-DD 형식)",

--- a/src/main/java/com/example/medicare_call/service/OpenAiHealthDataService.java
+++ b/src/main/java/com/example/medicare_call/service/OpenAiHealthDataService.java
@@ -91,7 +91,7 @@ public class OpenAiHealthDataService {
             다음 통화 내용에서 건강 데이터를 추출하여 JSON 형태로 응답해주세요.
             
             통화 날짜: %s
-            통화 언어: %s
+            통화 언어: 한국어
             통화 내용:
             %s
             
@@ -143,7 +143,6 @@ public class OpenAiHealthDataService {
             }
             """, 
             request.getCallDate(),
-            request.getTranscriptionLanguage(),
             request.getTranscriptionText()
         );
     }

--- a/src/main/resources/db/migration/V5__remove_transcription_language_from_carecallrecord.sql
+++ b/src/main/resources/db/migration/V5__remove_transcription_language_from_carecallrecord.sql
@@ -1,0 +1,2 @@
+-- CareCallRecord 테이블에서 transcription_language 컬럼 제거
+ALTER TABLE CareCallRecord DROP COLUMN transcription_language; 

--- a/src/test/java/com/example/medicare_call/controller/CallDataControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/CallDataControllerTest.java
@@ -104,7 +104,7 @@ class CallDataControllerTest {
                 .startTime(LocalDateTime.parse("2025-01-27T10:00:00"))
                 .endTime(LocalDateTime.parse("2025-01-27T10:15:00"))
                 .callStatus("completed")
-                .transcriptionLanguage("ko")
+
                 .transcriptionText("고객: 안녕하세요, 오늘 컨디션은 어떠세요?\n어르신: 네, 오늘은 컨디션이 좋아요.")
                 .build();
 
@@ -117,7 +117,7 @@ class CallDataControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(1))
                 .andExpect(jsonPath("$.callStatus").value("completed"))
-                .andExpect(jsonPath("$.transcriptionLanguage").value("ko"))
+
                 .andExpect(jsonPath("$.transcriptionText").value("고객: 안녕하세요, 오늘 컨디션은 어떠세요?\n어르신: 네, 오늘은 컨디션이 좋아요."));
     }
 

--- a/src/test/java/com/example/medicare_call/service/CallDataServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/CallDataServiceTest.java
@@ -90,7 +90,6 @@ class CallDataServiceTest {
                 .startTime(LocalDateTime.parse("2025-01-27T10:00:00"))
                 .endTime(LocalDateTime.parse("2025-01-27T10:15:00"))
                 .callStatus("completed")
-                .transcriptionLanguage("ko")
                 .transcriptionText("고객: 안녕하세요, 오늘 컨디션은 어떠세요?\n어르신: 네, 오늘은 컨디션이 좋아요.")
                 .build();
 
@@ -105,7 +104,7 @@ class CallDataServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(1);
         assertThat(result.getCallStatus()).isEqualTo("completed");
-        assertThat(result.getTranscriptionLanguage()).isEqualTo("ko");
+
         assertThat(result.getTranscriptionText()).isEqualTo("고객: 안녕하세요, 오늘 컨디션은 어떠세요?\n어르신: 네, 오늘은 컨디션이 좋아요.");
         
         verify(elderRepository).findById(1);
@@ -113,7 +112,6 @@ class CallDataServiceTest {
         verify(careCallRecordRepository).save(any(CareCallRecord.class));
         verify(openAiHealthDataService).extractHealthData(argThat(healthRequest -> 
             healthRequest.getTranscriptionText().equals("고객: 안녕하세요, 오늘 컨디션은 어떠세요?\n어르신: 네, 오늘은 컨디션이 좋아요.") &&
-            healthRequest.getTranscriptionLanguage().equals("ko") &&
             healthRequest.getCallDate().equals("2025-01-27")
         ));
     }
@@ -154,7 +152,7 @@ class CallDataServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(1);
         assertThat(result.getCallStatus()).isEqualTo("failed");
-        assertThat(result.getTranscriptionLanguage()).isNull();
+
         assertThat(result.getTranscriptionText()).isNull();
         
         verify(elderRepository).findById(1);
@@ -164,11 +162,10 @@ class CallDataServiceTest {
     }
 
     @Test
-    @DisplayName("통화 데이터 저장 성공 - 녹음 텍스트 언어만 있고 텍스트 없음")
-    void saveCallData_success_transcriptionLanguageOnly() {
+    @DisplayName("통화 데이터 저장 성공 - 녹음 텍스트 없음")
+    void saveCallData_success_transcriptionTextOnly() {
         // given
         CallDataRequest.TranscriptionData transcriptionData = CallDataRequest.TranscriptionData.builder()
-                .language("en")
                 .build();
 
         CallDataRequest request = CallDataRequest.builder()
@@ -191,7 +188,6 @@ class CallDataServiceTest {
                 .elder(elder)
                 .setting(setting)
                 .callStatus("busy")
-                .transcriptionLanguage("en")
                 .build();
 
         when(elderRepository.findById(1)).thenReturn(Optional.of(elder));
@@ -205,7 +201,6 @@ class CallDataServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(1);
         assertThat(result.getCallStatus()).isEqualTo("busy");
-        assertThat(result.getTranscriptionLanguage()).isEqualTo("en");
         assertThat(result.getTranscriptionText()).isNull();
         
         verify(elderRepository).findById(1);
@@ -318,7 +313,6 @@ class CallDataServiceTest {
                 .build();
 
         CallDataRequest.TranscriptionData transcriptionData = CallDataRequest.TranscriptionData.builder()
-                .language("ko")
                 .fullText(Arrays.asList(segment))
                 .build();
 
@@ -344,7 +338,6 @@ class CallDataServiceTest {
                 .setting(setting)
                 .startTime(LocalDateTime.parse("2025-01-27T10:00:00"))
                 .callStatus("completed")
-                .transcriptionLanguage("ko")
                 .transcriptionText("어르신: 오늘 아침에 밥을 먹었고, 혈당을 측정했어요. 120이 나왔어요.")
                 .build();
 
@@ -359,7 +352,6 @@ class CallDataServiceTest {
         assertThat(result).isNotNull();
         verify(openAiHealthDataService).extractHealthData(argThat(healthRequest -> 
             healthRequest.getTranscriptionText().equals("어르신: 오늘 아침에 밥을 먹었고, 혈당을 측정했어요. 120이 나왔어요.") &&
-            healthRequest.getTranscriptionLanguage().equals("ko") &&
             healthRequest.getCallDate().equals("2025-01-27")
         ));
     }

--- a/src/test/java/com/example/medicare_call/service/HealthDataExtractionIntegrationTest.java
+++ b/src/test/java/com/example/medicare_call/service/HealthDataExtractionIntegrationTest.java
@@ -46,7 +46,6 @@ class HealthDataExtractionIntegrationTest {
                     상담사: 좋은 수치네요. 기분은 어떠세요?
                     어르신: 오늘은 기분이 좋아요. 잠도 잘 잤어요.
                     """)
-                .transcriptionLanguage("ko")
                 .callDate("2024-01-01")
                 .build();
 
@@ -113,7 +112,6 @@ class HealthDataExtractionIntegrationTest {
                     상담사: 좋습니다. 컨디션은 어떠세요?
                     어르신: 오늘은 머리가 좀 아파요.
                     """)
-                .transcriptionLanguage("ko")
                 .callDate("2024-01-01")
                 .build();
 
@@ -171,7 +169,6 @@ class HealthDataExtractionIntegrationTest {
         // given
         HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
                 .transcriptionText("")
-                .transcriptionLanguage("ko")
                 .callDate("2024-01-01")
                 .build();
 

--- a/src/test/java/com/example/medicare_call/service/OpenAiHealthDataServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/OpenAiHealthDataServiceTest.java
@@ -50,7 +50,6 @@ class OpenAiHealthDataServiceTest {
         // given
         HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
                 .transcriptionText("오늘 아침에 밥을 먹었고, 혈당을 측정했어요. 120이 나왔어요.")
-                .transcriptionLanguage("ko")
                 .callDate("2024-01-01")
                 .build();
 
@@ -101,7 +100,7 @@ class OpenAiHealthDataServiceTest {
         when(restTemplate.postForObject(eq("https://api.openai.com/v1/chat/completions"), any(HttpEntity.class), eq(OpenAiResponse.class)))
                 .thenReturn(openAiResponse);
         // parseHealthDataResponse 메서드에서 trim()된 JSON 문자열을 사용하므로 Mock 설정을 수정
-        when(objectMapper.readValue(mockOpenAiResponse.trim(), HealthDataExtractionResponse.class))
+        when(objectMapper.readValue(any(String.class), eq(HealthDataExtractionResponse.class)))
                 .thenReturn(expectedResponse);
 
         // when
@@ -121,7 +120,6 @@ class OpenAiHealthDataServiceTest {
         // given
         HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
                 .transcriptionText("테스트 통화 내용")
-                .transcriptionLanguage("ko")
                 .callDate("2024-01-01")
                 .build();
 
@@ -148,7 +146,6 @@ class OpenAiHealthDataServiceTest {
         // given
         HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
                 .transcriptionText("테스트 통화 내용")
-                .transcriptionLanguage("ko")
                 .callDate("2024-01-01")
                 .build();
 
@@ -164,7 +161,7 @@ class OpenAiHealthDataServiceTest {
 
         when(restTemplate.postForObject(eq("https://api.openai.com/v1/chat/completions"), any(HttpEntity.class), eq(OpenAiResponse.class)))
                 .thenReturn(openAiResponse);
-        when(objectMapper.readValue("잘못된 JSON 형식", HealthDataExtractionResponse.class))
+        when(objectMapper.readValue(any(String.class), eq(HealthDataExtractionResponse.class)))
                 .thenThrow(new RuntimeException("JSON 파싱 오류"));
 
         // when
@@ -182,7 +179,6 @@ class OpenAiHealthDataServiceTest {
         // given
         HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
                 .transcriptionText("")
-                .transcriptionLanguage("ko")
                 .callDate("2024-01-01")
                 .build();
 
@@ -208,7 +204,7 @@ class OpenAiHealthDataServiceTest {
 
         when(restTemplate.postForObject(eq("https://api.openai.com/v1/chat/completions"), any(HttpEntity.class), eq(OpenAiResponse.class)))
                 .thenReturn(openAiResponse);
-        when(objectMapper.readValue("{}", HealthDataExtractionResponse.class))
+        when(objectMapper.readValue(any(String.class), eq(HealthDataExtractionResponse.class)))
                 .thenReturn(expectedResponse);
 
         // when


### PR DESCRIPTION
- 통화 내용이 한국어 외의 값으로 들어오는 시나리오는 없다.
- MVP단계에서는 DB에 언어를 별도 컬럼으로 기록할 필요성이 없으니 제거하자.
  - 컬럼 제거 마이그레이션 생성
- 통화 내용을 키워드 추출하는 단계에서는, 프롬프트에서 통화 내용이 한국어라는 것을 리터럴로 명시함
- 테스트도 관련 내용 일괄 제거