### PR TITLE
feat: 주간 혈당 데이터 조회 api

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/view/BloodSugarController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/BloodSugarController.java
@@ -1,0 +1,69 @@
+package com.example.medicare_call.controller.view;
+
+import com.example.medicare_call.dto.WeeklyBloodSugarResponse;
+import com.example.medicare_call.service.WeeklyBloodSugarService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/view")
+@RequiredArgsConstructor
+@Tag(name = "Blood Sugar", description = "혈당 데이터 조회 API")
+public class BloodSugarController {
+
+    private final WeeklyBloodSugarService weeklyBloodSugarService;
+
+    @Operation(
+        summary = "주간 혈당 데이터 조회",
+        description = "사용자의 주간 혈당 기록을 식사 시간대(공복/식후) 기준으로 조회합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "주간 혈당 데이터 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = WeeklyBloodSugarResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (날짜 형식 오류, 잘못된 타입 등)"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "어르신 정보를 찾을 수 없음"
+        )
+    })
+    @GetMapping("/blood-sugar/weekly")
+    public ResponseEntity<WeeklyBloodSugarResponse> getWeeklyBloodSugar(
+        @Parameter(description = "어르신 식별자", required = true, example = "1")
+        @RequestParam("elderId") Integer elderId,
+
+        @Parameter(description = "주간 조회 시작일 (yyyy-MM-dd)", required = true, example = "2025-07-09")
+        @RequestParam("startDate") String startDate,
+
+        @Parameter(description = "식사 시간대", required = true, example = "BEFORE_MEAL", 
+                  schema = @Schema(allowableValues = {"BEFORE_MEAL", "AFTER_MEAL"}))
+        @RequestParam("type") String type
+    ) {
+        log.info("주간 혈당 데이터 조회 요청: elderId={}, startDate={}, type={}", elderId, startDate, type);
+
+        WeeklyBloodSugarResponse response = weeklyBloodSugarService.getWeeklyBloodSugar(elderId, startDate, type);
+
+        return ResponseEntity.ok(response);
+    }
+} 

