### PR TITLE
feat: OpenAI 분석 결과 저장 구현

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/HealthDataController.java
+++ b/src/main/java/com/example/medicare_call/controller/HealthDataController.java
@@ -1,7 +1,24 @@
 package com.example.medicare_call.controller;
 
+import com.example.medicare_call.domain.CareCallRecord;
+import com.example.medicare_call.domain.CareCallSetting;
+import com.example.medicare_call.domain.Elder;
+import com.example.medicare_call.domain.Member;
+import com.example.medicare_call.domain.Medication;
+import com.example.medicare_call.domain.MedicationSchedule;
 import com.example.medicare_call.dto.HealthDataExtractionRequest;
 import com.example.medicare_call.dto.HealthDataExtractionResponse;
+import com.example.medicare_call.global.enums.ElderRelation;
+import com.example.medicare_call.global.enums.FrequencyType;
+import com.example.medicare_call.global.enums.Gender;
+import com.example.medicare_call.global.enums.ResidenceType;
+import com.example.medicare_call.repository.CareCallRecordRepository;
+import com.example.medicare_call.repository.CareCallSettingRepository;
+import com.example.medicare_call.repository.ElderRepository;
+import com.example.medicare_call.repository.MemberRepository;
+import com.example.medicare_call.repository.MedicationRepository;
+import com.example.medicare_call.repository.MedicationScheduleRepository;
+import com.example.medicare_call.service.CallDataService;
 import com.example.medicare_call.service.OpenAiHealthDataService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -14,6 +31,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
 @Slf4j
 @RestController
 @RequestMapping("/health-data")
@@ -22,6 +43,13 @@ import org.springframework.web.bind.annotation.*;
 public class HealthDataController {
     
     private final OpenAiHealthDataService openAiHealthDataService;
+    private final CallDataService callDataService;
+    private final ElderRepository elderRepository;
+    private final CareCallSettingRepository careCallSettingRepository;
+    private final CareCallRecordRepository careCallRecordRepository;
+    private final MemberRepository memberRepository;
+    private final MedicationRepository medicationRepository;
+    private final MedicationScheduleRepository medicationScheduleRepository;
 
     @Operation(
         summary = "건강 데이터 추출",
@@ -56,5 +84,286 @@ public class HealthDataController {
         log.info("건강 데이터 추출 요청: {}", request);
         HealthDataExtractionResponse response = openAiHealthDataService.extractHealthData(request);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+        summary = "[개발자용] 건강 데이터 DB 저장 테스트",
+        description = "건강 데이터를 DB에 저장하는 기능을 테스트합니다. (테스트용 엔드포인트)"
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "건강 데이터 DB 저장 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CareCallRecord.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류"
+        )
+    })
+    @PostMapping("/save-to-database")
+    public ResponseEntity<CareCallRecord> saveHealthDataToDatabase(
+        @RequestBody @Schema(
+            description = "건강 데이터 DB 저장 테스트 요청",
+            example = """
+            {
+              "elderId": 1,
+              "settingId": 1,
+              "transcriptionText": "오늘 아침에 밥을 먹었고, 혈당을 측정했어요. 120이 나왔어요. 기분도 좋아요.",
+              "callDate": "2024-01-01"
+            }
+            """
+        ) HealthDataTestRequest request
+    ) {
+        log.info("건강 데이터 DB 저장 테스트 요청: {}", request);
+        
+        // 테스트용 CareCallRecord 조회 또는 생성
+        CareCallRecord savedCallRecord = createOrGetTestCallRecord(
+                request.getElderId(), 
+                request.getSettingId(), 
+                request.getTranscriptionText()
+        );
+        
+        // OpenAI를 통한 건강 데이터 추출
+        HealthDataExtractionRequest extractionRequest = HealthDataExtractionRequest.builder()
+                .transcriptionText(request.getTranscriptionText())
+                .callDate(request.getCallDate())
+                .build();
+        
+        HealthDataExtractionResponse healthData = openAiHealthDataService.extractHealthData(extractionRequest);
+        
+        // 건강 데이터를 DB에 저장
+        callDataService.saveHealthDataToDatabase(savedCallRecord, healthData);
+        
+        return ResponseEntity.ok(savedCallRecord);
+    }
+
+    @Operation(
+        summary = "[개발자용] 건강 데이터 DB 저장 테스트 (수면 데이터)",
+        description = "수면 데이터가 포함된 건강 데이터를 DB에 저장하는 기능을 테스트합니다. (테스트용 엔드포인트)"
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "건강 데이터 DB 저장 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CareCallRecord.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류"
+        )
+    })
+    @PostMapping("/save-sleep-data")
+    public ResponseEntity<CareCallRecord> saveSleepDataToDatabase(
+        @RequestBody @Schema(
+            description = "수면 데이터 DB 저장 테스트 요청",
+            example = """
+            {
+              "elderId": 1,
+              "settingId": 1,
+              "transcriptionText": "어제 밤 10시에 잠들어서 오늘 아침 6시에 일어났어요. 8시간 잘 잤어요.",
+              "callDate": "2024-01-01"
+            }
+            """
+        ) HealthDataTestRequest request
+    ) {
+        log.info("수면 데이터 DB 저장 테스트 요청: {}", request);
+        
+        // 테스트용 CareCallRecord 조회 또는 생성
+        CareCallRecord savedCallRecord = createOrGetTestCallRecord(
+                request.getElderId(), 
+                request.getSettingId(), 
+                request.getTranscriptionText()
+        );
+        
+        // OpenAI를 통한 건강 데이터 추출
+        HealthDataExtractionRequest extractionRequest = HealthDataExtractionRequest.builder()
+                .transcriptionText(request.getTranscriptionText())
+                .callDate(request.getCallDate())
+                .build();
+        
+        HealthDataExtractionResponse healthData = openAiHealthDataService.extractHealthData(extractionRequest);
+        
+        // 건강 데이터를 DB에 저장
+        callDataService.saveHealthDataToDatabase(savedCallRecord, healthData);
+        
+        return ResponseEntity.ok(savedCallRecord);
+    }
+
+    @Operation(
+        summary = "[개발자용] 건강 데이터 DB 저장 테스트 (복약 데이터)",
+        description = "복약 데이터가 포함된 건강 데이터를 DB에 저장하는 기능을 테스트합니다. (테스트용 엔드포인트)"
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "건강 데이터 DB 저장 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CareCallRecord.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류"
+        )
+    })
+    @PostMapping("/save-medication-data")
+    public ResponseEntity<CareCallRecord> saveMedicationDataToDatabase(
+        @RequestBody @Schema(
+            description = "복약 데이터 DB 저장 테스트 요청",
+            example = """
+            {
+              "elderId": 1,
+              "settingId": 1,
+              "transcriptionText": "혈압약을 아침에 복용했어요. 오늘은 머리가 좀 아파요.",
+              "callDate": "2024-01-01"
+            }
+            """
+        ) HealthDataTestRequest request
+    ) {
+        log.info("복약 데이터 DB 저장 테스트 요청: {}", request);
+        
+        // 테스트용 CareCallRecord 조회 또는 생성
+        CareCallRecord savedCallRecord = createOrGetTestCallRecord(
+                request.getElderId(), 
+                request.getSettingId(), 
+                request.getTranscriptionText()
+        );
+        
+        // OpenAI를 통한 건강 데이터 추출
+        HealthDataExtractionRequest extractionRequest = HealthDataExtractionRequest.builder()
+                .transcriptionText(request.getTranscriptionText())
+                .callDate(request.getCallDate())
+                .build();
+        
+        HealthDataExtractionResponse healthData = openAiHealthDataService.extractHealthData(extractionRequest);
+        
+        // 건강 데이터를 DB에 저장
+        callDataService.saveHealthDataToDatabase(savedCallRecord, healthData);
+        
+        return ResponseEntity.ok(savedCallRecord);
+    }
+
+    /**
+     * 테스트용 Elder와 CareCallSetting을 조회하거나 생성합니다.
+     */
+    private CareCallRecord createOrGetTestCallRecord(Integer elderId, Integer settingId, String transcriptionText) {
+        // 테스트용 Member 생성 또는 조회
+        Member guardian = memberRepository.findById(1)
+                .orElseGet(() -> {
+                    Member newMember = Member.builder()
+                            .id(1)
+                            .name("테스트 보호자")
+                            .phone("010-1234-5678")
+                            .gender(Gender.MALE.getCode())
+                            .termsAgreedAt(LocalDateTime.now())
+                            .plan((byte) 1)
+                            .build();
+                    return memberRepository.save(newMember);
+                });
+        
+        // Elder 조회 또는 생성
+        Elder elder = elderRepository.findById(elderId)
+                .orElseGet(() -> {
+                    Elder newElder = Elder.builder()
+                            .id(elderId)
+                            .guardian(guardian)
+                            .name("테스트 어르신")
+                            .gender(Gender.MALE.getCode())
+                            .relationship(ElderRelation.CHILD)
+                            .residenceType(ResidenceType.ALONE)
+                            .build();
+                    return elderRepository.save(newElder);
+                });
+        
+        // CareCallSetting 조회 또는 생성
+        CareCallSetting setting = careCallSettingRepository.findById(settingId)
+                .orElseGet(() -> {
+                    CareCallSetting newSetting = CareCallSetting.builder()
+                            .id(settingId)
+                            .elder(elder)
+                            .firstCallTime(LocalDateTime.now().toLocalTime())
+                            .recurrence((byte) 1)
+                            .build();
+                    return careCallSettingRepository.save(newSetting);
+                });
+        
+        // 테스트용 Medication 생성 또는 조회
+        Medication medication = medicationRepository.findByName("혈압약")
+                .orElseGet(() -> {
+                    Medication newMedication = Medication.builder()
+                            .name("혈압약")
+                            .build();
+                    return medicationRepository.save(newMedication);
+                });
+        
+        // 테스트용 MedicationSchedule 생성 또는 조회
+        MedicationSchedule schedule = medicationScheduleRepository.findByElder(elder)
+                .stream()
+                .filter(s -> s.getMedication().equals(medication))
+                .findFirst()
+                .orElseGet(() -> {
+                    MedicationSchedule newSchedule = MedicationSchedule.builder()
+                            .medication(medication)
+                            .elder(elder)
+                            .scheduleTime("MORNING")
+                            .frequencyType(FrequencyType.DAILY)
+                            .build();
+                    return medicationScheduleRepository.save(newSchedule);
+                });
+        
+        // CareCallRecord 생성 및 저장
+        CareCallRecord callRecord = CareCallRecord.builder()
+                .elder(elder)
+                .setting(setting)
+                .calledAt(LocalDateTime.now())
+                .responded((byte) 1)
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now().plusMinutes(15))
+                .callStatus("completed")
+                .transcriptionText(transcriptionText)
+                .psychologicalDetails(null)
+                .healthDetails(null)
+                .build();
+        
+        return careCallRecordRepository.save(callRecord);
+    }
+
+    @Schema(description = "건강 데이터 DB 저장 테스트 요청")
+    public static class HealthDataTestRequest {
+        @Schema(description = "어르신 ID", example = "1")
+        private Integer elderId;
+        
+        @Schema(description = "통화 설정 ID", example = "1")
+        private Integer settingId;
+        
+        @Schema(
+            description = "통화 내용 텍스트", 
+            example = "오늘 아침에 밥을 먹었고, 혈당을 측정했어요. 120이 나왔어요. 기분도 좋아요."
+        )
+        private String transcriptionText;
+        
+        @Schema(description = "통화 날짜", example = "2024-01-01")
+        private String callDate;
+
+        // Getters and Setters
+        public Integer getElderId() { return elderId; }
+        public void setElderId(Integer elderId) { this.elderId = elderId; }
+        
+        public Integer getSettingId() { return settingId; }
+        public void setSettingId(Integer settingId) { this.settingId = settingId; }
+        
+        public String getTranscriptionText() { return transcriptionText; }
+        public void setTranscriptionText(String transcriptionText) { this.transcriptionText = transcriptionText; }
+        
+        public String getCallDate() { return callDate; }
+        public void setCallDate(String callDate) { this.callDate = callDate; }
     }
 } 

