### PR TITLE
feat: 혈당 데이터 status 컬럼 추가

### DIFF
--- a/src/main/java/com/example/medicare_call/domain/BloodSugarRecord.java
+++ b/src/main/java/com/example/medicare_call/domain/BloodSugarRecord.java
@@ -1,6 +1,7 @@
 package com.example.medicare_call.domain;
 
 import com.example.medicare_call.global.enums.BloodSugarMeasurementType;
+import com.example.medicare_call.global.enums.BloodSugarStatus;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
@@ -33,9 +34,9 @@ public class BloodSugarRecord {
     @Column(name = "unit", length = 10)
     private String unit;
 
-    // TODO: 주간 분석 결과로 초기화
-    @Column(name = "status")
-    private Byte status;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", columnDefinition = "VARCHAR(20)")
+    private BloodSugarStatus status;
 
     @Column(name = "recorded_at", nullable = false)
     private LocalDateTime recordedAt;
@@ -44,7 +45,7 @@ public class BloodSugarRecord {
     private String responseSummary;
 
     @Builder
-    public BloodSugarRecord(Integer id, CareCallRecord careCallRecord, BloodSugarMeasurementType measurementType, BigDecimal blood_sugar_value, String unit, Byte status, LocalDateTime recordedAt, String responseSummary) {
+    public BloodSugarRecord(Integer id, CareCallRecord careCallRecord, BloodSugarMeasurementType measurementType, BigDecimal blood_sugar_value, String unit, BloodSugarStatus status, LocalDateTime recordedAt, String responseSummary) {
         this.id = id;
         this.careCallRecord = careCallRecord;
         this.measurementType = measurementType;

--- a/src/main/java/com/example/medicare_call/dto/HealthDataExtractionResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/HealthDataExtractionResponse.java
@@ -104,6 +104,13 @@ public class HealthDataExtractionResponse {
         
         @Schema(description = "혈당 값 (mg/dL)", example = "120")
         private Integer bloodSugarValue;
+        
+        @Schema(
+            description = "혈당 상태",
+            example = "NORMAL",
+            allowableValues = {"LOW", "NORMAL", "HIGH"}
+        )
+        private String status;
     }
 
     @Getter

--- a/src/main/java/com/example/medicare_call/global/enums/BloodSugarStatus.java
+++ b/src/main/java/com/example/medicare_call/global/enums/BloodSugarStatus.java
@@ -1,0 +1,36 @@
+package com.example.medicare_call.global.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum BloodSugarStatus {
+    LOW(0, "저혈당"),
+    NORMAL(1, "정상"),
+    HIGH(2, "고혈당");
+
+    private final int value;
+    private final String description;
+
+    BloodSugarStatus(int value, String description) {
+        this.value = value;
+        this.description = description;
+    }
+
+    public static BloodSugarStatus fromValue(int value) {
+        for (BloodSugarStatus status : values()) {
+            if (status.getValue() == value) {
+                return status;
+            }
+        }
+        return null;
+    }
+
+    public static BloodSugarStatus fromDescription(String description) {
+        for (BloodSugarStatus status : values()) {
+            if (status.getDescription().equals(description)) {
+                return status;
+            }
+        }
+        return null;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/service/BloodSugarService.java
+++ b/src/main/java/com/example/medicare_call/service/BloodSugarService.java
@@ -4,6 +4,7 @@ import com.example.medicare_call.domain.BloodSugarRecord;
 import com.example.medicare_call.domain.CareCallRecord;
 import com.example.medicare_call.dto.HealthDataExtractionResponse;
 import com.example.medicare_call.global.enums.BloodSugarMeasurementType;
+import com.example.medicare_call.global.enums.BloodSugarStatus;
 import com.example.medicare_call.repository.BloodSugarRecordRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,17 +30,24 @@ public class BloodSugarService {
         // measurementType 결정 (식전/식후)
         BloodSugarMeasurementType measurementType = BloodSugarMeasurementType.fromDescription(bloodSugarData.getMealTime());
         
+        // status 결정 (LOW/NORMAL/HIGH)
+        BloodSugarStatus status = null;
+        if (bloodSugarData.getStatus() != null) {
+            status = BloodSugarStatus.valueOf(bloodSugarData.getStatus());
+        }
+        
         BloodSugarRecord bloodSugarRecord = BloodSugarRecord.builder()
                 .careCallRecord(callRecord)
                 .blood_sugar_value(BigDecimal.valueOf(bloodSugarData.getBloodSugarValue()))
                 .measurementType(measurementType)
+                .status(status)
                 .recordedAt(LocalDateTime.now()) // TODO: 혈당 측정한 시간을 전화를 통해 질의할 것인지 확정한 뒤에 재검토
                 .responseSummary(String.format("측정시각: %s, 식전/식후: %s", 
                     bloodSugarData.getMeasurementTime(), bloodSugarData.getMealTime()))
                 .build();
         
         bloodSugarRecordRepository.save(bloodSugarRecord);
-        log.info("혈당 데이터 저장 완료: value={}, mealTime={}", 
-            bloodSugarData.getBloodSugarValue(), bloodSugarData.getMealTime());
+        log.info("혈당 데이터 저장 완료: value={}, mealTime={}, status={}", 
+            bloodSugarData.getBloodSugarValue(), bloodSugarData.getMealTime(), status);
     }
 } 

--- a/src/main/java/com/example/medicare_call/service/OpenAiHealthDataService.java
+++ b/src/main/java/com/example/medicare_call/service/OpenAiHealthDataService.java
@@ -112,6 +112,7 @@ public class OpenAiHealthDataService {
                - 측정한 시각
                - 식전 여부
                - 혈당 값 (mg/dL)
+               - 혈당 상태 (식전/식후 여부를 고려하여 LOW/NORMAL/HIGH 판단)
             6. 복약 데이터
                - 약의 종류
                - 복약 여부
@@ -137,7 +138,8 @@ public class OpenAiHealthDataService {
               "bloodSugarData": {
                 "measurementTime": "측정 시각",
                 "mealTime": "식전/식후",
-                "bloodSugarValue": 숫자값
+                "bloodSugarValue": 숫자값,
+                "status": "LOW/NORMAL/HIGH"
               },
               "medicationData": {
                 "medicationType": "약 종류",

--- a/src/main/resources/db/migration/V8__convert_blood_sugar_status_to_enum.sql
+++ b/src/main/resources/db/migration/V8__convert_blood_sugar_status_to_enum.sql
@@ -1,0 +1,12 @@
+-- BloodSugarRecord 테이블의 status 컬럼을 TINYINT에서 VARCHAR로 변경
+-- 기존 데이터는 NULL로 설정 (애초에 기록되지 않고 있었음. 기존 값이 있었다면 별도 스크립트로 변환 처리해야 했을 것이다.)
+ALTER TABLE BloodSugarRecord
+ADD COLUMN status_new VARCHAR(20) DEFAULT NULL;
+
+-- 기존 status 컬럼 삭제
+ALTER TABLE BloodSugarRecord
+DROP COLUMN status;
+
+-- 새 status 컬럼 이름 변경
+ALTER TABLE BloodSugarRecord
+CHANGE COLUMN status_new status VARCHAR(20) DEFAULT NULL; 

--- a/src/test/java/com/example/medicare_call/service/BloodSugarServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/BloodSugarServiceTest.java
@@ -1,0 +1,177 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.BloodSugarRecord;
+import com.example.medicare_call.domain.CareCallRecord;
+import com.example.medicare_call.dto.HealthDataExtractionResponse;
+import com.example.medicare_call.global.enums.BloodSugarMeasurementType;
+import com.example.medicare_call.global.enums.BloodSugarStatus;
+import com.example.medicare_call.repository.BloodSugarRecordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BloodSugarServiceTest {
+
+    @Mock
+    private BloodSugarRecordRepository bloodSugarRecordRepository;
+
+    @InjectMocks
+    private BloodSugarService bloodSugarService;
+
+    private CareCallRecord testCallRecord;
+    private HealthDataExtractionResponse.BloodSugarData testBloodSugarData;
+
+    @BeforeEach
+    void setUp() {
+        testCallRecord = CareCallRecord.builder()
+                .id(1)
+                .elder(null)
+                .setting(null)
+                .calledAt(LocalDateTime.now())
+                .responded((byte) 1)
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now().plusMinutes(15))
+                .callStatus("completed")
+                .transcriptionText("테스트 통화 내용")
+                .build();
+
+        testBloodSugarData = HealthDataExtractionResponse.BloodSugarData.builder()
+                .measurementTime("아침")
+                .mealTime("식후")
+                .bloodSugarValue(120)
+                .status("NORMAL")
+                .build();
+    }
+
+    @Test
+    @DisplayName("혈당 데이터 저장 성공 - 정상 상태")
+    void saveBloodSugarData_성공_정상상태() {
+        // given
+        when(bloodSugarRecordRepository.save(any(BloodSugarRecord.class)))
+                .thenReturn(new BloodSugarRecord());
+
+        // when
+        bloodSugarService.saveBloodSugarData(testCallRecord, testBloodSugarData);
+
+        // then
+        ArgumentCaptor<BloodSugarRecord> captor = ArgumentCaptor.forClass(BloodSugarRecord.class);
+        verify(bloodSugarRecordRepository).save(captor.capture());
+
+        BloodSugarRecord savedRecord = captor.getValue();
+        assertThat(savedRecord.getCareCallRecord()).isEqualTo(testCallRecord);
+        assertThat(savedRecord.getBlood_sugar_value()).isEqualTo(BigDecimal.valueOf(120));
+        assertThat(savedRecord.getMeasurementType()).isEqualTo(BloodSugarMeasurementType.AFTER_MEAL);
+        assertThat(savedRecord.getStatus()).isEqualTo(BloodSugarStatus.NORMAL);
+        assertThat(savedRecord.getResponseSummary()).contains("측정시각: 아침, 식전/식후: 식후");
+    }
+
+    @Test
+    @DisplayName("혈당 데이터 저장 성공 - 고혈당 상태")
+    void saveBloodSugarData_성공_고혈당상태() {
+        // given
+        testBloodSugarData = HealthDataExtractionResponse.BloodSugarData.builder()
+                .measurementTime("저녁")
+                .mealTime("식후")
+                .bloodSugarValue(200)
+                .status("HIGH")
+                .build();
+
+        when(bloodSugarRecordRepository.save(any(BloodSugarRecord.class)))
+                .thenReturn(new BloodSugarRecord());
+
+        // when
+        bloodSugarService.saveBloodSugarData(testCallRecord, testBloodSugarData);
+
+        // then
+        ArgumentCaptor<BloodSugarRecord> captor = ArgumentCaptor.forClass(BloodSugarRecord.class);
+        verify(bloodSugarRecordRepository).save(captor.capture());
+
+        BloodSugarRecord savedRecord = captor.getValue();
+        assertThat(savedRecord.getStatus()).isEqualTo(BloodSugarStatus.HIGH);
+        assertThat(savedRecord.getBlood_sugar_value()).isEqualTo(BigDecimal.valueOf(200));
+    }
+
+    @Test
+    @DisplayName("혈당 데이터 저장 성공 - 저혈당 상태")
+    void saveBloodSugarData_성공_저혈당상태() {
+        // given
+        testBloodSugarData = HealthDataExtractionResponse.BloodSugarData.builder()
+                .measurementTime("아침")
+                .mealTime("식전")
+                .bloodSugarValue(70)
+                .status("LOW")
+                .build();
+
+        when(bloodSugarRecordRepository.save(any(BloodSugarRecord.class)))
+                .thenReturn(new BloodSugarRecord());
+
+        // when
+        bloodSugarService.saveBloodSugarData(testCallRecord, testBloodSugarData);
+
+        // then
+        ArgumentCaptor<BloodSugarRecord> captor = ArgumentCaptor.forClass(BloodSugarRecord.class);
+        verify(bloodSugarRecordRepository).save(captor.capture());
+
+        BloodSugarRecord savedRecord = captor.getValue();
+        assertThat(savedRecord.getStatus()).isEqualTo(BloodSugarStatus.LOW);
+        assertThat(savedRecord.getMeasurementType()).isEqualTo(BloodSugarMeasurementType.BEFORE_MEAL);
+    }
+
+    @Test
+    @DisplayName("혈당 데이터 저장 성공 - status가 null인 경우")
+    void saveBloodSugarData_성공_status_null() {
+        // given
+        testBloodSugarData = HealthDataExtractionResponse.BloodSugarData.builder()
+                .measurementTime("아침")
+                .mealTime("식후")
+                .bloodSugarValue(120)
+                .status(null)
+                .build();
+
+        when(bloodSugarRecordRepository.save(any(BloodSugarRecord.class)))
+                .thenReturn(new BloodSugarRecord());
+
+        // when
+        bloodSugarService.saveBloodSugarData(testCallRecord, testBloodSugarData);
+
+        // then
+        ArgumentCaptor<BloodSugarRecord> captor = ArgumentCaptor.forClass(BloodSugarRecord.class);
+        verify(bloodSugarRecordRepository).save(captor.capture());
+
+        BloodSugarRecord savedRecord = captor.getValue();
+        assertThat(savedRecord.getStatus()).isNull();
+    }
+
+    @Test
+    @DisplayName("혈당 데이터 저장 실패 - 혈당 값이 null인 경우")
+    void saveBloodSugarData_실패_혈당값_null() {
+        // given
+        testBloodSugarData = HealthDataExtractionResponse.BloodSugarData.builder()
+                .measurementTime("아침")
+                .mealTime("식후")
+                .bloodSugarValue(null)
+                .status("NORMAL")
+                .build();
+
+        // when
+        bloodSugarService.saveBloodSugarData(testCallRecord, testBloodSugarData);
+
+        // then
+        // 혈당 값이 null이면 저장하지 않음
+        verify(bloodSugarRecordRepository, org.mockito.Mockito.never()).save(any(BloodSugarRecord.class));
+    }
+} 

--- a/src/test/java/com/example/medicare_call/service/HealthDataExtractionIntegrationTest.java
+++ b/src/test/java/com/example/medicare_call/service/HealthDataExtractionIntegrationTest.java
@@ -62,7 +62,8 @@ class HealthDataExtractionIntegrationTest {
               "bloodSugarData": {
                 "measurementTime": "아침",
                 "mealTime": "식후",
-                "bloodSugarValue": 120
+                "bloodSugarValue": 120,
+                "status": "NORMAL"
               },
               "medicationData": null,
               "healthSigns": ["혈당이 정상 범위", "식사 후 혈당 측정"],

--- a/src/test/java/com/example/medicare_call/service/OpenAiHealthDataServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/OpenAiHealthDataServiceTest.java
@@ -65,7 +65,8 @@ class OpenAiHealthDataServiceTest {
               "bloodSugarData": {
                 "measurementTime": "아침",
                 "mealTime": "식후",
-                "bloodSugarValue": 120
+                "bloodSugarValue": 120,
+                "status": "NORMAL"
               },
               "medicationData": null,
               "healthSigns": ["혈당이 정상 범위"]
@@ -92,6 +93,7 @@ class OpenAiHealthDataServiceTest {
                         .measurementTime("아침")
                         .mealTime("식후")
                         .bloodSugarValue(120)
+                        .status("NORMAL")
                         .build())
                 .psychologicalState(List.of("기분이 좋음"))
                 .healthSigns(List.of("혈당이 정상 범위"))


### PR DESCRIPTION
### Description
- 혈당 데이터 조회 시에 포함되는 값인 혈당값 정상 여부(`status`)는 현재 따로 데이터 기록시 초기화되지 않고 있다.
  - `OpenAiHealthDataService`의 프롬프트를 변경하여, 혈당값만 반환하는 것이 아닌, 식전 식후 여부에 따라 상태값도 반환하도록 변경
- 이 상태값을 정의하기 위해 `BloodSugarStatus` enum을 추가
- 기존에는 `BloodSugarRecord`의 `status`컬럼에 정상, 비정상 정도의 값만 들어갈 것으로 예상하여 바이트 컬럼으로 설계했었지만, 복수 값을 사용함에 따라 컬럼 정의 변경
  - 마이그레이션 추가
- `BloodSugarService`에서 데이터 저장시, status컬럼도 저장하도록 변경