### PR TITLE
feat: 식사 데이터 날짜별 조회 API 구현

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/action/CallDataController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/CallDataController.java
@@ -1,4 +1,4 @@
-package com.example.medicare_call.controller;
+package com.example.medicare_call.controller.action;
 
 import com.example.medicare_call.domain.CareCallRecord;
 import com.example.medicare_call.dto.CallDataRequest;

--- a/src/main/java/com/example/medicare_call/controller/action/ElderController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/ElderController.java
@@ -1,4 +1,4 @@
-package com.example.medicare_call.controller;
+package com.example.medicare_call.controller.action;
 
 import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.service.ElderService;

--- a/src/main/java/com/example/medicare_call/controller/action/ElderHealthInfoController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/ElderHealthInfoController.java
@@ -1,4 +1,4 @@
-package com.example.medicare_call.controller;
+package com.example.medicare_call.controller.action;
 
 import com.example.medicare_call.dto.ElderHealthRegisterRequest;
 import com.example.medicare_call.service.ElderHealthInfoService;

--- a/src/main/java/com/example/medicare_call/controller/action/HealthDataController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/HealthDataController.java
@@ -1,4 +1,4 @@
-package com.example.medicare_call.controller;
+package com.example.medicare_call.controller.action;
 
 import com.example.medicare_call.domain.CareCallRecord;
 import com.example.medicare_call.domain.CareCallSetting;

--- a/src/main/java/com/example/medicare_call/controller/action/MemberController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/MemberController.java
@@ -1,4 +1,4 @@
-package com.example.medicare_call.controller;
+package com.example.medicare_call.controller.action;
 
 import com.example.medicare_call.dto.RegisterRequest;
 import com.example.medicare_call.global.annotation.AuthPhone;

--- a/src/main/java/com/example/medicare_call/controller/action/SmsController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/SmsController.java
@@ -1,4 +1,4 @@
-package com.example.medicare_call.controller;
+package com.example.medicare_call.controller.action;
 
 import com.example.medicare_call.dto.SmsRequest;
 import com.example.medicare_call.dto.SmsVerificationResponse;

--- a/src/main/java/com/example/medicare_call/controller/view/MealRecordController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/MealRecordController.java
@@ -1,0 +1,65 @@
+package com.example.medicare_call.controller.view;
+
+import com.example.medicare_call.dto.DailyMealResponse;
+import com.example.medicare_call.service.MealRecordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/view")
+@RequiredArgsConstructor
+@Tag(name = "Meal Record", description = "식사 기록 조회 API")
+public class MealRecordController {
+    
+    private final MealRecordService mealRecordService;
+    
+    @Operation(
+        summary = "날짜별 식사 데이터 조회",
+        description = "어르신의 특정 날짜에 해당하는 아침, 점심, 저녁 식사 기록을 조회합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "식사 데이터 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = DailyMealResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (날짜 형식 오류 등)"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "보호자 정보를 찾을 수 없음"
+        )
+    })
+    @GetMapping("/dailyMeal")
+    public ResponseEntity<DailyMealResponse> getDailyMeals(
+        @Parameter(description = "어르신 식별자", required = true, example = "1")
+        @RequestParam("elderId") Integer elderId,
+        
+        @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", required = true, example = "2025-07-16")
+        @RequestParam("date") String date
+    ) {
+        log.info("날짜별 식사 데이터 조회 요청: elderId={}, date={}", elderId, date);
+        
+        DailyMealResponse response = mealRecordService.getDailyMeals(elderId, date);
+        
+        return ResponseEntity.ok(response);
+    }
+} 

