### PR TITLE
refactor: RESTful APIs

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/view/BloodSugarController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/BloodSugarController.java
@@ -13,13 +13,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/view")
+@RequestMapping("/elders")
 @RequiredArgsConstructor
 @Tag(name = "Blood Sugar", description = "혈당 데이터 조회 API")
 public class BloodSugarController {
@@ -28,7 +29,7 @@ public class BloodSugarController {
 
     @Operation(
         summary = "주간 혈당 데이터 조회",
-        description = "사용자의 주간 혈당 기록을 식사 시간대(공복/식후) 기준으로 조회합니다."
+        description = "어르신의 주간 혈당 기록을 식사 시간대(공복/식후) 기준으로 조회합니다."
     )
     @ApiResponses({
         @ApiResponse(
@@ -48,10 +49,10 @@ public class BloodSugarController {
             description = "어르신 정보를 찾을 수 없음"
         )
     })
-    @GetMapping("/blood-sugar/weekly")
+    @GetMapping("/{elderId}/blood-sugar/weekly")
     public ResponseEntity<WeeklyBloodSugarResponse> getWeeklyBloodSugar(
         @Parameter(description = "어르신 식별자", required = true, example = "1")
-        @RequestParam("elderId") Integer elderId,
+        @PathVariable("elderId") Integer elderId,
 
         @Parameter(description = "주간 조회 시작일 (yyyy-MM-dd)", required = true, example = "2025-07-09")
         @RequestParam("startDate") String startDate,

--- a/src/main/java/com/example/medicare_call/controller/view/HomeController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/HomeController.java
@@ -13,13 +13,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/view")
+@RequestMapping("/elders")
 @RequiredArgsConstructor
 @Tag(name = "Home", description = "홈 화면 데이터 조회 API")
 public class HomeController {
@@ -48,10 +48,10 @@ public class HomeController {
             description = "어르신 정보를 찾을 수 없음"
         )
     })
-    @GetMapping("/home")
+    @GetMapping("/{elderId}/home")
     public ResponseEntity<HomeResponse> getHomeData(
         @Parameter(description = "조회할 어르신의 식별자", required = true, example = "1")
-        @RequestParam("elderId") Integer elderId
+        @PathVariable("elderId") Integer elderId
     ) {
         log.info("홈 화면 데이터 조회 요청: elderId={}", elderId);
 

--- a/src/main/java/com/example/medicare_call/controller/view/MealRecordController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/MealRecordController.java
@@ -13,13 +13,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/view")
+@RequestMapping("/elders")
 @RequiredArgsConstructor
 @Tag(name = "Meal Record", description = "식사 기록 조회 API")
 public class MealRecordController {
@@ -45,13 +46,13 @@ public class MealRecordController {
         ),
         @ApiResponse(
             responseCode = "404",
-            description = "보호자 정보를 찾을 수 없음"
+            description = "어르신 정보를 찾을 수 없음"
         )
     })
-    @GetMapping("/dailyMeal")
+    @GetMapping("/{elderId}/meals")
     public ResponseEntity<DailyMealResponse> getDailyMeals(
         @Parameter(description = "어르신 식별자", required = true, example = "1")
-        @RequestParam("elderId") Integer elderId,
+        @PathVariable("elderId") Integer elderId,
         
         @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", required = true, example = "2025-07-16")
         @RequestParam("date") String date

--- a/src/main/java/com/example/medicare_call/controller/view/MentalAnalysisController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/MentalAnalysisController.java
@@ -13,13 +13,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/view")
+@RequestMapping("/elders")
 @RequiredArgsConstructor
 @Tag(name = "Mental Analysis", description = "심리 상태 분석 조회 API")
 public class MentalAnalysisController {
@@ -48,10 +49,10 @@ public class MentalAnalysisController {
             description = "어르신 정보를 찾을 수 없음"
         )
     })
-    @GetMapping("/dailyMentalAnalysis")
+    @GetMapping("/{elderId}/mental-analysis")
     public ResponseEntity<DailyMentalAnalysisResponse> getDailyMentalAnalysis(
         @Parameter(description = "어르신 식별자", required = true, example = "1")
-        @RequestParam("elderId") Integer elderId,
+        @PathVariable("elderId") Integer elderId,
         
         @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", required = true, example = "2025-07-16")
         @RequestParam("date") String date

--- a/src/main/java/com/example/medicare_call/controller/view/SleepRecordController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/SleepRecordController.java
@@ -13,13 +13,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/view")
+@RequestMapping("/elders")
 @RequiredArgsConstructor
 @Tag(name = "Sleep Record", description = "수면 기록 조회 API")
 public class SleepRecordController {
@@ -48,10 +49,10 @@ public class SleepRecordController {
             description = "어르신 정보를 찾을 수 없음"
         )
     })
-    @GetMapping("/dailySleep")
+    @GetMapping("/{elderId}/sleep")
     public ResponseEntity<DailySleepResponse> getDailySleep(
         @Parameter(description = "어르신 식별자", required = true, example = "1")
-        @RequestParam("elderId") Integer elderId,
+        @PathVariable("elderId") Integer elderId,
         
         @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", required = true, example = "2025-07-16")
         @RequestParam("date") String date

--- a/src/test/java/com/example/medicare_call/controller/view/BloodSugarControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/BloodSugarControllerTest.java
@@ -85,8 +85,7 @@ class BloodSugarControllerTest {
                 .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(get("/view/blood-sugar/weekly")
-                        .param("elderId", elderId.toString())
+        mockMvc.perform(get("/elders/{elderId}/blood-sugar/weekly", elderId)
                         .param("startDate", startDate)
                         .param("type", type))
                 .andExpect(status().isOk())
@@ -129,8 +128,7 @@ class BloodSugarControllerTest {
                 .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(get("/view/blood-sugar/weekly")
-                        .param("elderId", elderId.toString())
+        mockMvc.perform(get("/elders/{elderId}/blood-sugar/weekly", elderId)
                         .param("startDate", startDate)
                         .param("type", type))
                 .andExpect(status().isOk())

--- a/src/test/java/com/example/medicare_call/controller/view/HomeControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/HomeControllerTest.java
@@ -81,8 +81,7 @@ class HomeControllerTest {
                 .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(get("/view/home")
-                        .param("elderId", elderId.toString()))
+        mockMvc.perform(get("/elders/{elderId}/home", elderId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.elderName").value("김옥자"))
                 .andExpect(jsonPath("$.aisummary").value("TODO: AI 요약 기능 구현 필요"))

--- a/src/test/java/com/example/medicare_call/controller/view/MealRecordControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/MealRecordControllerTest.java
@@ -57,8 +57,7 @@ class MealRecordControllerTest {
                 .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(get("/view/dailyMeal")
-                        .param("elderId", elderId.toString())
+        mockMvc.perform(get("/elders/{elderId}/meals", elderId)
                         .param("date", date))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.date").value(date))
@@ -89,8 +88,7 @@ class MealRecordControllerTest {
                 .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(get("/view/dailyMeal")
-                        .param("elderId", elderId.toString())
+        mockMvc.perform(get("/elders/{elderId}/meals", elderId)
                         .param("date", date))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.date").value(date))
@@ -121,8 +119,7 @@ class MealRecordControllerTest {
                 .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(get("/view/dailyMeal")
-                        .param("elderId", elderId.toString())
+        mockMvc.perform(get("/elders/{elderId}/meals", elderId)
                         .param("date", date))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.date").value(date))

--- a/src/test/java/com/example/medicare_call/controller/view/MentalAnalysisControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/MentalAnalysisControllerTest.java
@@ -54,8 +54,7 @@ class MentalAnalysisControllerTest {
                 .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(get("/view/dailyMentalAnalysis")
-                        .param("elderId", elderId.toString())
+        mockMvc.perform(get("/elders/{elderId}/mental-analysis", elderId)
                         .param("date", date))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.date").value(date))
@@ -80,8 +79,7 @@ class MentalAnalysisControllerTest {
                 .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(get("/view/dailyMentalAnalysis")
-                        .param("elderId", elderId.toString())
+        mockMvc.perform(get("/elders/{elderId}/mental-analysis", elderId)
                         .param("date", date))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.date").value(date))
@@ -105,8 +103,7 @@ class MentalAnalysisControllerTest {
                 .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(get("/view/dailyMentalAnalysis")
-                        .param("elderId", elderId.toString())
+        mockMvc.perform(get("/elders/{elderId}/mental-analysis", elderId)
                         .param("date", date))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.date").value(date))

--- a/src/test/java/com/example/medicare_call/controller/view/SleepRecordControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/SleepRecordControllerTest.java
@@ -58,8 +58,7 @@ class SleepRecordControllerTest {
                 .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(get("/view/dailySleep")
-                        .param("elderId", elderId.toString())
+        mockMvc.perform(get("/elders/{elderId}/sleep", elderId)
                         .param("date", date))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.date").value(date))
@@ -92,8 +91,7 @@ class SleepRecordControllerTest {
                 .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(get("/view/dailySleep")
-                        .param("elderId", elderId.toString())
+        mockMvc.perform(get("/elders/{elderId}/sleep", elderId)
                         .param("date", date))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.date").value(date))
@@ -126,8 +124,7 @@ class SleepRecordControllerTest {
                 .thenReturn(expectedResponse);
 
         // when & then
-        mockMvc.perform(get("/view/dailySleep")
-                        .param("elderId", elderId.toString())
+        mockMvc.perform(get("/elders/{elderId}/sleep", elderId)
                         .param("date", date))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.date").value(date))


### PR DESCRIPTION
### Desc
- 전화 컨텍스트에서 파싱한 엔드포인트들을 좀더 RESTful하게 설계하자
- 수면 데이터 조회
  - 기존: `/view/dailySleep?elderId=1&date=2025-07-16`
  - 변경: `/elders/{elderId}/sleep?date=2025-07-16`
- 식사 데이터 조회
  - 기존: `/view/dailyMeal?elderId=1&date=2025-07-16`
  - 변경: `/elders/{elderId}/meals?date=2025-07-16`
- 심리 상태 분석 조회
  - 기존: `/view/dailyMentalAnalysis?elderId=1&date=2025-07-16`
  - 변경: `/elders/{elderId}/mental-analysis?date=2025-07-16`
- 주간 혈당 데이터 조회
  - 기존: `/view/blood-sugar/weekly?elderId=1&startDate=2025-07-09&type=BEFORE_MEAL`
  - 변경: `/elders/{elderId}/blood-sugar/weekly?startDate=2025-07-09&type=BEFORE_MEAL`
- 홈 화면 데이터 조회
  - 기존: `/view/home?elderId=1`
  - 변경: `/elders/{elderId}/home`