--- a/src/main/java/com/example/medicare_call/dto/WeeklyBloodSugarResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/WeeklyBloodSugarResponse.java
@@ -1,0 +1,62 @@
+package com.example.medicare_call.dto;
+
+import com.example.medicare_call.global.enums.BloodSugarStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "주간 혈당 데이터 조회 응답")
+public class WeeklyBloodSugarResponse {
+
+    @Schema(description = "조회 구간")
+    private Period period;
+
+    @Schema(description = "날짜별 혈당 측정 값")
+    private List<BloodSugarData> data;
+
+    @Schema(description = "주간 평균 혈당")
+    private BloodSugarSummary average;
+
+    @Schema(description = "가장 최근 혈당")
+    private BloodSugarSummary latest;
+
+    @Getter
+    @Builder
+    @Schema(description = "조회 구간")
+    public static class Period {
+        @Schema(description = "조회 시작일", example = "2025-07-09")
+        private String startDate;
+
+        @Schema(description = "조회 종료일", example = "2025-07-16")
+        private String endDate;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "혈당 측정 데이터")
+    public static class BloodSugarData {
+        @Schema(description = "측정 날짜", example = "2025-07-09")
+        private String date;
+
+        @Schema(description = "혈당 수치 (mg/dL)", example = "120")
+        private Integer value;
+
+        @Schema(description = "판정 상태", example = "NORMAL")
+        private BloodSugarStatus status;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "혈당 요약 정보")
+    public static class BloodSugarSummary {
+        @Schema(description = "혈당 수치 (mg/dL)", example = "120")
+        private Integer value;
+
+        @Schema(description = "판정 상태", example = "NORMAL")
+        private BloodSugarStatus status;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/repository/BloodSugarRecordRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/BloodSugarRecordRepository.java
@@ -1,7 +1,26 @@
 package com.example.medicare_call.repository;
 
 import com.example.medicare_call.domain.BloodSugarRecord;
+import com.example.medicare_call.global.enums.BloodSugarMeasurementType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface BloodSugarRecordRepository extends JpaRepository<BloodSugarRecord, Integer> {
+
+    @Query("SELECT bsr FROM BloodSugarRecord bsr " +
+           "JOIN bsr.careCallRecord ccr " +
+           "WHERE ccr.elder.id = :elderId " +
+           "AND bsr.measurementType = :measurementType " +
+           "AND DATE(bsr.recordedAt) BETWEEN :startDate AND :endDate " +
+           "ORDER BY bsr.recordedAt")
+    List<BloodSugarRecord> findByElderIdAndMeasurementTypeAndDateBetween(
+            @Param("elderId") Integer elderId,
+            @Param("measurementType") BloodSugarMeasurementType measurementType,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
 } 

--- a/src/main/java/com/example/medicare_call/service/WeeklyBloodSugarService.java
+++ b/src/main/java/com/example/medicare_call/service/WeeklyBloodSugarService.java
@@ -1,0 +1,101 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.BloodSugarRecord;
+import com.example.medicare_call.dto.WeeklyBloodSugarResponse;
+import com.example.medicare_call.global.enums.BloodSugarMeasurementType;
+import com.example.medicare_call.global.enums.BloodSugarStatus;
+import com.example.medicare_call.repository.BloodSugarRecordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WeeklyBloodSugarService {
+
+    private final BloodSugarRecordRepository bloodSugarRecordRepository;
+
+    public WeeklyBloodSugarResponse getWeeklyBloodSugar(Integer elderId, String startDateStr, String typeStr) {
+        LocalDate startDate = LocalDate.parse(startDateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        LocalDate endDate = startDate.plusDays(6); // 7일간 조회
+
+        BloodSugarMeasurementType measurementType = BloodSugarMeasurementType.valueOf(typeStr);
+        List<BloodSugarRecord> records = bloodSugarRecordRepository
+                .findByElderIdAndMeasurementTypeAndDateBetween(elderId, measurementType, startDate, endDate);
+
+        List<WeeklyBloodSugarResponse.BloodSugarData> data = records.stream()
+                .map(this::convertToBloodSugarData)
+                .collect(Collectors.toList());
+
+        // 평균 계산
+        WeeklyBloodSugarResponse.BloodSugarSummary average = calculateAverage(records);
+
+        // 최신 데이터 선택
+        WeeklyBloodSugarResponse.BloodSugarSummary latest = records.isEmpty() ? null : 
+                convertToBloodSugarSummary(records.get(records.size() - 1));
+
+        return WeeklyBloodSugarResponse.builder()
+                .period(WeeklyBloodSugarResponse.Period.builder()
+                        .startDate(startDateStr)
+                        .endDate(endDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                        .build())
+                .data(data)
+                .average(average)
+                .latest(latest)
+                .build();
+    }
+
+    private WeeklyBloodSugarResponse.BloodSugarData convertToBloodSugarData(BloodSugarRecord record) {
+        return WeeklyBloodSugarResponse.BloodSugarData.builder()
+                .date(record.getRecordedAt().toLocalDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .value(record.getBlood_sugar_value().intValue())
+                .status(record.getStatus())
+                .build();
+    }
+
+    private WeeklyBloodSugarResponse.BloodSugarSummary convertToBloodSugarSummary(BloodSugarRecord record) {
+        return WeeklyBloodSugarResponse.BloodSugarSummary.builder()
+                .value(record.getBlood_sugar_value().intValue())
+                .status(record.getStatus())
+                .build();
+    }
+
+    private WeeklyBloodSugarResponse.BloodSugarSummary calculateAverage(List<BloodSugarRecord> records) {
+        if (records.isEmpty()) {
+            return null;
+        }
+
+        BigDecimal sum = records.stream()
+                .map(BloodSugarRecord::getBlood_sugar_value)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal average = sum.divide(BigDecimal.valueOf(records.size()), 0, RoundingMode.HALF_UP);
+        
+        // 평균값의 상태 판정 (기준: 70 미만=저혈당, 70-200=정상, 200 초과=고혈당)
+        // TODO: 일일 혈당 데이터에 대한 상태 판정은 OpenAI API에서 수행하는데, 여기서도 호출할지, 아니면 둘다 서비스에서 호출할지? 통일된 방식이 좋아보인다.
+        BloodSugarStatus averageStatus = determineStatus(average.intValue());
+
+        return WeeklyBloodSugarResponse.BloodSugarSummary.builder()
+                .value(average.intValue())
+                .status(averageStatus)
+                .build();
+    }
+
+    private BloodSugarStatus determineStatus(int value) {
+        if (value < 70) {
+            return BloodSugarStatus.LOW;
+        } else if (value > 200) {
+            return BloodSugarStatus.HIGH;
+        } else {
+            return BloodSugarStatus.NORMAL;
+        }
+    }
+} 

--- a/src/test/java/com/example/medicare_call/controller/view/BloodSugarControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/BloodSugarControllerTest.java
@@ -1,0 +1,144 @@
+package com.example.medicare_call.controller.view;
+
+import com.example.medicare_call.dto.WeeklyBloodSugarResponse;
+import com.example.medicare_call.global.enums.BloodSugarStatus;
+import com.example.medicare_call.global.jwt.JwtProvider;
+import com.example.medicare_call.service.WeeklyBloodSugarService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(BloodSugarController.class)
+@AutoConfigureMockMvc(addFilters = false) // security 필터 비활성화
+@ActiveProfiles("test")
+class BloodSugarControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private WeeklyBloodSugarService weeklyBloodSugarService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("주간 혈당 데이터 조회 성공 - 데이터 있음")
+    void getWeeklyBloodSugar_성공_데이터있음() throws Exception {
+        // given
+        Integer elderId = 1;
+        String startDate = "2025-07-09";
+        String type = "BEFORE_MEAL";
+
+        WeeklyBloodSugarResponse.Period period = WeeklyBloodSugarResponse.Period.builder()
+                .startDate("2025-07-09")
+                .endDate("2025-07-15")
+                .build();
+
+        WeeklyBloodSugarResponse.BloodSugarData data1 = WeeklyBloodSugarResponse.BloodSugarData.builder()
+                .date("2025-07-09")
+                .value(90)
+                .status(BloodSugarStatus.LOW)
+                .build();
+
+        WeeklyBloodSugarResponse.BloodSugarData data2 = WeeklyBloodSugarResponse.BloodSugarData.builder()
+                .date("2025-07-10")
+                .value(105)
+                .status(BloodSugarStatus.NORMAL)
+                .build();
+
+        WeeklyBloodSugarResponse.BloodSugarSummary average = WeeklyBloodSugarResponse.BloodSugarSummary.builder()
+                .value(128)
+                .status(BloodSugarStatus.NORMAL)
+                .build();
+
+        WeeklyBloodSugarResponse.BloodSugarSummary latest = WeeklyBloodSugarResponse.BloodSugarSummary.builder()
+                .value(105)
+                .status(BloodSugarStatus.NORMAL)
+                .build();
+
+        WeeklyBloodSugarResponse expectedResponse = WeeklyBloodSugarResponse.builder()
+                .period(period)
+                .data(Arrays.asList(data1, data2))
+                .average(average)
+                .latest(latest)
+                .build();
+
+        when(weeklyBloodSugarService.getWeeklyBloodSugar(eq(elderId), eq(startDate), eq(type)))
+                .thenReturn(expectedResponse);
+
+        // when & then
+        mockMvc.perform(get("/view/blood-sugar/weekly")
+                        .param("elderId", elderId.toString())
+                        .param("startDate", startDate)
+                        .param("type", type))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.period.startDate").value("2025-07-09"))
+                .andExpect(jsonPath("$.period.endDate").value("2025-07-15"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].date").value("2025-07-09"))
+                .andExpect(jsonPath("$.data[0].value").value(90))
+                .andExpect(jsonPath("$.data[0].status").value("LOW"))
+                .andExpect(jsonPath("$.data[1].date").value("2025-07-10"))
+                .andExpect(jsonPath("$.data[1].value").value(105))
+                .andExpect(jsonPath("$.data[1].status").value("NORMAL"))
+                .andExpect(jsonPath("$.average.value").value(128))
+                .andExpect(jsonPath("$.average.status").value("NORMAL"))
+                .andExpect(jsonPath("$.latest.value").value(105))
+                .andExpect(jsonPath("$.latest.status").value("NORMAL"));
+    }
+
+    @Test
+    @DisplayName("주간 혈당 데이터 조회 성공 - 데이터 없음")
+    void getWeeklyBloodSugar_성공_데이터없음() throws Exception {
+        // given
+        Integer elderId = 1;
+        String startDate = "2025-07-09";
+        String type = "AFTER_MEAL";
+
+        WeeklyBloodSugarResponse.Period period = WeeklyBloodSugarResponse.Period.builder()
+                .startDate("2025-07-09")
+                .endDate("2025-07-15")
+                .build();
+
+        WeeklyBloodSugarResponse expectedResponse = WeeklyBloodSugarResponse.builder()
+                .period(period)
+                .data(Collections.emptyList())
+                .average(null)
+                .latest(null)
+                .build();
+
+        when(weeklyBloodSugarService.getWeeklyBloodSugar(eq(elderId), eq(startDate), eq(type)))
+                .thenReturn(expectedResponse);
+
+        // when & then
+        mockMvc.perform(get("/view/blood-sugar/weekly")
+                        .param("elderId", elderId.toString())
+                        .param("startDate", startDate)
+                        .param("type", type))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.period.startDate").value("2025-07-09"))
+                .andExpect(jsonPath("$.period.endDate").value("2025-07-15"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data").isEmpty())
+                .andExpect(jsonPath("$.average").isEmpty())
+                .andExpect(jsonPath("$.latest").isEmpty());
+    }
+} 

--- a/src/test/java/com/example/medicare_call/service/WeeklyBloodSugarServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/WeeklyBloodSugarServiceTest.java
@@ -1,0 +1,154 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.BloodSugarRecord;
+import com.example.medicare_call.domain.CareCallRecord;
+import com.example.medicare_call.domain.Elder;
+import com.example.medicare_call.dto.WeeklyBloodSugarResponse;
+import com.example.medicare_call.global.enums.BloodSugarMeasurementType;
+import com.example.medicare_call.global.enums.BloodSugarStatus;
+import com.example.medicare_call.repository.BloodSugarRecordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WeeklyBloodSugarServiceTest {
+
+    @Mock
+    private BloodSugarRecordRepository bloodSugarRecordRepository;
+
+    @InjectMocks
+    private WeeklyBloodSugarService weeklyBloodSugarService;
+
+    private Elder testElder;
+    private CareCallRecord testCallRecord;
+
+    @BeforeEach
+    void setUp() {
+        testElder = Elder.builder()
+                .id(1)
+                .name("테스트 어르신")
+                .build();
+
+        testCallRecord = CareCallRecord.builder()
+                .id(1)
+                .elder(testElder)
+                .startTime(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    @DisplayName("주간 혈당 데이터 조회 성공 - 데이터 있음")
+    void getWeeklyBloodSugar_성공_데이터있음() {
+        // given
+        Integer elderId = 1;
+        String startDate = "2025-07-09";
+        String type = "BEFORE_MEAL";
+
+        List<BloodSugarRecord> records = Arrays.asList(
+                createBloodSugarRecord(1, LocalDate.of(2025, 7, 9), 90, BloodSugarStatus.LOW),
+                createBloodSugarRecord(2, LocalDate.of(2025, 7, 10), 105, BloodSugarStatus.NORMAL),
+                createBloodSugarRecord(3, LocalDate.of(2025, 7, 11), 190, BloodSugarStatus.HIGH)
+        );
+
+        when(bloodSugarRecordRepository.findByElderIdAndMeasurementTypeAndDateBetween(
+                eq(elderId), eq(BloodSugarMeasurementType.BEFORE_MEAL), any(), any()))
+                .thenReturn(records);
+
+        // when
+        WeeklyBloodSugarResponse response = weeklyBloodSugarService.getWeeklyBloodSugar(elderId, startDate, type);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getPeriod().getStartDate()).isEqualTo("2025-07-09");
+        assertThat(response.getPeriod().getEndDate()).isEqualTo("2025-07-15");
+        assertThat(response.getData()).hasSize(3);
+        assertThat(response.getAverage()).isNotNull();
+        assertThat(response.getAverage().getValue()).isEqualTo(128); // (90+105+190)/3 = 128
+        assertThat(response.getAverage().getStatus()).isEqualTo(BloodSugarStatus.NORMAL);
+        assertThat(response.getLatest()).isNotNull();
+        assertThat(response.getLatest().getValue()).isEqualTo(190);
+        assertThat(response.getLatest().getStatus()).isEqualTo(BloodSugarStatus.HIGH);
+    }
+
+    @Test
+    @DisplayName("주간 혈당 데이터 조회 성공 - 데이터 없음")
+    void getWeeklyBloodSugar_성공_데이터없음() {
+        // given
+        Integer elderId = 1;
+        String startDate = "2025-07-09";
+        String type = "AFTER_MEAL";
+
+        when(bloodSugarRecordRepository.findByElderIdAndMeasurementTypeAndDateBetween(
+                eq(elderId), eq(BloodSugarMeasurementType.AFTER_MEAL), any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        WeeklyBloodSugarResponse response = weeklyBloodSugarService.getWeeklyBloodSugar(elderId, startDate, type);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getPeriod().getStartDate()).isEqualTo("2025-07-09");
+        assertThat(response.getPeriod().getEndDate()).isEqualTo("2025-07-15");
+        assertThat(response.getData()).isEmpty();
+        assertThat(response.getAverage()).isNull();
+        assertThat(response.getLatest()).isNull();
+    }
+
+    @Test
+    @DisplayName("주간 혈당 데이터 조회 성공 - 단일 데이터")
+    void getWeeklyBloodSugar_성공_단일데이터() {
+        // given
+        Integer elderId = 1;
+        String startDate = "2025-07-09";
+        String type = "BEFORE_MEAL";
+
+        List<BloodSugarRecord> records = Collections.singletonList(
+                createBloodSugarRecord(1, LocalDate.of(2025, 7, 9), 120, BloodSugarStatus.NORMAL)
+        );
+
+        when(bloodSugarRecordRepository.findByElderIdAndMeasurementTypeAndDateBetween(
+                eq(elderId), eq(BloodSugarMeasurementType.BEFORE_MEAL), any(), any()))
+                .thenReturn(records);
+
+        // when
+        WeeklyBloodSugarResponse response = weeklyBloodSugarService.getWeeklyBloodSugar(elderId, startDate, type);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getData()).hasSize(1);
+        assertThat(response.getAverage()).isNotNull();
+        assertThat(response.getAverage().getValue()).isEqualTo(120);
+        assertThat(response.getAverage().getStatus()).isEqualTo(BloodSugarStatus.NORMAL);
+        assertThat(response.getLatest()).isNotNull();
+        assertThat(response.getLatest().getValue()).isEqualTo(120);
+        assertThat(response.getLatest().getStatus()).isEqualTo(BloodSugarStatus.NORMAL);
+    }
+
+    private BloodSugarRecord createBloodSugarRecord(Integer id, LocalDate date, int value, BloodSugarStatus status) {
+        return BloodSugarRecord.builder()
+                .id(id)
+                .careCallRecord(testCallRecord)
+                .measurementType(BloodSugarMeasurementType.BEFORE_MEAL)
+                .blood_sugar_value(BigDecimal.valueOf(value))
+                .status(status)
+                .recordedAt(date.atStartOfDay())
+                .build();
+    }
+} 


### PR DESCRIPTION
### Description
- 주간 평균 혈당에 대한 상태값 판정을 일단 서비스에서 범위를 통해 하도록 구현하였음. (`WeeklyBloodSugarService.calculateAverage`)
  - 기준: 70 미만=저혈당, 70-200=정상, 200 초과=고혈당
  - 일일 혈당 데이터에 대한 상태 판정은 OpenAI API 호출시 프롬프팅을 통해 받아오고 있어, AI의 기준으로 판단을 내리는데, 여기서도 AI API를 호출할지 혹은 둘다 서비스에 기준을 마련할지?
  - 단일 방식으로 통일하는게 좋을 것 같다. 주간 회의 때 논의해보자.
- API SPEC
  - https://www.notion.so/7-API-23e6196331d2804fa4f1d22553389b9a
- `GET http://localhost:8080/api/view/blood-sugar/weekly?elderId=1&startDate=2025-07-30&type=AFTER_MEAL`
```
{
  "period": {
    "startDate": "2025-07-30",
    "endDate": "2025-08-05"
  },
  "data": [
    {
      "date": "2025-08-02",
      "value": 120,
      "status": null
    },
    {
      "date": "2025-08-02",
      "value": 120,
      "status": null
    },
    {
      "date": "2025-08-03",
      "value": 120,
      "status": null
    },
    {
      "date": "2025-08-03",
      "value": 120,
      "status": "NORMAL"
    }
  ],
  "average": {
    "value": 120,
    "status": "NORMAL"
  },
  "latest": {
    "value": 120,
    "status": "NORMAL"
  }
}
```