--- a/src/main/java/com/example/medicare_call/dto/DailyMealResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/DailyMealResponse.java
@@ -1,0 +1,31 @@
+package com.example.medicare_call.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "날짜별 식사 데이터 조회 응답")
+public class DailyMealResponse {
+    
+    @Schema(description = "조회한 날짜", example = "2025-07-16")
+    private String date;
+    
+    @Schema(description = "각 식사 시간대별 기록")
+    private Meals meals;
+    
+    @Getter
+    @Builder
+    @Schema(description = "식사 시간대별 기록")
+    public static class Meals {
+        @Schema(description = "아침 식사 내용", example = "간단히 밥과 반찬을 드셨어요.")
+        private String breakfast;
+        
+        @Schema(description = "점심 식사 내용", example = "식사하지 않으셨어요.")
+        private String lunch;
+        
+        @Schema(description = "저녁 식사 내용", example = "저녁은 간단히 드셨어요.")
+        private String dinner;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/repository/MealRecordRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/MealRecordRepository.java
@@ -2,6 +2,18 @@ package com.example.medicare_call.repository;
 
 import com.example.medicare_call.domain.MealRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface MealRecordRepository extends JpaRepository<MealRecord, Integer> {
+    
+    @Query("SELECT mr FROM MealRecord mr " +
+           "JOIN mr.careCallRecord ccr " +
+           "WHERE ccr.elder.id = :elderId " +
+           "AND DATE(mr.recordedAt) = :date " +
+           "ORDER BY mr.recordedAt")
+    List<MealRecord> findByElderIdAndDate(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
 } 

--- a/src/main/java/com/example/medicare_call/service/MealRecordService.java
+++ b/src/main/java/com/example/medicare_call/service/MealRecordService.java
@@ -1,0 +1,61 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.MealRecord;
+import com.example.medicare_call.dto.DailyMealResponse;
+import com.example.medicare_call.global.enums.MealType;
+import com.example.medicare_call.repository.MealRecordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MealRecordService {
+    
+    private final MealRecordRepository mealRecordRepository;
+    
+    public DailyMealResponse getDailyMeals(Integer elderId, String dateStr) {
+        LocalDate date = LocalDate.parse(dateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        
+        List<MealRecord> mealRecords = mealRecordRepository.findByElderIdAndDate(elderId, date);
+        
+        String breakfast = null;
+        String lunch = null;
+        String dinner = null;
+        
+        for (MealRecord record : mealRecords) {
+            MealType mealType = MealType.fromValue(record.getMealType());
+            if (mealType != null) {
+                String mealContent = record.getResponseSummary();
+                
+                switch (mealType) {
+                    case BREAKFAST:
+                        breakfast = mealContent;
+                        break;
+                    case LUNCH:
+                        lunch = mealContent;
+                        break;
+                    case DINNER:
+                        dinner = mealContent;
+                        break;
+                }
+            }
+        }
+        
+        DailyMealResponse.Meals meals = DailyMealResponse.Meals.builder()
+                .breakfast(breakfast)
+                .lunch(lunch)
+                .dinner(dinner)
+                .build();
+        
+        return DailyMealResponse.builder()
+                .date(dateStr)
+                .meals(meals)
+                .build();
+    }
+} 

--- a/src/test/java/com/example/medicare_call/controller/action/CallDataControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/action/CallDataControllerTest.java
@@ -1,4 +1,4 @@
-package com.example.medicare_call.controller;
+package com.example.medicare_call.controller.action;
 
 import com.example.medicare_call.domain.CareCallRecord;
 import com.example.medicare_call.domain.CareCallSetting;

--- a/src/test/java/com/example/medicare_call/controller/action/ElderControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/action/ElderControllerTest.java
@@ -1,4 +1,4 @@
-package com.example.medicare_call.controller;
+package com.example.medicare_call.controller.action;
 
 import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.dto.ElderRegisterRequest;

--- a/src/test/java/com/example/medicare_call/controller/action/ElderHealthInfoControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/action/ElderHealthInfoControllerTest.java
@@ -1,4 +1,4 @@
-package com.example.medicare_call.controller;
+package com.example.medicare_call.controller.action;
 
 import com.example.medicare_call.dto.ElderHealthRegisterRequest;
 import com.example.medicare_call.global.enums.ElderHealthNoteType;
@@ -7,7 +7,6 @@ import com.example.medicare_call.global.jwt.JwtProvider;
 import com.example.medicare_call.service.ElderHealthInfoService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;

--- a/src/test/java/com/example/medicare_call/controller/action/SmsControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/action/SmsControllerTest.java
@@ -1,4 +1,4 @@
-package com.example.medicare_call.controller;
+package com.example.medicare_call.controller.action;
 
 import com.example.medicare_call.dto.SmsRequest;
 import com.example.medicare_call.dto.SmsVerificationResponse;

--- a/src/test/java/com/example/medicare_call/controller/view/MealRecordControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/MealRecordControllerTest.java
@@ -1,0 +1,133 @@
+package com.example.medicare_call.controller.view;
+
+import com.example.medicare_call.dto.DailyMealResponse;
+import com.example.medicare_call.global.jwt.JwtProvider;
+import com.example.medicare_call.service.MealRecordService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(MealRecordController.class)
+@AutoConfigureMockMvc(addFilters = false) // security 필터 비활성화
+@ActiveProfiles("test")
+class MealRecordControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MealRecordService mealRecordService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("날짜별 식사 데이터 조회 성공 - 모든 데이터 있음")
+    void getDailyMeals_성공() throws Exception {
+        // given
+        Integer elderId = 1;
+        String date = "2025-07-16";
+        
+        DailyMealResponse.Meals meals = DailyMealResponse.Meals.builder()
+                .breakfast("아침에 밥과 반찬을 드셨어요.")
+                .lunch("점심은 간단히 드셨어요.")
+                .dinner("저녁은 많이 드셨어요.")
+                .build();
+        
+        DailyMealResponse expectedResponse = DailyMealResponse.builder()
+                .date(date)
+                .meals(meals)
+                .build();
+
+        when(mealRecordService.getDailyMeals(eq(elderId), eq(date)))
+                .thenReturn(expectedResponse);
+
+        // when & then
+        mockMvc.perform(get("/view/dailyMeal")
+                        .param("elderId", elderId.toString())
+                        .param("date", date))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.date").value(date))
+                .andExpect(jsonPath("$.meals.breakfast").value("아침에 밥과 반찬을 드셨어요."))
+                .andExpect(jsonPath("$.meals.lunch").value("점심은 간단히 드셨어요."))
+                .andExpect(jsonPath("$.meals.dinner").value("저녁은 많이 드셨어요."));
+    }
+
+    @Test
+    @DisplayName("날짜별 식사 데이터 조회 성공 - 일부 데이터 있음")
+    void getDailyMeals_일부_데이터_있음() throws Exception {
+        // given
+        Integer elderId = 1;
+        String date = "2025-07-16";
+        
+        DailyMealResponse.Meals meals = DailyMealResponse.Meals.builder()
+                .breakfast("아침에 밥과 반찬을 드셨어요.")
+                .lunch(null)
+                .dinner("저녁은 많이 드셨어요.")
+                .build();
+        
+        DailyMealResponse expectedResponse = DailyMealResponse.builder()
+                .date(date)
+                .meals(meals)
+                .build();
+
+        when(mealRecordService.getDailyMeals(eq(elderId), eq(date)))
+                .thenReturn(expectedResponse);
+
+        // when & then
+        mockMvc.perform(get("/view/dailyMeal")
+                        .param("elderId", elderId.toString())
+                        .param("date", date))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.date").value(date))
+                .andExpect(jsonPath("$.meals.breakfast").value("아침에 밥과 반찬을 드셨어요."))
+                .andExpect(jsonPath("$.meals.lunch").isEmpty())
+                .andExpect(jsonPath("$.meals.dinner").value("저녁은 많이 드셨어요."));
+    }
+
+    @Test
+    @DisplayName("날짜별 식사 데이터 조회 성공 - 데이터 없음")
+    void getDailyMeals_데이터_없음() throws Exception {
+        // given
+        Integer elderId = 1;
+        String date = "2025-07-16";
+        
+        DailyMealResponse.Meals meals = DailyMealResponse.Meals.builder()
+                .breakfast(null)
+                .lunch(null)
+                .dinner(null)
+                .build();
+        
+        DailyMealResponse expectedResponse = DailyMealResponse.builder()
+                .date(date)
+                .meals(meals)
+                .build();
+
+        when(mealRecordService.getDailyMeals(eq(elderId), eq(date)))
+                .thenReturn(expectedResponse);
+
+        // when & then
+        mockMvc.perform(get("/view/dailyMeal")
+                        .param("elderId", elderId.toString())
+                        .param("date", date))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.date").value(date))
+                .andExpect(jsonPath("$.meals.breakfast").isEmpty())
+                .andExpect(jsonPath("$.meals.lunch").isEmpty())
+                .andExpect(jsonPath("$.meals.dinner").isEmpty());
+    }
+} 

--- a/src/test/java/com/example/medicare_call/service/MealRecordServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/MealRecordServiceTest.java
@@ -1,0 +1,143 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.CareCallRecord;
+import com.example.medicare_call.domain.Elder;
+import com.example.medicare_call.domain.MealRecord;
+import com.example.medicare_call.domain.Member;
+import com.example.medicare_call.dto.DailyMealResponse;
+import com.example.medicare_call.global.enums.Gender;
+import com.example.medicare_call.global.enums.MealType;
+import com.example.medicare_call.repository.MealRecordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MealRecordServiceTest {
+
+    @Mock
+    private MealRecordRepository mealRecordRepository;
+
+    @InjectMocks
+    private MealRecordService mealRecordService;
+
+    private Member guardian;
+    private Elder elder;
+    private CareCallRecord callRecord;
+
+    @BeforeEach
+    void setUp() {
+        guardian = Member.builder()
+                .id(1)
+                .name("테스트 보호자")
+                .phone("010-1234-5678")
+                .gender(Gender.MALE.getCode())
+                .build();
+
+        elder = Elder.builder()
+                .id(1)
+                .guardian(guardian)
+                .name("테스트 어르신")
+                .gender(Gender.MALE.getCode())
+                .build();
+
+        callRecord = CareCallRecord.builder()
+                .id(1)
+                .elder(elder)
+                .calledAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    void getDailyMeals_모든_식사_데이터_있음() {
+        // given
+        LocalDate date = LocalDate.of(2025, 7, 16);
+        String dateStr = "2025-07-16";
+
+        List<MealRecord> mealRecords = Arrays.asList(
+                createMealRecord(MealType.BREAKFAST, "아침에 밥과 반찬을 드셨어요."),
+                createMealRecord(MealType.LUNCH, "점심은 간단히 드셨어요."),
+                createMealRecord(MealType.DINNER, "저녁은 많이 드셨어요.")
+        );
+
+        when(mealRecordRepository.findByElderIdAndDate(eq(1), eq(date)))
+                .thenReturn(mealRecords);
+
+        // when
+        DailyMealResponse response = mealRecordService.getDailyMeals(1, dateStr);
+
+        // then
+        assertThat(response.getDate()).isEqualTo(dateStr);
+        assertThat(response.getMeals().getBreakfast()).isEqualTo("아침에 밥과 반찬을 드셨어요.");
+        assertThat(response.getMeals().getLunch()).isEqualTo("점심은 간단히 드셨어요.");
+        assertThat(response.getMeals().getDinner()).isEqualTo("저녁은 많이 드셨어요.");
+    }
+
+    @Test
+    void getDailyMeals_일부_식사_데이터_있음() {
+        // given
+        LocalDate date = LocalDate.of(2025, 7, 16);
+        String dateStr = "2025-07-16";
+
+        List<MealRecord> mealRecords = Arrays.asList(
+                createMealRecord(MealType.BREAKFAST, "아침에 밥과 반찬을 드셨어요."),
+                createMealRecord(MealType.DINNER, "저녁은 많이 드셨어요.")
+        );
+
+        when(mealRecordRepository.findByElderIdAndDate(eq(1), eq(date)))
+                .thenReturn(mealRecords);
+
+        // when
+        DailyMealResponse response = mealRecordService.getDailyMeals(1, dateStr);
+
+        // then
+        assertThat(response.getDate()).isEqualTo(dateStr);
+        assertThat(response.getMeals().getBreakfast()).isEqualTo("아침에 밥과 반찬을 드셨어요.");
+        assertThat(response.getMeals().getLunch()).isNull();
+        assertThat(response.getMeals().getDinner()).isEqualTo("저녁은 많이 드셨어요.");
+    }
+
+    @Test
+    void getDailyMeals_데이터_없음() {
+        // given
+        LocalDate date = LocalDate.of(2025, 7, 16);
+        String dateStr = "2025-07-16";
+
+        when(mealRecordRepository.findByElderIdAndDate(eq(1), eq(date)))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        DailyMealResponse response = mealRecordService.getDailyMeals(1, dateStr);
+
+        // then
+        assertThat(response.getDate()).isEqualTo(dateStr);
+        assertThat(response.getMeals().getBreakfast()).isNull();
+        assertThat(response.getMeals().getLunch()).isNull();
+        assertThat(response.getMeals().getDinner()).isNull();
+    }
+
+    private MealRecord createMealRecord(MealType mealType, String responseSummary) {
+        return MealRecord.builder()
+                .id(1)
+                .careCallRecord(callRecord)
+                .mealType(mealType.getValue())
+                .eatenStatus((byte) 1)
+                .responseSummary(responseSummary)
+                .recordedAt(LocalDateTime.now())
+                .build();
+    }
+} 


### PR DESCRIPTION
### Desc
- API Spec
  - https://www.notion.so/API-23e6196331d2804f9462ff35348b741c
- view를 담당하게 될 엔드포인트와 action을 수행하는 엔드포인트를 분리하였음

### Request sample 
`http://localhost:8080/api/view/dailyMeal?elderId=1&date=2025-08-02`
```
{
  "date": "2025-08-02",
  "meals": {
    "breakfast": "아침에 밥을 먹음",
    "lunch": null,
    "dinner": null
  }
}
```