--- a/src/main/java/com/example/medicare_call/domain/BloodSugarRecord.java
+++ b/src/main/java/com/example/medicare_call/domain/BloodSugarRecord.java
@@ -1,5 +1,6 @@
 package com.example.medicare_call.domain;
 
+import com.example.medicare_call.global.enums.BloodSugarMeasurementType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
@@ -22,8 +23,9 @@ public class BloodSugarRecord {
     @JoinColumn(name = "carecall_record_id", nullable = false)
     private CareCallRecord careCallRecord;
 
-    @Column(name = "measurement_type")
-    private Byte measurementType;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "measurement_type", columnDefinition = "VARCHAR(20)")
+    private BloodSugarMeasurementType measurementType;
 
     @Column(name = "blood_sugar_value")
     private BigDecimal blood_sugar_value;
@@ -31,6 +33,7 @@ public class BloodSugarRecord {
     @Column(name = "unit", length = 10)
     private String unit;
 
+    // TODO: 주간 분석 결과로 초기화
     @Column(name = "status")
     private Byte status;
 
@@ -41,7 +44,7 @@ public class BloodSugarRecord {
     private String responseSummary;
 
     @Builder
-    public BloodSugarRecord(Integer id, CareCallRecord careCallRecord, Byte measurementType, BigDecimal blood_sugar_value, String unit, Byte status, LocalDateTime recordedAt, String responseSummary) {
+    public BloodSugarRecord(Integer id, CareCallRecord careCallRecord, BloodSugarMeasurementType measurementType, BigDecimal blood_sugar_value, String unit, Byte status, LocalDateTime recordedAt, String responseSummary) {
         this.id = id;
         this.careCallRecord = careCallRecord;
         this.measurementType = measurementType;

--- a/src/main/java/com/example/medicare_call/domain/CareCallRecord.java
+++ b/src/main/java/com/example/medicare_call/domain/CareCallRecord.java
@@ -31,34 +31,38 @@ public class CareCallRecord {
     private Byte responded;
 
     @Column(name = "sleep_start")
-    private LocalDateTime sleepStart;
+    private LocalDateTime sleepStart; // 수면 시작 시간
 
     @Column(name = "sleep_end")
-    private LocalDateTime sleepEnd;
+    private LocalDateTime sleepEnd; // 수면 종료 시간
 
     @Column(name = "health_status")
-    private Byte healthStatus;
+    private Byte healthStatus; // 1: 좋음, 0: 나쁨
 
     @Column(name = "psych_status")
-    private Byte psychStatus;
+    private Byte psychStatus; // 1: 좋음, 0: 나쁨
 
     @Column(name = "start_time")
-    private LocalDateTime startTime;
+    private LocalDateTime startTime; // 통화 시작 시간
 
     @Column(name = "end_time")
-    private LocalDateTime endTime;
+    private LocalDateTime endTime; // 통화 종료 시간
 
     @Column(name = "call_status")
-    private String callStatus;
-
-
+    private String callStatus; // 통화 상태
 
     @Column(name = "transcription_text", columnDefinition = "TEXT")
-    private String transcriptionText;
+    private String transcriptionText; // 통화 내용 텍스트
+
+    @Column(name = "psychological_details", columnDefinition = "TEXT")
+    private String psychologicalDetails; // 심리 상태 상세 내용
+
+    @Column(name = "health_details", columnDefinition = "TEXT")
+    private String healthDetails; // 건강 징후 상세 내용
 
     @Builder
     public CareCallRecord(Integer id, Elder elder, CareCallSetting setting, LocalDateTime calledAt, Byte responded, LocalDateTime sleepStart, LocalDateTime sleepEnd, Byte healthStatus, Byte psychStatus,
-                          LocalDateTime startTime, LocalDateTime endTime, String callStatus, String transcriptionText) {
+                          LocalDateTime startTime, LocalDateTime endTime, String callStatus, String transcriptionText, String psychologicalDetails, String healthDetails) {
         this.id = id;
         this.elder = elder;
         this.setting = setting;
@@ -72,5 +76,7 @@ public class CareCallRecord {
         this.endTime = endTime;
         this.callStatus = callStatus;
         this.transcriptionText = transcriptionText;
+        this.psychologicalDetails = psychologicalDetails;
+        this.healthDetails = healthDetails;
     }
 } 

--- a/src/main/java/com/example/medicare_call/domain/MedicationSchedule.java
+++ b/src/main/java/com/example/medicare_call/domain/MedicationSchedule.java
@@ -1,5 +1,6 @@
 package com.example.medicare_call.domain;
 
+import com.example.medicare_call.global.enums.FrequencyType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
@@ -30,11 +31,17 @@ public class MedicationSchedule {
     @Column(name = "notes", length = 500)
     private String notes;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "frequency_type", nullable = false, columnDefinition = "VARCHAR(20)")
+    private FrequencyType frequencyType;
+
     @Builder
-    public MedicationSchedule(Integer id, Elder elder, Medication medication, String scheduleTime) {
+    public MedicationSchedule(Integer id, Elder elder, Medication medication, String scheduleTime, String notes, FrequencyType frequencyType) {
         this.id = id;
         this.elder = elder;
         this.medication = medication;
         this.scheduleTime = scheduleTime;
+        this.notes = notes;
+        this.frequencyType = frequencyType;
     }
 } 

--- a/src/main/java/com/example/medicare_call/domain/MedicationTakenRecord.java
+++ b/src/main/java/com/example/medicare_call/domain/MedicationTakenRecord.java
@@ -1,5 +1,6 @@
 package com.example.medicare_call.domain;
 
+import com.example.medicare_call.global.enums.MedicationTakenStatus;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
@@ -23,14 +24,15 @@ public class MedicationTakenRecord {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "medication_schedule_id")
-    private MedicationSchedule medicationSchedule;
+    private MedicationSchedule medicationSchedule; // 매칭되는 스케줄이 있으면 설정, 없으면 null
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "medication_id", nullable = false)
     private Medication medication;
 
-    @Column(name = "taken_status")
-    private Byte takenStatus;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "taken_status", columnDefinition = "VARCHAR(20)")
+    private MedicationTakenStatus takenStatus;
 
     @Column(name = "response_summary", length = 500)
     private String responseSummary;
@@ -39,7 +41,7 @@ public class MedicationTakenRecord {
     private LocalDateTime recordedAt;
 
     @Builder
-    public MedicationTakenRecord(Integer id, CareCallRecord careCallRecord, MedicationSchedule medicationSchedule, Medication medication, Byte takenStatus, String responseSummary, LocalDateTime recordedAt) {
+    public MedicationTakenRecord(Integer id, CareCallRecord careCallRecord, MedicationSchedule medicationSchedule, Medication medication, MedicationTakenStatus takenStatus, String responseSummary, LocalDateTime recordedAt) {
         this.id = id;
         this.careCallRecord = careCallRecord;
         this.medicationSchedule = medicationSchedule;

--- a/src/main/java/com/example/medicare_call/dto/HealthDataExtractionResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/HealthDataExtractionResponse.java
@@ -27,6 +27,13 @@ public class HealthDataExtractionResponse {
     @Schema(description = "심리 상태 목록", example = "[\"기분이 좋음\", \"스트레스 없음\"]")
     private List<String> psychologicalState;
     
+    @Schema(
+        description = "심리 상태 요약",
+        example = "좋음",
+        allowableValues = {"좋음", "나쁨"}
+    )
+    private String psychologicalStatus;
+    
     @Schema(description = "혈당 데이터")
     private BloodSugarData bloodSugarData;
     
@@ -35,6 +42,13 @@ public class HealthDataExtractionResponse {
     
     @Schema(description = "건강 징후 목록", example = "[\"혈당이 정상 범위\", \"수면 패턴 양호\"]")
     private List<String> healthSigns;
+    
+    @Schema(
+        description = "건강 상태 요약",
+        example = "좋음",
+        allowableValues = {"좋음", "나쁨"}
+    )
+    private String healthStatus;
 
     @Getter
     @Builder

--- a/src/main/java/com/example/medicare_call/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/medicare_call/global/config/RestTemplateConfig.java
@@ -1,8 +1,11 @@
 package com.example.medicare_call.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -13,7 +16,11 @@ public class RestTemplateConfig {
     }
     
     @Bean
+    @Primary
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return objectMapper;
     }
 }

--- a/src/main/java/com/example/medicare_call/global/enums/BloodSugarMeasurementType.java
+++ b/src/main/java/com/example/medicare_call/global/enums/BloodSugarMeasurementType.java
@@ -1,0 +1,35 @@
+package com.example.medicare_call.global.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum BloodSugarMeasurementType {
+    BEFORE_MEAL("식전", (byte) 1),
+    AFTER_MEAL("식후", (byte) 2);
+
+    private final String description;
+    private final byte value;
+
+    BloodSugarMeasurementType(String description, byte value) {
+        this.description = description;
+        this.value = value;
+    }
+
+    public static BloodSugarMeasurementType fromDescription(String description) {
+        for (BloodSugarMeasurementType type : values()) {
+            if (type.getDescription().equals(description)) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    public static BloodSugarMeasurementType fromValue(byte value) {
+        for (BloodSugarMeasurementType type : values()) {
+            if (type.getValue() == value) {
+                return type;
+            }
+        }
+        return null;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/global/enums/FrequencyType.java
+++ b/src/main/java/com/example/medicare_call/global/enums/FrequencyType.java
@@ -1,0 +1,37 @@
+package com.example.medicare_call.global.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum FrequencyType {
+    DAILY(0, "매일"),
+    WEEKLY(1, "주간"),
+    MONTHLY(2, "월간"),
+    SPECIFIC_DAYS(3, "특정일");
+
+    private final int value;
+    private final String description;
+
+    FrequencyType(int value, String description) {
+        this.value = value;
+        this.description = description;
+    }
+
+    public static FrequencyType fromValue(int value) {
+        for (FrequencyType type : values()) {
+            if (type.getValue() == value) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    public static FrequencyType fromDescription(String description) {
+        for (FrequencyType type : values()) {
+            if (type.getDescription().equals(description)) {
+                return type;
+            }
+        }
+        return null;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/global/enums/HealthStatus.java
+++ b/src/main/java/com/example/medicare_call/global/enums/HealthStatus.java
@@ -1,0 +1,26 @@
+package com.example.medicare_call.global.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum HealthStatus {
+    GOOD("좋음", (byte) 1),
+    BAD("나쁨", (byte) 0);
+
+    private final String description;
+    private final byte value;
+
+    HealthStatus(String description, byte value) {
+        this.description = description;
+        this.value = value;
+    }
+
+    public static HealthStatus fromValue(byte value) {
+        for (HealthStatus status : values()) {
+            if (status.getValue() == value) {
+                return status;
+            }
+        }
+        return null;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/global/enums/MealEatenStatus.java
+++ b/src/main/java/com/example/medicare_call/global/enums/MealEatenStatus.java
@@ -1,0 +1,26 @@
+package com.example.medicare_call.global.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum MealEatenStatus {
+    EATEN("섭취함", (byte) 1),
+    NOT_EATEN("섭취하지 않음", (byte) 0);
+
+    private final String description;
+    private final byte value;
+
+    MealEatenStatus(String description, byte value) {
+        this.description = description;
+        this.value = value;
+    }
+
+    public static MealEatenStatus fromValue(byte value) {
+        for (MealEatenStatus status : values()) {
+            if (status.getValue() == value) {
+                return status;
+            }
+        }
+        return null;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/global/enums/MealType.java
+++ b/src/main/java/com/example/medicare_call/global/enums/MealType.java
@@ -1,0 +1,36 @@
+package com.example.medicare_call.global.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum MealType {
+    BREAKFAST("아침", (byte) 1),
+    LUNCH("점심", (byte) 2),
+    DINNER("저녁", (byte) 3);
+
+    private final String description;
+    private final byte value;
+
+    MealType(String description, byte value) {
+        this.description = description;
+        this.value = value;
+    }
+
+    public static MealType fromDescription(String description) {
+        for (MealType type : values()) {
+            if (type.getDescription().equals(description)) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    public static MealType fromValue(byte value) {
+        for (MealType type : values()) {
+            if (type.getValue() == value) {
+                return type;
+            }
+        }
+        return null;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/global/enums/MedicationScheduleTime.java
+++ b/src/main/java/com/example/medicare_call/global/enums/MedicationScheduleTime.java
@@ -1,7 +1,25 @@
 package com.example.medicare_call.global.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum MedicationScheduleTime {
-    MORNING,
-    LUNCH,
-    DINNER
+    MORNING("아침"),
+    LUNCH("점심"),
+    DINNER("저녁");
+
+    private final String description;
+
+    MedicationScheduleTime(String description) {
+        this.description = description;
+    }
+
+    public static MedicationScheduleTime fromDescription(String description) {
+        for (MedicationScheduleTime time : values()) {
+            if (time.getDescription().equals(description)) {
+                return time;
+            }
+        }
+        return null;
+    }
 } 

--- a/src/main/java/com/example/medicare_call/global/enums/MedicationTakenStatus.java
+++ b/src/main/java/com/example/medicare_call/global/enums/MedicationTakenStatus.java
@@ -1,0 +1,35 @@
+package com.example.medicare_call.global.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum MedicationTakenStatus {
+    TAKEN("복용함", (byte) 1),
+    NOT_TAKEN("복용하지 않음", (byte) 0);
+
+    private final String description;
+    private final byte value;
+
+    MedicationTakenStatus(String description, byte value) {
+        this.description = description;
+        this.value = value;
+    }
+
+    public static MedicationTakenStatus fromDescription(String description) {
+        for (MedicationTakenStatus status : values()) {
+            if (status.getDescription().equals(description)) {
+                return status;
+            }
+        }
+        return null;
+    }
+
+    public static MedicationTakenStatus fromValue(byte value) {
+        for (MedicationTakenStatus status : values()) {
+            if (status.getValue() == value) {
+                return status;
+            }
+        }
+        return null;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/global/enums/PsychologicalStatus.java
+++ b/src/main/java/com/example/medicare_call/global/enums/PsychologicalStatus.java
@@ -1,0 +1,26 @@
+package com.example.medicare_call.global.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum PsychologicalStatus {
+    GOOD("좋음", (byte) 1),
+    BAD("나쁨", (byte) 0);
+
+    private final String description;
+    private final byte value;
+
+    PsychologicalStatus(String description, byte value) {
+        this.description = description;
+        this.value = value;
+    }
+
+    public static PsychologicalStatus fromValue(byte value) {
+        for (PsychologicalStatus status : values()) {
+            if (status.getValue() == value) {
+                return status;
+            }
+        }
+        return null;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/repository/MedicationScheduleRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/MedicationScheduleRepository.java
@@ -1,7 +1,11 @@
 package com.example.medicare_call.repository;
 
 import com.example.medicare_call.domain.MedicationSchedule;
+import com.example.medicare_call.domain.Elder;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MedicationScheduleRepository extends JpaRepository<MedicationSchedule, Integer> {
+    List<MedicationSchedule> findByElder(Elder elder);
 } 

--- a/src/main/java/com/example/medicare_call/service/HealthDataService.java
+++ b/src/main/java/com/example/medicare_call/service/HealthDataService.java
@@ -1,0 +1,205 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.CareCallRecord;
+import com.example.medicare_call.domain.MealRecord;
+import com.example.medicare_call.dto.HealthDataExtractionResponse;
+import com.example.medicare_call.global.enums.HealthStatus;
+import com.example.medicare_call.global.enums.MealEatenStatus;
+import com.example.medicare_call.global.enums.MealType;
+import com.example.medicare_call.global.enums.PsychologicalStatus;
+import com.example.medicare_call.repository.CareCallRecordRepository;
+import com.example.medicare_call.repository.MealRecordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HealthDataService {
+    private final CareCallRecordRepository careCallRecordRepository;
+    private final MealRecordRepository mealRecordRepository;
+
+    @Transactional
+    public void updateCareCallRecordWithHealthData(CareCallRecord callRecord, HealthDataExtractionResponse healthData) {
+        CareCallRecord updatedRecord = callRecord;
+        
+        // 식사 데이터 처리
+        if (healthData.getMealData() != null) {
+            saveMealData(updatedRecord, healthData.getMealData());
+        }
+        
+        // 수면 데이터 처리
+        if (healthData.getSleepData() != null) {
+            updatedRecord = updateSleepData(updatedRecord, healthData.getSleepData());
+        }
+        
+        // 심리 상태 처리
+        if (healthData.getPsychologicalState() != null && !healthData.getPsychologicalState().isEmpty()) {
+            updatedRecord = updatePsychologicalStatus(updatedRecord, healthData.getPsychologicalState(), healthData.getPsychologicalStatus());
+        }
+        
+        // 건강 징후 처리
+        if (healthData.getHealthSigns() != null && !healthData.getHealthSigns().isEmpty()) {
+            updatedRecord = updateHealthStatus(updatedRecord, healthData.getHealthSigns(), healthData.getHealthStatus());
+        }
+        
+        // 업데이트된 CareCallRecord 저장
+        careCallRecordRepository.save(updatedRecord);
+        log.info("CareCallRecord 건강 데이터 업데이트 완료: callId={}", updatedRecord.getId());
+    }
+    
+    private void saveMealData(CareCallRecord callRecord, HealthDataExtractionResponse.MealData mealData) {
+        // 식사 타입 결정
+        MealType mealType = MealType.fromDescription(mealData.getMealType());
+        if (mealType == null) {
+            log.warn("알 수 없는 식사 타입: {}", mealData.getMealType());
+            return;
+        }
+        
+        // 식사 데이터 저장 (식사를 했다고 가정)
+        MealRecord mealRecord = MealRecord.builder()
+                .careCallRecord(callRecord)
+                .mealType(mealType.getValue())
+                .eatenStatus(MealEatenStatus.EATEN.getValue())
+                .responseSummary(mealData.getMealSummary())
+                .recordedAt(LocalDateTime.now())
+                .build();
+        
+        mealRecordRepository.save(mealRecord);
+        log.info("식사 데이터 저장 완료: mealType={}, summary={}", mealData.getMealType(), mealData.getMealSummary());
+    }
+    
+    private CareCallRecord updateSleepData(CareCallRecord callRecord, HealthDataExtractionResponse.SleepData sleepData) {
+        LocalDateTime callDate = callRecord.getStartTime() != null ? 
+            callRecord.getStartTime().toLocalDate().atStartOfDay() : 
+            LocalDateTime.now().toLocalDate().atStartOfDay();
+        
+        LocalDateTime sleepStart = null;
+        LocalDateTime sleepEnd = null;
+        
+        // 수면 시작 시간 파싱
+        if (sleepData.getSleepStartTime() != null) {
+            try {
+                LocalTime sleepStartTime = LocalTime.parse(sleepData.getSleepStartTime());
+                sleepStart = callDate.plusHours(sleepStartTime.getHour()).plusMinutes(sleepStartTime.getMinute());
+            } catch (Exception e) {
+                log.warn("수면 시작 시간 파싱 실패: {}", sleepData.getSleepStartTime(), e);
+            }
+        }
+        
+        // 수면 종료 시간 파싱
+        if (sleepData.getSleepEndTime() != null) {
+            try {
+                LocalTime sleepEndTime = LocalTime.parse(sleepData.getSleepEndTime());
+                sleepEnd = callDate.plusHours(sleepEndTime.getHour()).plusMinutes(sleepEndTime.getMinute());
+            } catch (Exception e) {
+                log.warn("수면 종료 시간 파싱 실패: {}", sleepData.getSleepEndTime(), e);
+            }
+        }
+        
+        // 수면 데이터가 있으면 CareCallRecord 업데이트
+        if (sleepStart != null || sleepEnd != null) {
+            callRecord = CareCallRecord.builder()
+                    .id(callRecord.getId())
+                    .elder(callRecord.getElder())
+                    .setting(callRecord.getSetting())
+                    .calledAt(callRecord.getCalledAt())
+                    .responded(callRecord.getResponded())
+                    .sleepStart(sleepStart != null ? sleepStart : callRecord.getSleepStart())
+                    .sleepEnd(sleepEnd != null ? sleepEnd : callRecord.getSleepEnd())
+                    .healthStatus(callRecord.getHealthStatus())
+                    .psychStatus(callRecord.getPsychStatus())
+                    .startTime(callRecord.getStartTime())
+                    .endTime(callRecord.getEndTime())
+                    .callStatus(callRecord.getCallStatus())
+                    .transcriptionText(callRecord.getTranscriptionText())
+                    .psychologicalDetails(callRecord.getPsychologicalDetails())
+                    .healthDetails(callRecord.getHealthDetails())
+                    .build();
+        }
+        
+        log.info("수면 데이터 업데이트 완료: sleepStart={}, sleepEnd={}, totalSleepTime={}", 
+            sleepData.getSleepStartTime(), sleepData.getSleepEndTime(), sleepData.getTotalSleepTime());
+        
+        return callRecord;
+    }
+    
+    private CareCallRecord updatePsychologicalStatus(CareCallRecord callRecord, java.util.List<String> psychologicalState, String psychologicalStatus) {
+        // OpenAiHealthDataService 에서 고정값을 내려줘서 리터럴을 사용하여 비교함
+        Byte psychStatus = null;
+        if ("좋음".equals(psychologicalStatus)) {
+            psychStatus = PsychologicalStatus.GOOD.getValue();
+        } else if ("나쁨".equals(psychologicalStatus)) {
+            psychStatus = PsychologicalStatus.BAD.getValue();
+        }
+        
+        // 상세 내용을 문자열로 저장
+        String psychologicalDetails = String.join(", ", psychologicalState);
+        
+        if (psychStatus != null) {
+            callRecord = CareCallRecord.builder()
+                    .id(callRecord.getId())
+                    .elder(callRecord.getElder())
+                    .setting(callRecord.getSetting())
+                    .calledAt(callRecord.getCalledAt())
+                    .responded(callRecord.getResponded())
+                    .sleepStart(callRecord.getSleepStart())
+                    .sleepEnd(callRecord.getSleepEnd())
+                    .healthStatus(callRecord.getHealthStatus())
+                    .psychStatus(psychStatus)
+                    .startTime(callRecord.getStartTime())
+                    .endTime(callRecord.getEndTime())
+                    .callStatus(callRecord.getCallStatus())
+                    .transcriptionText(callRecord.getTranscriptionText())
+                    .psychologicalDetails(psychologicalDetails)
+                    .healthDetails(callRecord.getHealthDetails())
+                    .build();
+        }
+        
+        log.info("심리 상태 업데이트 완료: psychologicalState={}, psychologicalStatus={}", psychologicalState, psychologicalStatus);
+        
+        return callRecord;
+    }
+    
+    private CareCallRecord updateHealthStatus(CareCallRecord callRecord, java.util.List<String> healthSigns, String healthStatus) {
+        // OpenAiHealthDataService 에서 고정값을 내려줘서 리터럴을 사용하여 비교함
+        Byte healthStatusValue = null;
+        if ("좋음".equals(healthStatus)) {
+            healthStatusValue = HealthStatus.GOOD.getValue();
+        } else if ("나쁨".equals(healthStatus)) {
+            healthStatusValue = HealthStatus.BAD.getValue();
+        }
+        
+        // 상세 내용을 문자열로 저장
+        String healthDetails = String.join(", ", healthSigns);
+        
+        if (healthStatusValue != null) {
+            callRecord = CareCallRecord.builder()
+                    .id(callRecord.getId())
+                    .elder(callRecord.getElder())
+                    .setting(callRecord.getSetting())
+                    .calledAt(callRecord.getCalledAt())
+                    .responded(callRecord.getResponded())
+                    .sleepStart(callRecord.getSleepStart())
+                    .sleepEnd(callRecord.getSleepEnd())
+                    .healthStatus(healthStatusValue)
+                    .psychStatus(callRecord.getPsychStatus())
+                    .startTime(callRecord.getStartTime())
+                    .endTime(callRecord.getEndTime())
+                    .callStatus(callRecord.getCallStatus())
+                    .transcriptionText(callRecord.getTranscriptionText())
+                    .psychologicalDetails(callRecord.getPsychologicalDetails())
+                    .healthDetails(healthDetails)
+                    .build();
+        }
+        
+        log.info("건강 징후 업데이트 완료: healthSigns={}, healthStatus={}", healthSigns, healthStatus);
+        
+        return callRecord;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/service/MedicationService.java
+++ b/src/main/java/com/example/medicare_call/service/MedicationService.java
@@ -1,0 +1,84 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.*;
+import com.example.medicare_call.dto.HealthDataExtractionResponse;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
+import com.example.medicare_call.global.enums.MedicationTakenStatus;
+import com.example.medicare_call.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MedicationService {
+    private final MedicationTakenRecordRepository medicationTakenRecordRepository;
+    private final MedicationScheduleRepository medicationScheduleRepository;
+    private final MedicationRepository medicationRepository;
+
+    @Transactional
+    public void saveMedicationTakenRecord(CareCallRecord callRecord, HealthDataExtractionResponse.MedicationData medicationData) {
+        // 약 이름으로 Medication 찾기
+        Optional<Medication> medicationOpt = medicationRepository.findByName(medicationData.getMedicationType());
+        if (medicationOpt.isEmpty()) {
+            log.warn("약을 찾을 수 없습니다: {}", medicationData.getMedicationType());
+            return;
+        }
+
+        Medication medication = medicationOpt.get();
+
+        // 해당 어르신의 복약 스케줄에서 매칭되는 것 찾기
+        List<MedicationSchedule> schedules = medicationScheduleRepository.findByElder(callRecord.getElder());
+        MedicationSchedule matchedSchedule = null;
+        
+        for (MedicationSchedule schedule : schedules) {
+            if (schedule.getMedication().getId().equals(medication.getId()) &&
+                isScheduleTimeMatched(schedule.getScheduleTime(), medicationData.getTakenTime())) {
+                matchedSchedule = schedule;
+                break;
+            }
+        }
+        
+        // takenStatus 결정
+        MedicationTakenStatus takenStatus = MedicationTakenStatus.fromDescription(medicationData.getTaken());
+        
+        MedicationTakenRecord medicationRecord = MedicationTakenRecord.builder()
+                .careCallRecord(callRecord)
+                .medicationSchedule(matchedSchedule) // 매칭되는 스케줄이 있으면 설정, 없으면 null
+                .medication(medication)
+                .takenStatus(takenStatus)
+                .responseSummary(String.format("복용시간: %s, 복용여부: %s", 
+                    medicationData.getTakenTime(), medicationData.getTaken()))
+                .recordedAt(LocalDateTime.now())
+                .build();
+        
+        medicationTakenRecordRepository.save(medicationRecord);
+        log.info("복약 데이터 저장 완료: medication={}, taken={}, scheduleMatched={}", 
+            medicationData.getMedicationType(), medicationData.getTaken(), matchedSchedule != null);
+    }
+
+    /**
+     * 스케줄 시간과 복용 시간을 매칭하는 메서드
+     * DB에 저장된 스케줄 시간(예: "MORNING,LUNCH")과 프롬프트에서 나온 복용 시간(예: "아침")을 매칭
+     */
+    private boolean isScheduleTimeMatched(String scheduleTime, String takenTime) {
+        if (scheduleTime == null || takenTime == null) {
+            return false;
+        }
+
+        // 프롬프트에서 나오는 시간을 enum으로 변환
+        MedicationScheduleTime takenTimeEnum = MedicationScheduleTime.fromDescription(takenTime);
+        if (takenTimeEnum == null) {
+            return false;
+        }
+
+        // DB에 저장된 스케줄 시간에 포함되어 있는지 확인
+        return scheduleTime.contains(takenTimeEnum.name());
+    }
+} 

--- a/src/main/java/com/example/medicare_call/service/OpenAiHealthDataService.java
+++ b/src/main/java/com/example/medicare_call/service/OpenAiHealthDataService.java
@@ -105,7 +105,9 @@ public class OpenAiHealthDataService {
                - 취침 시작 시각
                - 취침 종료 시각
                - 총 수면 시간
-            4. 심리 상태 요약 데이터 (짧은 문장들로 요약)
+            4. 심리 상태 데이터
+               - 심리 상태 상세 내용 (짧은 문장들로 요약)
+               - 심리 상태 요약 (좋음/나쁨)
             5. 혈당 데이터
                - 측정한 시각
                - 식전 여부
@@ -114,7 +116,9 @@ public class OpenAiHealthDataService {
                - 약의 종류
                - 복약 여부
                - 복용 시간
-            7. 건강 징후 데이터 (짧은 문장들로 요약)
+            7. 건강 징후 데이터
+               - 건강 징후 상세 내용 (짧은 문장들로 요약)
+               - 건강 상태 요약 (좋음/나쁨)
             
             응답은 반드시 다음 JSON 구조로 해주세요:
             {
@@ -128,7 +132,8 @@ public class OpenAiHealthDataService {
                 "sleepEndTime": "취침 종료 시각",
                 "totalSleepTime": "총 수면 시간"
               },
-              "psychologicalState": ["심리 상태 요약 1", "심리 상태 요약 2"],
+              "psychologicalState": ["심리 상태 상세 내용 1", "심리 상태 상세 내용 2"],
+              "psychologicalStatus": "좋음/나쁨",
               "bloodSugarData": {
                 "measurementTime": "측정 시각",
                 "mealTime": "식전/식후",
@@ -139,7 +144,8 @@ public class OpenAiHealthDataService {
                 "taken": "복용 여부",
                 "takenTime": "복용 시간"
               },
-              "healthSigns": ["건강 징후 1", "건강 징후 2"]
+              "healthSigns": ["건강 징후 상세 내용 1", "건강 징후 상세 내용 2"],
+              "healthStatus": "좋음/나쁨"
             }
             """, 
             request.getCallDate(),
@@ -171,9 +177,11 @@ public class OpenAiHealthDataService {
                 .mealData(null)
                 .sleepData(null)
                 .psychologicalState(null)
+                .psychologicalStatus(null)
                 .bloodSugarData(null)
                 .medicationData(null)
                 .healthSigns(null)
+                .healthStatus(null)
                 .build();
     }
 } 

--- a/src/main/resources/db/migration/V6__convert_measurement_status_to_enums_and_add_health_details.sql
+++ b/src/main/resources/db/migration/V6__convert_measurement_status_to_enums_and_add_health_details.sql
@@ -1,0 +1,42 @@
+-- BloodSugarRecord 테이블의 measurement_type 컬럼을 TINYINT에서 VARCHAR로 변경
+-- 기존 데이터 변환: 1 -> 'BEFORE_MEAL', 2 -> 'AFTER_MEAL'
+ALTER TABLE BloodSugarRecord 
+ADD COLUMN measurement_type_new VARCHAR(20) DEFAULT NULL;
+
+UPDATE BloodSugarRecord 
+SET measurement_type_new = CASE 
+    WHEN measurement_type = 1 THEN 'BEFORE_MEAL'
+    WHEN measurement_type = 2 THEN 'AFTER_MEAL'
+    ELSE NULL
+END;
+
+ALTER TABLE BloodSugarRecord 
+DROP COLUMN measurement_type;
+
+ALTER TABLE BloodSugarRecord 
+CHANGE COLUMN measurement_type_new measurement_type VARCHAR(20) DEFAULT NULL;
+
+-- MedicationTakenRecord 테이블의 taken_status 컬럼을 TINYINT에서 VARCHAR로 변경
+-- 기존 데이터 변환: 1 -> 'TAKEN', 0 -> 'NOT_TAKEN'
+ALTER TABLE MedicationTakenRecord 
+ADD COLUMN taken_status_new VARCHAR(20) DEFAULT NULL;
+
+UPDATE MedicationTakenRecord 
+SET taken_status_new = CASE 
+    WHEN taken_status = 1 THEN 'TAKEN'
+    WHEN taken_status = 0 THEN 'NOT_TAKEN'
+    ELSE NULL
+END;
+
+ALTER TABLE MedicationTakenRecord 
+DROP COLUMN taken_status;
+
+ALTER TABLE MedicationTakenRecord 
+CHANGE COLUMN taken_status_new taken_status VARCHAR(20) DEFAULT NULL;
+
+-- CareCallRecord 테이블에 새로운 컬럼 추가
+ALTER TABLE CareCallRecord 
+ADD COLUMN psychological_details TEXT DEFAULT NULL;
+
+ALTER TABLE CareCallRecord 
+ADD COLUMN health_details TEXT DEFAULT NULL; 

--- a/src/main/resources/db/migration/V7__convert_frequency_type_to_enum.sql
+++ b/src/main/resources/db/migration/V7__convert_frequency_type_to_enum.sql
@@ -1,0 +1,19 @@
+-- MedicationSchedule 테이블의 frequency_type 컬럼을 TINYINT에서 VARCHAR로 변경
+-- 기존 데이터 변환: 0 -> 'DAILY', 1 -> 'WEEKLY', 2 -> 'MONTHLY', 3 -> 'SPECIFIC_DAYS'
+ALTER TABLE MedicationSchedule 
+ADD COLUMN frequency_type_new VARCHAR(20) DEFAULT NULL;
+
+UPDATE MedicationSchedule 
+SET frequency_type_new = CASE 
+    WHEN frequency_type = 0 THEN 'DAILY'
+    WHEN frequency_type = 1 THEN 'WEEKLY'
+    WHEN frequency_type = 2 THEN 'MONTHLY'
+    WHEN frequency_type = 3 THEN 'SPECIFIC_DAYS'
+    ELSE 'DAILY'
+END;
+
+ALTER TABLE MedicationSchedule 
+DROP COLUMN frequency_type;
+
+ALTER TABLE MedicationSchedule 
+CHANGE COLUMN frequency_type_new frequency_type VARCHAR(20) NOT NULL; 

--- a/src/test/java/com/example/medicare_call/controller/CallDataControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/CallDataControllerTest.java
@@ -104,8 +104,9 @@ class CallDataControllerTest {
                 .startTime(LocalDateTime.parse("2025-01-27T10:00:00"))
                 .endTime(LocalDateTime.parse("2025-01-27T10:15:00"))
                 .callStatus("completed")
-
                 .transcriptionText("고객: 안녕하세요, 오늘 컨디션은 어떠세요?\n어르신: 네, 오늘은 컨디션이 좋아요.")
+                .psychologicalDetails(null)
+                .healthDetails(null)
                 .build();
 
         when(callDataService.saveCallData(any(CallDataRequest.class))).thenReturn(savedRecord);
@@ -209,6 +210,8 @@ class CallDataControllerTest {
                 .elder(elder)
                 .setting(setting)
                 .callStatus("completed")
+                .psychologicalDetails(null)
+                .healthDetails(null)
                 .build();
 
         when(callDataService.saveCallData(any(CallDataRequest.class))).thenReturn(savedRecord);

--- a/src/test/java/com/example/medicare_call/global/enums/BloodSugarMeasurementTypeTest.java
+++ b/src/test/java/com/example/medicare_call/global/enums/BloodSugarMeasurementTypeTest.java
@@ -1,0 +1,48 @@
+package com.example.medicare_call.global.enums;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BloodSugarMeasurementTypeTest {
+
+    @Test
+    @DisplayName("fromDescription 반환값 검증")
+    void fromDescription_returnsCorrectEnum() {
+        // when & then
+        assertThat(BloodSugarMeasurementType.fromDescription("식전"))
+                .isEqualTo(BloodSugarMeasurementType.BEFORE_MEAL);
+        
+        assertThat(BloodSugarMeasurementType.fromDescription("식후"))
+                .isEqualTo(BloodSugarMeasurementType.AFTER_MEAL);
+        
+        assertThat(BloodSugarMeasurementType.fromDescription("알 수 없는 값"))
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("fromValue 반환값 검증")
+    void fromValue_returnsCorrectEnum() {
+        // when & then
+        assertThat(BloodSugarMeasurementType.fromValue((byte) 1))
+                .isEqualTo(BloodSugarMeasurementType.BEFORE_MEAL);
+        
+        assertThat(BloodSugarMeasurementType.fromValue((byte) 2))
+                .isEqualTo(BloodSugarMeasurementType.AFTER_MEAL);
+        
+        assertThat(BloodSugarMeasurementType.fromValue((byte) 99))
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("enum 값 설정 검증")
+    void enumValues_areCorrectlySet() {
+        // when & then
+        assertThat(BloodSugarMeasurementType.BEFORE_MEAL.getDescription()).isEqualTo("식전");
+        assertThat(BloodSugarMeasurementType.BEFORE_MEAL.getValue()).isEqualTo((byte) 1);
+        
+        assertThat(BloodSugarMeasurementType.AFTER_MEAL.getDescription()).isEqualTo("식후");
+        assertThat(BloodSugarMeasurementType.AFTER_MEAL.getValue()).isEqualTo((byte) 2);
+    }
+} 

--- a/src/test/java/com/example/medicare_call/global/enums/MealTypeTest.java
+++ b/src/test/java/com/example/medicare_call/global/enums/MealTypeTest.java
@@ -1,0 +1,57 @@
+package com.example.medicare_call.global.enums;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MealTypeTest {
+
+    @Test
+    @DisplayName("fromDescription 반환값 검증")
+    void fromDescription_returnsCorrectEnum() {
+        // when & then
+        assertThat(MealType.fromDescription("아침"))
+                .isEqualTo(MealType.BREAKFAST);
+        
+        assertThat(MealType.fromDescription("점심"))
+                .isEqualTo(MealType.LUNCH);
+        
+        assertThat(MealType.fromDescription("저녁"))
+                .isEqualTo(MealType.DINNER);
+        
+        assertThat(MealType.fromDescription("알 수 없는 값"))
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("fromValue 반환값 검증")
+    void fromValue_returnsCorrectEnum() {
+        // when & then
+        assertThat(MealType.fromValue((byte) 1))
+                .isEqualTo(MealType.BREAKFAST);
+        
+        assertThat(MealType.fromValue((byte) 2))
+                .isEqualTo(MealType.LUNCH);
+        
+        assertThat(MealType.fromValue((byte) 3))
+                .isEqualTo(MealType.DINNER);
+        
+        assertThat(MealType.fromValue((byte) 99))
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("enum 값 설정 검증")
+    void enumValues_areCorrectlySet() {
+        // when & then
+        assertThat(MealType.BREAKFAST.getDescription()).isEqualTo("아침");
+        assertThat(MealType.BREAKFAST.getValue()).isEqualTo((byte) 1);
+        
+        assertThat(MealType.LUNCH.getDescription()).isEqualTo("점심");
+        assertThat(MealType.LUNCH.getValue()).isEqualTo((byte) 2);
+        
+        assertThat(MealType.DINNER.getDescription()).isEqualTo("저녁");
+        assertThat(MealType.DINNER.getValue()).isEqualTo((byte) 3);
+    }
+} 

--- a/src/test/java/com/example/medicare_call/global/enums/MedicationTakenStatusTest.java
+++ b/src/test/java/com/example/medicare_call/global/enums/MedicationTakenStatusTest.java
@@ -1,0 +1,48 @@
+package com.example.medicare_call.global.enums;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MedicationTakenStatusTest {
+
+    @Test
+    @DisplayName("fromDescription 반환값 검증")
+    void fromDescription_returnsCorrectEnum() {
+        // when & then
+        assertThat(MedicationTakenStatus.fromDescription("복용함"))
+                .isEqualTo(MedicationTakenStatus.TAKEN);
+        
+        assertThat(MedicationTakenStatus.fromDescription("복용하지 않음"))
+                .isEqualTo(MedicationTakenStatus.NOT_TAKEN);
+        
+        assertThat(MedicationTakenStatus.fromDescription("알 수 없는 값"))
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("fromValue 반환값 검증")
+    void fromValue_returnsCorrectEnum() {
+        // when & then
+        assertThat(MedicationTakenStatus.fromValue((byte) 1))
+                .isEqualTo(MedicationTakenStatus.TAKEN);
+        
+        assertThat(MedicationTakenStatus.fromValue((byte) 0))
+                .isEqualTo(MedicationTakenStatus.NOT_TAKEN);
+        
+        assertThat(MedicationTakenStatus.fromValue((byte) 99))
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("enum 값 설정 검증")
+    void enumValues_areCorrectlySet() {
+        // when & then
+        assertThat(MedicationTakenStatus.TAKEN.getDescription()).isEqualTo("복용함");
+        assertThat(MedicationTakenStatus.TAKEN.getValue()).isEqualTo((byte) 1);
+        
+        assertThat(MedicationTakenStatus.NOT_TAKEN.getDescription()).isEqualTo("복용하지 않음");
+        assertThat(MedicationTakenStatus.NOT_TAKEN.getValue()).isEqualTo((byte) 0);
+    }
+} 

--- a/src/test/java/com/example/medicare_call/service/CallDataServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/CallDataServiceTest.java
@@ -91,6 +91,8 @@ class CallDataServiceTest {
                 .endTime(LocalDateTime.parse("2025-01-27T10:15:00"))
                 .callStatus("completed")
                 .transcriptionText("고객: 안녕하세요, 오늘 컨디션은 어떠세요?\n어르신: 네, 오늘은 컨디션이 좋아요.")
+                .psychologicalDetails(null)
+                .healthDetails(null)
                 .build();
 
         when(elderRepository.findById(1)).thenReturn(Optional.of(elder));
@@ -139,6 +141,8 @@ class CallDataServiceTest {
                 .elder(elder)
                 .setting(setting)
                 .callStatus("failed")
+                .psychologicalDetails(null)
+                .healthDetails(null)
                 .build();
 
         when(elderRepository.findById(1)).thenReturn(Optional.of(elder));
@@ -188,6 +192,8 @@ class CallDataServiceTest {
                 .elder(elder)
                 .setting(setting)
                 .callStatus("busy")
+                .psychologicalDetails(null)
+                .healthDetails(null)
                 .build();
 
         when(elderRepository.findById(1)).thenReturn(Optional.of(elder));
@@ -281,6 +287,8 @@ class CallDataServiceTest {
                 .elder(elder)
                 .setting(setting)
                 .callStatus("no-answer")
+                .psychologicalDetails(null)
+                .healthDetails(null)
                 .build();
 
         when(elderRepository.findById(1)).thenReturn(Optional.of(elder));
@@ -339,6 +347,8 @@ class CallDataServiceTest {
                 .startTime(LocalDateTime.parse("2025-01-27T10:00:00"))
                 .callStatus("completed")
                 .transcriptionText("어르신: 오늘 아침에 밥을 먹었고, 혈당을 측정했어요. 120이 나왔어요.")
+                .psychologicalDetails(null)
+                .healthDetails(null)
                 .build();
 
         when(elderRepository.findById(1)).thenReturn(Optional.of(elder));

--- a/src/test/java/com/example/medicare_call/service/HealthDataExtractionIntegrationTest.java
+++ b/src/test/java/com/example/medicare_call/service/HealthDataExtractionIntegrationTest.java
@@ -58,13 +58,15 @@ class HealthDataExtractionIntegrationTest {
               },
               "sleepData": null,
               "psychologicalState": ["기분이 좋음", "잠을 잘 잤음"],
+              "psychologicalStatus": "좋음",
               "bloodSugarData": {
                 "measurementTime": "아침",
                 "mealTime": "식후",
                 "bloodSugarValue": 120
               },
               "medicationData": null,
-              "healthSigns": ["혈당이 정상 범위", "식사 후 혈당 측정"]
+              "healthSigns": ["혈당이 정상 범위", "식사 후 혈당 측정"],
+              "healthStatus": "좋음"
             }
             """;
 
@@ -125,13 +127,15 @@ class HealthDataExtractionIntegrationTest {
                 "totalSleepTime": "8시간"
               },
               "psychologicalState": null,
+              "psychologicalStatus": null,
               "bloodSugarData": null,
               "medicationData": {
                 "medicationType": "혈압약",
                 "taken": "복용함",
                 "takenTime": "아침"
               },
-              "healthSigns": ["머리가 아픔"]
+              "healthSigns": ["머리가 아픔"],
+              "healthStatus": "나쁨"
             }
             """;
 
@@ -178,9 +182,11 @@ class HealthDataExtractionIntegrationTest {
               "mealData": null,
               "sleepData": null,
               "psychologicalState": null,
+              "psychologicalStatus": null,
               "bloodSugarData": null,
               "medicationData": null,
-              "healthSigns": null
+              "healthSigns": null,
+              "healthStatus": null
             }
             """;
 

--- a/src/test/java/com/example/medicare_call/service/HealthDataServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/HealthDataServiceTest.java
@@ -1,0 +1,173 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.CareCallRecord;
+import com.example.medicare_call.domain.Elder;
+import com.example.medicare_call.domain.MealRecord;
+import com.example.medicare_call.dto.HealthDataExtractionResponse;
+import com.example.medicare_call.repository.CareCallRecordRepository;
+import com.example.medicare_call.repository.MealRecordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class HealthDataServiceTest {
+
+    @Mock
+    private CareCallRecordRepository careCallRecordRepository;
+
+    @Mock
+    private MealRecordRepository mealRecordRepository;
+
+    @InjectMocks
+    private HealthDataService healthDataService;
+
+    private CareCallRecord callRecord;
+    private Elder elder;
+
+    @BeforeEach
+    void setUp() {
+        elder = Elder.builder()
+                .id(1)
+                .name("테스트 어르신")
+                .build();
+
+        callRecord = CareCallRecord.builder()
+                .id(1)
+                .elder(elder)
+                .calledAt(LocalDateTime.now())
+                .responded((byte) 1)
+                .psychologicalDetails(null)
+                .healthDetails(null)
+                .build();
+    }
+
+    @Test
+    @DisplayName("식사 데이터 저장 검증")
+    void updateCareCallRecordWithHealthData_savesMealData() {
+        // given
+        HealthDataExtractionResponse.MealData mealData = HealthDataExtractionResponse.MealData.builder()
+                .mealType("아침")
+                .mealSummary("김치찌개와 밥을 먹었음")
+                .build();
+
+        HealthDataExtractionResponse healthData = HealthDataExtractionResponse.builder()
+                .mealData(mealData)
+                .build();
+
+        when(mealRecordRepository.save(any(MealRecord.class))).thenReturn(MealRecord.builder().id(1).build());
+        when(careCallRecordRepository.save(any(CareCallRecord.class))).thenReturn(callRecord);
+
+        // when
+        healthDataService.updateCareCallRecordWithHealthData(callRecord, healthData);
+
+        // then
+        verify(mealRecordRepository).save(any(MealRecord.class));
+        verify(careCallRecordRepository).save(any(CareCallRecord.class));
+    }
+
+    @Test
+    @DisplayName("심리 상태 데이터 저장 검증")
+    void updateCareCallRecordWithHealthData_updatesPsychologicalStatus() {
+        // given
+        List<String> psychologicalState = Arrays.asList("기분이 좋음", "잠을 잘 잤음");
+        HealthDataExtractionResponse healthData = HealthDataExtractionResponse.builder()
+                .psychologicalState(psychologicalState)
+                .psychologicalStatus("좋음")
+                .build();
+
+        when(careCallRecordRepository.save(any(CareCallRecord.class))).thenReturn(callRecord);
+
+        // when
+        healthDataService.updateCareCallRecordWithHealthData(callRecord, healthData);
+
+        // then
+        verify(careCallRecordRepository).save(argThat(record -> 
+            record.getPsychStatus() != null && 
+            record.getPsychologicalDetails() != null &&
+            record.getPsychologicalDetails().contains("기분이 좋음")
+        ));
+    }
+
+    @Test
+    @DisplayName("건강 징후 데이터 저장 검증")
+    void updateCareCallRecordWithHealthData_updatesHealthStatus() {
+        // given
+        List<String> healthSigns = Arrays.asList("혈당이 정상 범위", "식사 후 혈당 측정");
+        HealthDataExtractionResponse healthData = HealthDataExtractionResponse.builder()
+                .healthSigns(healthSigns)
+                .healthStatus("좋음")
+                .build();
+
+        when(careCallRecordRepository.save(any(CareCallRecord.class))).thenReturn(callRecord);
+
+        // when
+        healthDataService.updateCareCallRecordWithHealthData(callRecord, healthData);
+
+        // then
+        verify(careCallRecordRepository).save(argThat(record -> 
+            record.getHealthStatus() != null && 
+            record.getHealthDetails() != null &&
+            record.getHealthDetails().contains("혈당이 정상 범위")
+        ));
+    }
+
+    @Test
+    @DisplayName("수면 데이터 저장 검증")
+    void updateCareCallRecordWithHealthData_updatesSleepData() {
+        // given
+        HealthDataExtractionResponse.SleepData sleepData = HealthDataExtractionResponse.SleepData.builder()
+                .sleepStartTime("22:00")
+                .sleepEndTime("06:00")
+                .totalSleepTime("8시간")
+                .build();
+
+        HealthDataExtractionResponse healthData = HealthDataExtractionResponse.builder()
+                .sleepData(sleepData)
+                .build();
+
+        when(careCallRecordRepository.save(any(CareCallRecord.class))).thenReturn(callRecord);
+
+        // when
+        healthDataService.updateCareCallRecordWithHealthData(callRecord, healthData);
+
+        // then
+        verify(careCallRecordRepository).save(argThat(record -> 
+            record.getSleepStart() != null && 
+            record.getSleepEnd() != null
+        ));
+    }
+
+    @Test
+    @DisplayName("모든 데이터가 null일 때 저장되지 않음")
+    void updateCareCallRecordWithHealthData_withNullData_doesNotSave() {
+        // given
+        HealthDataExtractionResponse healthData = HealthDataExtractionResponse.builder()
+                .mealData(null)
+                .sleepData(null)
+                .psychologicalState(null)
+                .healthSigns(null)
+                .build();
+
+        when(careCallRecordRepository.save(any(CareCallRecord.class))).thenReturn(callRecord);
+
+        // when
+        healthDataService.updateCareCallRecordWithHealthData(callRecord, healthData);
+
+        // then
+        verify(mealRecordRepository, never()).save(any(MealRecord.class));
+        verify(careCallRecordRepository).save(any(CareCallRecord.class));
+    }
+} 

--- a/src/test/java/com/example/medicare_call/service/MedicationServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/MedicationServiceTest.java
@@ -1,0 +1,257 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.*;
+import com.example.medicare_call.dto.HealthDataExtractionResponse;
+import com.example.medicare_call.repository.MedicationRepository;
+import com.example.medicare_call.repository.MedicationScheduleRepository;
+import com.example.medicare_call.repository.MedicationTakenRecordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class MedicationServiceTest {
+
+    @Mock
+    private MedicationTakenRecordRepository medicationTakenRecordRepository;
+
+    @Mock
+    private MedicationScheduleRepository medicationScheduleRepository;
+
+    @Mock
+    private MedicationRepository medicationRepository;
+
+    @InjectMocks
+    private MedicationService medicationService;
+
+    private CareCallRecord callRecord;
+    private Elder elder;
+    private Medication medication;
+    private MedicationSchedule medicationSchedule;
+
+    @BeforeEach
+    void setUp() {
+        elder = Elder.builder()
+                .id(1)
+                .name("테스트 어르신")
+                .build();
+
+        callRecord = CareCallRecord.builder()
+                .id(1)
+                .elder(elder)
+                .build();
+
+        medication = Medication.builder()
+                .id(1)
+                .name("혈압약")
+                .build();
+
+        medicationSchedule = MedicationSchedule.builder()
+                .id(1)
+                .elder(elder)
+                .medication(medication)
+                .scheduleTime("MORNING")
+                .build();
+    }
+
+    @Test
+    @DisplayName("복약 데이터 저장 성공 - 스케줄 매칭됨")
+    void saveMedicationTakenRecord_success_withScheduleMatch() {
+        // given
+        HealthDataExtractionResponse.MedicationData medicationData = HealthDataExtractionResponse.MedicationData.builder()
+                .medicationType("혈압약")
+                .taken("복용함")
+                .takenTime("아침")
+                .build();
+
+        when(medicationRepository.findByName("혈압약")).thenReturn(Optional.of(medication));
+        when(medicationScheduleRepository.findByElder(elder)).thenReturn(Arrays.asList(medicationSchedule));
+        when(medicationTakenRecordRepository.save(any(MedicationTakenRecord.class))).thenReturn(MedicationTakenRecord.builder().id(1).build());
+
+        // when
+        medicationService.saveMedicationTakenRecord(callRecord, medicationData);
+
+        // then
+        verify(medicationRepository).findByName("혈압약");
+        verify(medicationScheduleRepository).findByElder(elder);
+        verify(medicationTakenRecordRepository).save(argThat(record -> 
+            record.getMedication().getId().equals(1) &&
+            record.getMedicationSchedule().getId().equals(1) &&
+            record.getTakenStatus().name().equals("TAKEN")
+        ));
+    }
+
+    @Test
+    @DisplayName("복약 데이터 저장 성공 - 스케줄 매칭 안됨")
+    void saveMedicationTakenRecord_success_withoutScheduleMatch() {
+        // given
+        HealthDataExtractionResponse.MedicationData medicationData = HealthDataExtractionResponse.MedicationData.builder()
+                .medicationType("혈압약")
+                .taken("복용함")
+                .takenTime("점심")
+                .build();
+
+        when(medicationRepository.findByName("혈압약")).thenReturn(Optional.of(medication));
+        when(medicationScheduleRepository.findByElder(elder)).thenReturn(Arrays.asList(medicationSchedule));
+        when(medicationTakenRecordRepository.save(any(MedicationTakenRecord.class))).thenReturn(MedicationTakenRecord.builder().id(1).build());
+
+        // when
+        medicationService.saveMedicationTakenRecord(callRecord, medicationData);
+
+        // then
+        verify(medicationTakenRecordRepository).save(argThat(record -> 
+            record.getMedication().getId().equals(1) &&
+            record.getMedicationSchedule() == null &&
+            record.getTakenStatus().name().equals("TAKEN")
+        ));
+    }
+
+    @Test
+    @DisplayName("복약 데이터 저장 성공 - 복용하지 않음")
+    void saveMedicationTakenRecord_success_notTaken() {
+        // given
+        HealthDataExtractionResponse.MedicationData medicationData = HealthDataExtractionResponse.MedicationData.builder()
+                .medicationType("혈압약")
+                .taken("복용하지 않음")
+                .takenTime("아침")
+                .build();
+
+        when(medicationRepository.findByName("혈압약")).thenReturn(Optional.of(medication));
+        when(medicationScheduleRepository.findByElder(elder)).thenReturn(Arrays.asList(medicationSchedule));
+        when(medicationTakenRecordRepository.save(any(MedicationTakenRecord.class))).thenReturn(MedicationTakenRecord.builder().id(1).build());
+
+        // when
+        medicationService.saveMedicationTakenRecord(callRecord, medicationData);
+
+        // then
+        verify(medicationTakenRecordRepository).save(argThat(record -> 
+            record.getTakenStatus().name().equals("NOT_TAKEN")
+        ));
+    }
+
+    @Test
+    @DisplayName("복약 데이터 저장 실패 - 약을 찾을 수 없음")
+    void saveMedicationTakenRecord_fail_medicationNotFound() {
+        // given
+        HealthDataExtractionResponse.MedicationData medicationData = HealthDataExtractionResponse.MedicationData.builder()
+                .medicationType("존재하지 않는 약")
+                .taken("복용함")
+                .takenTime("아침")
+                .build();
+
+        when(medicationRepository.findByName("존재하지 않는 약")).thenReturn(Optional.empty());
+
+        // when
+        medicationService.saveMedicationTakenRecord(callRecord, medicationData);
+
+        // then
+        verify(medicationRepository).findByName("존재하지 않는 약");
+        verify(medicationScheduleRepository, never()).findByElder(any());
+        verify(medicationTakenRecordRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("스케줄 시간 매칭 테스트 - 아침")
+    void scheduleTimeMatching_morning() {
+        // given
+        HealthDataExtractionResponse.MedicationData medicationData = HealthDataExtractionResponse.MedicationData.builder()
+                .medicationType("혈압약")
+                .taken("복용함")
+                .takenTime("아침")
+                .build();
+
+        MedicationSchedule morningSchedule = MedicationSchedule.builder()
+                .id(1)
+                .elder(elder)
+                .medication(medication)
+                .scheduleTime("MORNING,LUNCH")
+                .build();
+
+        when(medicationRepository.findByName("혈압약")).thenReturn(Optional.of(medication));
+        when(medicationScheduleRepository.findByElder(elder)).thenReturn(Arrays.asList(morningSchedule));
+        when(medicationTakenRecordRepository.save(any(MedicationTakenRecord.class))).thenReturn(MedicationTakenRecord.builder().id(1).build());
+
+        // when
+        medicationService.saveMedicationTakenRecord(callRecord, medicationData);
+
+        // then
+        verify(medicationTakenRecordRepository).save(argThat(record -> 
+            record.getMedicationSchedule() != null &&
+            record.getMedicationSchedule().getId().equals(1)
+        ));
+    }
+
+    @Test
+    @DisplayName("스케줄 시간 매칭 테스트 - 점심")
+    void scheduleTimeMatching_lunch() {
+        // given
+        HealthDataExtractionResponse.MedicationData medicationData = HealthDataExtractionResponse.MedicationData.builder()
+                .medicationType("혈압약")
+                .taken("복용함")
+                .takenTime("점심")
+                .build();
+
+        MedicationSchedule lunchSchedule = MedicationSchedule.builder()
+                .id(1)
+                .elder(elder)
+                .medication(medication)
+                .scheduleTime("MORNING,LUNCH")
+                .build();
+
+        when(medicationRepository.findByName("혈압약")).thenReturn(Optional.of(medication));
+        when(medicationScheduleRepository.findByElder(elder)).thenReturn(Arrays.asList(lunchSchedule));
+        when(medicationTakenRecordRepository.save(any(MedicationTakenRecord.class))).thenReturn(MedicationTakenRecord.builder().id(1).build());
+
+        // when
+        medicationService.saveMedicationTakenRecord(callRecord, medicationData);
+
+        // then
+        verify(medicationTakenRecordRepository).save(argThat(record -> 
+            record.getMedicationSchedule() != null &&
+            record.getMedicationSchedule().getId().equals(1)
+        ));
+    }
+
+    @Test
+    @DisplayName("스케줄 시간 매칭 테스트 - 매칭 안됨")
+    void scheduleTimeMatching_noMatch() {
+        // given
+        HealthDataExtractionResponse.MedicationData medicationData = HealthDataExtractionResponse.MedicationData.builder()
+                .medicationType("혈압약")
+                .taken("복용함")
+                .takenTime("저녁")
+                .build();
+
+        MedicationSchedule morningSchedule = MedicationSchedule.builder()
+                .id(1)
+                .elder(elder)
+                .medication(medication)
+                .scheduleTime("MORNING,LUNCH")
+                .build();
+
+        when(medicationRepository.findByName("혈압약")).thenReturn(Optional.of(medication));
+        when(medicationScheduleRepository.findByElder(elder)).thenReturn(Arrays.asList(morningSchedule));
+        when(medicationTakenRecordRepository.save(any(MedicationTakenRecord.class))).thenReturn(MedicationTakenRecord.builder().id(1).build());
+
+        // when
+        medicationService.saveMedicationTakenRecord(callRecord, medicationData);
+
+        // then
+        verify(medicationTakenRecordRepository).save(argThat(record -> 
+            record.getMedicationSchedule() == null
+        ));
+    }
+} 


### PR DESCRIPTION
### Description
- `OpenAiHealthDataService`에서는 OpenAI API를 호출하여, `HealthDataExtractionResponse`라는 일정한 구조체로 통화 정보 데이터를 반환한다. 이 구조체로부터 데이터를 파싱하여 알맞은 테이블에 값을 저장하는 service를 구현한다.
  - `BloodSugarService`, `MedicationService`, `HealthDataService`
  - 위 서비스들은 각각 혈당, 복약, 그리고 기타 정보들을 DB에 저장하는 작업을 수행한다.
  - 비즈니스 로직대로는 `CallDataController`에서 통화 데이터를 수신한 뒤에 최종 단계에서 `CallDataService`에서 데이터를 저장하는 단계에서 호출된다.
- 데이터를 관리하기 위한 enum 추가
  - enum을 사용하기 위한 마이그레이션 추가
  - `OpenAiHealthDataService`에서 일관된 형식으로 데이터를 반환하도록 프롬프트 제어
- 데이터 저장은 결국 전화 데이터를 노드 서버에서 보내주어야 가능하므로, 테스트 통화 데이터를 이용하여 데이터 저장 과정을 간단히 검증해보기 위한 엔드포인트를 구현
  - `HealthDataController`
- ObjectMapper LocalDateTime 처리 설정 추가
  - timestamp가 아닌, ISO 8601 형식을 사용하도록
- 컬럼 추가
  - `psychological_details`, `health_details`

### TODO
- Medication 테이블을 제거할지 검토
- 데이터 파싱 프롬프트에 MedicationSchedule을 포함하여 복약 이름값 매칭 처리
- 컬럼값 전반적으로 정리, 스키마 정리 마이그레이션
- 서비스 추가 분리 리팩토링 진행 (MealData 이런것도 분리해내자)