### PR TITLE
feat: 홈 화면 API 구현

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/view/HomeController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/HomeController.java
@@ -1,0 +1,62 @@
+package com.example.medicare_call.controller.view;
+
+import com.example.medicare_call.dto.HomeResponse;
+import com.example.medicare_call.service.HomeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/view")
+@RequiredArgsConstructor
+@Tag(name = "Home", description = "홈 화면 데이터 조회 API")
+public class HomeController {
+
+    private final HomeService homeService;
+
+    @Operation(
+        summary = "홈 화면 데이터 조회",
+        description = "초기 화면 렌더링에 필요한 데이터를 제공하는 API입니다. 홈 화면 진입 시에 호출하면 됩니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "홈 화면 데이터 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = HomeResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "어르신 정보를 찾을 수 없음"
+        )
+    })
+    @GetMapping("/home")
+    public ResponseEntity<HomeResponse> getHomeData(
+        @Parameter(description = "조회할 어르신의 식별자", required = true, example = "1")
+        @RequestParam("elderId") Integer elderId
+    ) {
+        log.info("홈 화면 데이터 조회 요청: elderId={}", elderId);
+
+        HomeResponse response = homeService.getHomeData(elderId);
+
+        return ResponseEntity.ok(response);
+    }
+} 

--- a/src/main/java/com/example/medicare_call/dto/HomeResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/HomeResponse.java
@@ -1,0 +1,105 @@
+package com.example.medicare_call.dto;
+
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "홈 화면 데이터 조회 응답")
+public class HomeResponse {
+
+    @Schema(description = "어르신 이름", example = "김옥자")
+    private String elderName;
+
+    @Schema(description = "AI가 생성한 건강 상태 요약 문장", example = "아침·점심 복약과 식사는 문제 없으나, 저녁 약 복용이 늦어진 우려가 있어요.")
+    private String AISummary;
+
+    @Schema(description = "식사 여부 상태 정보")
+    private MealStatus mealStatus;
+
+    @Schema(description = "전체 복약 상태 요약")
+    private MedicationStatus medicationStatus;
+
+    @Schema(description = "수면 요약 정보")
+    private Sleep sleep;
+
+    @Schema(description = "사용자의 건강 상태 평가", example = "좋음")
+    private String healthStatus;
+
+    @Schema(description = "사용자의 심리 상태 평가", example = "좋음")
+    private String mentalStatus;
+
+    @Schema(description = "혈당 정보")
+    private BloodSugar bloodSugar;
+
+    @Getter
+    @Builder
+    @Schema(description = "식사 여부 상태 정보")
+    public static class MealStatus {
+        @Schema(description = "아침 식사 여부", example = "true")
+        private Boolean breakfast;
+
+        @Schema(description = "점심 식사 여부", example = "true")
+        private Boolean lunch;
+
+        @Schema(description = "저녁 식사 여부", example = "false")
+        private Boolean dinner;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "전체 복약 상태 요약")
+    public static class MedicationStatus {
+        @Schema(description = "오늘까지 복용한 약 횟수 총합", example = "0")
+        private Integer totalTaken;
+
+        @Schema(description = "하루 복약 목표 횟수 총합", example = "5")
+        private Integer totalGoal;
+
+        @Schema(description = "다음 복약 예정 시간", example = "LUNCH")
+        private MedicationScheduleTime nextMedicationTime;
+
+        @Schema(description = "약 종류별 복약 정보 목록")
+        private List<MedicationInfo> medicationList;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "약 종류별 복약 정보")
+    public static class MedicationInfo {
+        @Schema(description = "약 종류", example = "당뇨약")
+        private String type;
+
+        @Schema(description = "복약한 횟수", example = "0")
+        private Integer taken;
+
+        @Schema(description = "목표 복약 횟수", example = "3")
+        private Integer goal;
+
+        @Schema(description = "해당 약의 다음 복약 예정 시간", example = "LUNCH")
+        private MedicationScheduleTime nextTime;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "수면 요약 정보")
+    public static class Sleep {
+        @Schema(description = "평균 수면 시간 (시)", example = "7")
+        private Integer meanHours;
+
+        @Schema(description = "평균 수면 시간 (분)", example = "12")
+        private Integer meanMinutes;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "혈당 정보")
+    public static class BloodSugar {
+        @Schema(description = "평균 혈당 수치 (mg/dL 단위)", example = "120")
+        private Integer meanValue;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/repository/BloodSugarRecordRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/BloodSugarRecordRepository.java
@@ -23,4 +23,11 @@ public interface BloodSugarRecordRepository extends JpaRepository<BloodSugarReco
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate
     );
+
+    @Query("SELECT bsr FROM BloodSugarRecord bsr " +
+           "JOIN bsr.careCallRecord ccr " +
+           "WHERE ccr.elder.id = :elderId " +
+           "AND DATE(bsr.recordedAt) = :date " +
+           "ORDER BY bsr.recordedAt")
+    List<BloodSugarRecord> findByElderIdAndDate(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
 } 

--- a/src/main/java/com/example/medicare_call/repository/CareCallRecordRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/CareCallRecordRepository.java
@@ -25,4 +25,11 @@ public interface CareCallRecordRepository extends JpaRepository<CareCallRecord, 
                    "AND ccr.psychologicalDetails IS NOT NULL " +
                    "ORDER BY ccr.startTime")
             List<CareCallRecord> findByElderIdAndDateWithPsychologicalData(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
+
+            @Query("SELECT ccr FROM CareCallRecord ccr " +
+                   "WHERE ccr.elder.id = :elderId " +
+                   "AND DATE(ccr.startTime) = :date " +
+                   "AND ccr.healthDetails IS NOT NULL " +
+                   "ORDER BY ccr.startTime")
+            List<CareCallRecord> findByElderIdAndDateWithHealthData(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
 } 

--- a/src/main/java/com/example/medicare_call/repository/MedicationTakenRecordRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/MedicationTakenRecordRepository.java
@@ -2,6 +2,17 @@ package com.example.medicare_call.repository;
 
 import com.example.medicare_call.domain.MedicationTakenRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface MedicationTakenRecordRepository extends JpaRepository<MedicationTakenRecord, Integer> {
+
+    @Query("SELECT mtr FROM MedicationTakenRecord mtr " +
+           "JOIN mtr.careCallRecord ccr " +
+           "WHERE ccr.elder.id = :elderId " +
+           "AND DATE(mtr.recordedAt) = :date")
+    List<MedicationTakenRecord> findByElderIdAndDate(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
 } 

--- a/src/main/java/com/example/medicare_call/service/HomeService.java
+++ b/src/main/java/com/example/medicare_call/service/HomeService.java
@@ -1,0 +1,321 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.BloodSugarRecord;
+import com.example.medicare_call.domain.CareCallRecord;
+import com.example.medicare_call.domain.Elder;
+import com.example.medicare_call.domain.MealRecord;
+import com.example.medicare_call.domain.MedicationSchedule;
+import com.example.medicare_call.domain.MedicationTakenRecord;
+import com.example.medicare_call.dto.HomeResponse;
+import com.example.medicare_call.global.enums.MealType;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
+import com.example.medicare_call.repository.BloodSugarRecordRepository;
+import com.example.medicare_call.repository.CareCallRecordRepository;
+import com.example.medicare_call.repository.ElderRepository;
+import com.example.medicare_call.repository.MealRecordRepository;
+import com.example.medicare_call.repository.MedicationScheduleRepository;
+import com.example.medicare_call.repository.MedicationTakenRecordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HomeService {
+
+    private final ElderRepository elderRepository;
+    private final MealRecordRepository mealRecordRepository;
+    private final MedicationScheduleRepository medicationScheduleRepository;
+    private final MedicationTakenRecordRepository medicationTakenRecordRepository;
+    private final BloodSugarRecordRepository bloodSugarRecordRepository;
+    private final CareCallRecordRepository careCallRecordRepository;
+
+    public HomeResponse getHomeData(Integer elderId) {
+        LocalDate today = LocalDate.now();
+
+        // 어르신 정보 조회
+        Elder elder = elderRepository.findById(elderId)
+                .orElseThrow(() -> new RuntimeException("어르신을 찾을 수 없습니다: " + elderId));
+
+        // 오늘의 식사 기록 조회
+        List<MealRecord> todayMeals = mealRecordRepository.findByElderIdAndDate(elderId, today);
+        HomeResponse.MealStatus mealStatus = getMealStatus(todayMeals);
+
+        // 복약 정보 조회
+        List<MedicationSchedule> medicationSchedules = medicationScheduleRepository.findByElder(elder);
+        List<MedicationTakenRecord> todayMedications = medicationTakenRecordRepository.findByElderIdAndDate(elderId, today);
+        HomeResponse.MedicationStatus medicationStatus = getMedicationStatus(medicationSchedules, todayMedications);
+
+        // 수면 정보 조회
+        HomeResponse.Sleep sleep = getSleepInfo(elderId, today);
+
+        // 건강 상태 및 심리 상태 조회
+        String healthStatus = getHealthStatus(elderId, today);
+        String mentalStatus = getMentalStatus(elderId, today);
+
+        // 혈당 정보 조회
+        HomeResponse.BloodSugar bloodSugar = getBloodSugarInfo(elderId, today);
+
+        return HomeResponse.builder()
+                .elderName(elder.getName())
+                .AISummary("TODO: AI 요약 기능 구현 필요") // TODO: AI 요약 기능 구현
+                .mealStatus(mealStatus)
+                .medicationStatus(medicationStatus)
+                .sleep(sleep)
+                .healthStatus(healthStatus)
+                .mentalStatus(mentalStatus)
+                .bloodSugar(bloodSugar)
+                .build();
+    }
+
+    private HomeResponse.MealStatus getMealStatus(List<MealRecord> todayMeals) {
+        boolean breakfast = false;
+        boolean lunch = false;
+        boolean dinner = false;
+
+        for (MealRecord meal : todayMeals) {
+            MealType mealType = MealType.fromValue(meal.getMealType());
+            if (mealType != null) {
+                switch (mealType) {
+                    case BREAKFAST:
+                        breakfast = true;
+                        break;
+                    case LUNCH:
+                        lunch = true;
+                        break;
+                    case DINNER:
+                        dinner = true;
+                        break;
+                }
+            }
+        }
+
+        return HomeResponse.MealStatus.builder()
+                .breakfast(breakfast)
+                .lunch(lunch)
+                .dinner(dinner)
+                .build();
+    }
+
+    private HomeResponse.MedicationStatus getMedicationStatus(List<MedicationSchedule> schedules, List<MedicationTakenRecord> todayMedications) {
+        int totalTaken = todayMedications.size();
+        
+        // 약 종류별로 스케줄을 그룹화하여 목표 복용 횟수 계산
+        Map<String, List<MedicationSchedule>> medicationSchedules = schedules.stream()
+                .collect(Collectors.groupingBy(
+                        schedule -> schedule.getMedication().getName()
+                ));
+
+        // 약 종류별 복용 횟수 계산
+        Map<String, Long> medicationTakenCounts = todayMedications.stream()
+                .collect(Collectors.groupingBy(
+                        mtr -> mtr.getMedicationSchedule().getMedication().getName(),
+                        Collectors.counting()
+                ));
+
+        List<HomeResponse.MedicationInfo> medicationList = medicationSchedules.entrySet().stream()
+                .map(entry -> {
+                    String medicationName = entry.getKey();
+                    List<MedicationSchedule> medicationScheduleList = entry.getValue();
+                    
+                    // 해당 약의 하루 목표 복용 횟수 (스케줄 개수)
+                    int goal = medicationScheduleList.size();
+                    int taken = medicationTakenCounts.getOrDefault(medicationName, 0L).intValue();
+
+                    // 다음 복약 시간 계산 (해당 약의 스케줄 중 가장 가까운 시간)
+                    MedicationScheduleTime nextTime = calculateNextMedicationTimeForMedication(medicationScheduleList);
+
+                    return HomeResponse.MedicationInfo.builder()
+                            .type(medicationName)
+                            .taken(taken)
+                            .goal(goal)
+                            .nextTime(nextTime)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        // 전체 목표 복용 횟수 계산
+        int totalGoal = schedules.size();
+
+        // 전체 다음 복약 시간 계산 (모든 약 중 가장 가까운 시간)
+        MedicationScheduleTime nextTime = calculateNextMedicationTime(schedules);
+
+        return HomeResponse.MedicationStatus.builder()
+                .totalTaken(totalTaken)
+                .totalGoal(totalGoal)
+                .nextMedicationTime(nextTime)
+                .medicationList(medicationList)
+                .build();
+    }
+
+    private MedicationScheduleTime calculateNextMedicationTime(List<MedicationSchedule> schedules) {
+        LocalTime now = LocalTime.now();
+        LocalTime nextTime = null;
+        MedicationScheduleTime nextScheduleTime = null;
+
+        for (MedicationSchedule schedule : schedules) {
+            MedicationScheduleTime scheduleTime = MedicationScheduleTime.valueOf(schedule.getScheduleTime());
+            LocalTime scheduleLocalTime = getLocalTimeFromScheduleTime(scheduleTime);
+            
+            if (scheduleLocalTime.isAfter(now)) {
+                if (nextTime == null || scheduleLocalTime.isBefore(nextTime)) {
+                    nextTime = scheduleLocalTime;
+                    nextScheduleTime = scheduleTime;
+                }
+            }
+        }
+
+        // 오늘 남은 시간이 없으면 내일의 첫 번째 복약 시간으로 설정
+        if (nextScheduleTime == null && !schedules.isEmpty()) {
+            nextScheduleTime = schedules.stream()
+                    .map(schedule -> MedicationScheduleTime.valueOf(schedule.getScheduleTime()))
+                    .min(Comparator.comparing(this::getLocalTimeFromScheduleTime))
+                    .orElse(MedicationScheduleTime.MORNING);
+        }
+
+        return nextScheduleTime != null ? nextScheduleTime : MedicationScheduleTime.MORNING;
+    }
+
+    private LocalTime getLocalTimeFromScheduleTime(MedicationScheduleTime scheduleTime) {
+        switch (scheduleTime) {
+            case MORNING:
+                return LocalTime.of(8, 0);
+            case LUNCH:
+                return LocalTime.of(12, 0);
+            case DINNER:
+                return LocalTime.of(18, 0);
+            default:
+                return LocalTime.of(8, 0);
+        }
+    }
+
+    private MedicationScheduleTime calculateNextMedicationTimeForMedication(List<MedicationSchedule> medicationSchedules) {
+        LocalTime now = LocalTime.now();
+        LocalTime nextTime = null;
+        MedicationScheduleTime nextScheduleTime = null;
+
+        for (MedicationSchedule schedule : medicationSchedules) {
+            MedicationScheduleTime scheduleTime = MedicationScheduleTime.valueOf(schedule.getScheduleTime());
+            LocalTime scheduleLocalTime = getLocalTimeFromScheduleTime(scheduleTime);
+            
+            if (scheduleLocalTime.isAfter(now)) {
+                if (nextTime == null || scheduleLocalTime.isBefore(nextTime)) {
+                    nextTime = scheduleLocalTime;
+                    nextScheduleTime = scheduleTime;
+                }
+            }
+        }
+
+        // 오늘 남은 시간이 없으면 내일의 첫 번째 복약 시간으로 설정
+        if (nextScheduleTime == null && !medicationSchedules.isEmpty()) {
+            nextScheduleTime = medicationSchedules.stream()
+                    .map(schedule -> MedicationScheduleTime.valueOf(schedule.getScheduleTime())) // enum 목록
+                    .min(Comparator.comparing(this::getLocalTimeFromScheduleTime)) // 수치 기준으로 가장 이른 시간대 선택
+                    .orElse(MedicationScheduleTime.MORNING); // fallback인데 null로 처리하는게 좋을지?
+        }
+
+        return nextScheduleTime != null ? nextScheduleTime : MedicationScheduleTime.MORNING;
+    }
+
+    private HomeResponse.Sleep getSleepInfo(Integer elderId, LocalDate date) {
+        List<CareCallRecord> sleepRecords = careCallRecordRepository.findByElderIdAndDateWithSleepData(elderId, date);
+        
+        if (sleepRecords.isEmpty()) {
+            return null;
+        }
+
+        // 수면 시간 계산
+        long totalMinutes = 0;
+        int validRecords = 0;
+
+        for (CareCallRecord record : sleepRecords) {
+            if (record.getSleepStart() != null && record.getSleepEnd() != null) {
+                // 수면 시간 계산 (LocalDateTime 형식)
+                LocalDateTime sleepStart = record.getSleepStart();
+                LocalDateTime sleepEnd = record.getSleepEnd();
+                
+                try {
+                    long durationMinutes = Duration.between(sleepStart, sleepEnd).toMinutes();
+                    totalMinutes += durationMinutes;
+                    validRecords++;
+                } catch (Exception e) {
+                    log.warn("수면 시간 계산 실패: start={}, end={}", sleepStart, sleepEnd);
+                }
+            }
+        }
+
+        if (validRecords == 0) {
+            return null;
+        }
+
+        long averageMinutes = totalMinutes / validRecords;
+        int hours = (int) (averageMinutes / 60);
+        int minutes = (int) (averageMinutes % 60);
+
+        return HomeResponse.Sleep.builder()
+                .meanHours(hours)
+                .meanMinutes(minutes)
+                .build();
+    }
+
+    private String getHealthStatus(Integer elderId, LocalDate date) {
+        List<CareCallRecord> healthRecords = careCallRecordRepository.findByElderIdAndDateWithHealthData(elderId, date);
+        
+        if (healthRecords.isEmpty()) {
+            return null;
+        }
+
+        // 가장 최근 기록의 건강 상태 반환
+        CareCallRecord latestRecord = healthRecords.get(healthRecords.size() - 1);
+        return latestRecord.getHealthDetails();
+    }
+
+    private String getMentalStatus(Integer elderId, LocalDate date) {
+        List<CareCallRecord> mentalRecords = careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(elderId, date);
+        
+        if (mentalRecords.isEmpty()) {
+            return null;
+        }
+
+        // 가장 최근 기록의 심리 상태 반환
+        CareCallRecord latestRecord = mentalRecords.get(mentalRecords.size() - 1);
+        return latestRecord.getPsychologicalDetails();
+    }
+
+    private HomeResponse.BloodSugar getBloodSugarInfo(Integer elderId, LocalDate date) {
+        List<BloodSugarRecord> bloodSugarRecords = bloodSugarRecordRepository.findByElderIdAndDate(elderId, date);
+        
+        if (bloodSugarRecords.isEmpty()) {
+            return null;
+        }
+
+        // 평균 혈당 계산
+        BigDecimal sum = bloodSugarRecords.stream()
+                .map(BloodSugarRecord::getBlood_sugar_value)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        if (sum.equals(BigDecimal.ZERO)) {
+            return null;
+        }
+
+        BigDecimal average = sum.divide(BigDecimal.valueOf(bloodSugarRecords.size()), 0, RoundingMode.HALF_UP);
+
+        return HomeResponse.BloodSugar.builder()
+                .meanValue(average.intValue())
+                .build();
+    }
+} 

--- a/src/test/java/com/example/medicare_call/controller/view/HomeControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/HomeControllerTest.java
@@ -1,0 +1,101 @@
+package com.example.medicare_call.controller.view;
+
+import com.example.medicare_call.dto.HomeResponse;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
+import com.example.medicare_call.global.jwt.JwtProvider;
+import com.example.medicare_call.service.HomeService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(HomeController.class)
+@AutoConfigureMockMvc(addFilters = false) // security 필터 비활성화
+@ActiveProfiles("test")
+class HomeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private HomeService homeService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("홈 화면 데이터 조회 성공")
+    void getHomeData_성공() throws Exception {
+        // given
+        Integer elderId = 1;
+
+        HomeResponse.MealStatus mealStatus = HomeResponse.MealStatus.builder()
+                .breakfast(true)
+                .lunch(true)
+                .dinner(false)
+                .build();
+
+        HomeResponse.MedicationStatus medicationStatus = HomeResponse.MedicationStatus.builder()
+                .totalTaken(2)
+                .totalGoal(3)
+                .nextMedicationTime(MedicationScheduleTime.DINNER)
+                .medicationList(Collections.emptyList())
+                .build();
+
+        HomeResponse.Sleep sleep = HomeResponse.Sleep.builder()
+                .meanHours(7)
+                .meanMinutes(30)
+                .build();
+
+        HomeResponse.BloodSugar bloodSugar = HomeResponse.BloodSugar.builder()
+                .meanValue(120)
+                .build();
+
+        HomeResponse expectedResponse = HomeResponse.builder()
+                .elderName("김옥자")
+                .AISummary("TODO: AI 요약 기능 구현 필요")
+                .mealStatus(mealStatus)
+                .medicationStatus(medicationStatus)
+                .sleep(sleep)
+                .healthStatus("좋음")
+                .mentalStatus("좋음")
+                .bloodSugar(bloodSugar)
+                .build();
+
+        when(homeService.getHomeData(eq(elderId)))
+                .thenReturn(expectedResponse);
+
+        // when & then
+        mockMvc.perform(get("/view/home")
+                        .param("elderId", elderId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.elderName").value("김옥자"))
+                .andExpect(jsonPath("$.aisummary").value("TODO: AI 요약 기능 구현 필요"))
+                .andExpect(jsonPath("$.mealStatus.breakfast").value(true))
+                .andExpect(jsonPath("$.mealStatus.lunch").value(true))
+                .andExpect(jsonPath("$.mealStatus.dinner").value(false))
+                .andExpect(jsonPath("$.medicationStatus.totalTaken").value(2))
+                .andExpect(jsonPath("$.medicationStatus.totalGoal").value(3))
+                .andExpect(jsonPath("$.medicationStatus.nextMedicationTime").value("DINNER"))
+                .andExpect(jsonPath("$.sleep.meanHours").value(7))
+                .andExpect(jsonPath("$.sleep.meanMinutes").value(30))
+                .andExpect(jsonPath("$.healthStatus").value("좋음"))
+                .andExpect(jsonPath("$.mentalStatus").value("좋음"))
+                .andExpect(jsonPath("$.bloodSugar.meanValue").value(120));
+    }
+} 

--- a/src/test/java/com/example/medicare_call/service/HomeServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/HomeServiceTest.java
@@ -1,0 +1,226 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.Elder;
+import com.example.medicare_call.domain.MealRecord;
+import com.example.medicare_call.domain.Medication;
+import com.example.medicare_call.domain.MedicationSchedule;
+import com.example.medicare_call.domain.MedicationTakenRecord;
+import com.example.medicare_call.dto.HomeResponse;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
+import com.example.medicare_call.repository.BloodSugarRecordRepository;
+import com.example.medicare_call.repository.CareCallRecordRepository;
+import com.example.medicare_call.repository.ElderRepository;
+import com.example.medicare_call.repository.MealRecordRepository;
+import com.example.medicare_call.repository.MedicationScheduleRepository;
+import com.example.medicare_call.repository.MedicationTakenRecordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HomeServiceTest {
+
+    @Mock
+    private ElderRepository elderRepository;
+
+    @Mock
+    private MealRecordRepository mealRecordRepository;
+
+    @Mock
+    private MedicationScheduleRepository medicationScheduleRepository;
+
+    @Mock
+    private MedicationTakenRecordRepository medicationTakenRecordRepository;
+
+    @Mock
+    private BloodSugarRecordRepository bloodSugarRecordRepository;
+
+    @Mock
+    private CareCallRecordRepository careCallRecordRepository;
+
+    @InjectMocks
+    private HomeService homeService;
+
+    private Elder testElder;
+    private LocalDate testDate;
+
+    @BeforeEach
+    void setUp() {
+        testElder = Elder.builder()
+                .id(1)
+                .name("김옥자")
+                .build();
+        testDate = LocalDate.now();
+    }
+
+    @Test
+    @DisplayName("홈 화면 데이터 조회 성공")
+    void getHomeData_성공() {
+        // given
+        Integer elderId = 1;
+
+        when(elderRepository.findById(elderId)).thenReturn(java.util.Optional.of(testElder));
+        when(mealRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(medicationScheduleRepository.findByElder(testElder))
+                .thenReturn(Collections.emptyList());
+        when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        HomeResponse response = homeService.getHomeData(elderId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getElderName()).isEqualTo("김옥자");
+        assertThat(response.getAISummary()).isEqualTo("TODO: AI 요약 기능 구현 필요");
+        assertThat(response.getMealStatus()).isNotNull();
+        assertThat(response.getMealStatus().getBreakfast()).isFalse();
+        assertThat(response.getMealStatus().getLunch()).isFalse();
+        assertThat(response.getMealStatus().getDinner()).isFalse();
+        assertThat(response.getMedicationStatus()).isNotNull();
+        assertThat(response.getMedicationStatus().getTotalTaken()).isEqualTo(0);
+        assertThat(response.getMedicationStatus().getTotalGoal()).isEqualTo(0);
+        assertThat(response.getSleep()).isNull();
+        assertThat(response.getHealthStatus()).isNull();
+        assertThat(response.getMentalStatus()).isNull();
+        assertThat(response.getBloodSugar()).isNull();
+    }
+
+    @Test
+    @DisplayName("홈 화면 데이터 조회 실패 - 어르신을 찾을 수 없음")
+    void getHomeData_실패_어르신없음() {
+        // given
+        Integer elderId = 999;
+
+        when(elderRepository.findById(elderId)).thenReturn(java.util.Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> homeService.getHomeData(elderId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("어르신을 찾을 수 없습니다");
+    }
+
+                    @Test
+                @DisplayName("홈 화면 데이터 조회 성공 - 식사 데이터 있음")
+                void getHomeData_성공_식사데이터있음() {
+                    // given
+                    Integer elderId = 1;
+
+                    // 식사 기록 생성
+                    MealRecord breakfastMeal = createMealRecord(1, (byte) 1);
+                    MealRecord lunchMeal = createMealRecord(2, (byte) 2);
+
+                    when(elderRepository.findById(elderId)).thenReturn(java.util.Optional.of(testElder));
+                    when(mealRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                            .thenReturn(Arrays.asList(breakfastMeal, lunchMeal));
+                    when(medicationScheduleRepository.findByElder(testElder))
+                            .thenReturn(Collections.emptyList());
+                    when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                            .thenReturn(Collections.emptyList());
+                    when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                            .thenReturn(Collections.emptyList());
+                    when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
+                            .thenReturn(Collections.emptyList());
+                    when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
+                            .thenReturn(Collections.emptyList());
+                    when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+                            .thenReturn(Collections.emptyList());
+
+                    // when
+                    HomeResponse response = homeService.getHomeData(elderId);
+
+                    // then
+                    assertThat(response.getMealStatus().getBreakfast()).isTrue();
+                    assertThat(response.getMealStatus().getLunch()).isTrue();
+                    assertThat(response.getMealStatus().getDinner()).isFalse();
+                }
+
+                @Test
+                @DisplayName("홈 화면 데이터 조회 성공 - 복약 스케줄 있음")
+                void getHomeData_성공_복약스케줄있음() {
+                    // given
+                    Integer elderId = 1;
+
+                    // 복약 스케줄 생성 (하루 3회 복용)
+                    MedicationSchedule morningSchedule = createMedicationSchedule(1, "혈압약", "MORNING");
+                    MedicationSchedule lunchSchedule = createMedicationSchedule(2, "혈압약", "LUNCH");
+                    MedicationSchedule dinnerSchedule = createMedicationSchedule(3, "혈압약", "DINNER");
+
+                    when(elderRepository.findById(elderId)).thenReturn(java.util.Optional.of(testElder));
+                    when(mealRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                            .thenReturn(Collections.emptyList());
+                    when(medicationScheduleRepository.findByElder(testElder))
+                            .thenReturn(Arrays.asList(morningSchedule, lunchSchedule, dinnerSchedule));
+                    when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                            .thenReturn(Collections.emptyList());
+                    when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                            .thenReturn(Collections.emptyList());
+                    when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
+                            .thenReturn(Collections.emptyList());
+                    when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
+                            .thenReturn(Collections.emptyList());
+                    when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+                            .thenReturn(Collections.emptyList());
+
+                    // when
+                    HomeResponse response = homeService.getHomeData(elderId);
+
+                    // then
+                    assertThat(response.getMedicationStatus()).isNotNull();
+                    assertThat(response.getMedicationStatus().getTotalGoal()).isEqualTo(3);
+                    assertThat(response.getMedicationStatus().getTotalTaken()).isEqualTo(0);
+                    assertThat(response.getMedicationStatus().getMedicationList()).hasSize(1);
+                    
+                    HomeResponse.MedicationInfo medicationInfo = response.getMedicationStatus().getMedicationList().get(0);
+                    assertThat(medicationInfo.getType()).isEqualTo("혈압약");
+                    assertThat(medicationInfo.getGoal()).isEqualTo(3); // 하루 3회 복용 목표
+                    assertThat(medicationInfo.getTaken()).isEqualTo(0);
+                }
+
+    private MealRecord createMealRecord(Integer id, Byte mealType) {
+        return MealRecord.builder()
+                .id(id)
+                .mealType(mealType)
+                .recordedAt(LocalDateTime.now())
+                .build();
+    }
+
+    private MedicationSchedule createMedicationSchedule(Integer id, String medicationName, String scheduleTime) {
+        Medication medication = Medication.builder()
+                .id(id)
+                .name(medicationName)
+                .build();
+
+        return MedicationSchedule.builder()
+                .id(id)
+                .medication(medication)
+                .scheduleTime(scheduleTime)
+                .build();
+    }
+} 


### PR DESCRIPTION
### Desc
- AI 요약 기능은 현재 미구현
  - API호출 시점을 고민중. 케어콜이 끝난 뒤에 별도 컬럼을 파서 저장하자?
  - 일단 임시 리터럴을 반환해주도록 처리하고 후속에서 별도로 구현한다
- Restful한 설계로 리팩토링을 고민중
  - `/elders/{elderId}/summary` 이런거? 후속에서 바꿀 때 다시 고민해보자.
- API SPEC
  - https://www.notion.so/API-23e6196331d2801191aae5ced24d484e
- `GET http://localhost:8080/api/view/home?elderId=1`
```
{
  "elderName": "테스트 어르신",
  "mealStatus": {
    "breakfast": true,
    "lunch": false,
    "dinner": false
  },
  "medicationStatus": {
    "totalTaken": 0,
    "totalGoal": 1,
    "nextMedicationTime": "MORNING",
    "medicationList": [
      {
        "type": "혈압약",
        "taken": 0,
        "goal": 1,
        "nextTime": "MORNING"
      }
    ]
  },
  "sleep": {
    "meanHours": 9,
    "meanMinutes": 15
  },
  "healthStatus": "새벽에 뒤척임, 수면 중간에 깸",
  "mentalStatus": "새벽에 뒤척임, 수면 중간에 깸",
  "bloodSugar": {
    "meanValue": 120
  },
  "aisummary": "TODO: AI 요약 기능 구현 필요"
}
```