### PR TITLE
refactor: LocalDate

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/view/BloodSugarController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/BloodSugarController.java
@@ -12,11 +12,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 @Slf4j
 @RestController
@@ -55,7 +58,7 @@ public class BloodSugarController {
         @PathVariable("elderId") Integer elderId,
 
         @Parameter(description = "주간 조회 시작일 (yyyy-MM-dd)", required = true, example = "2025-07-09")
-        @RequestParam("startDate") String startDate,
+        @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
 
         @Parameter(description = "식사 시간대", required = true, example = "BEFORE_MEAL", 
                   schema = @Schema(allowableValues = {"BEFORE_MEAL", "AFTER_MEAL"}))

--- a/src/main/java/com/example/medicare_call/controller/view/MealRecordController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/MealRecordController.java
@@ -12,11 +12,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 @Slf4j
 @RestController
@@ -55,7 +58,7 @@ public class MealRecordController {
         @PathVariable("elderId") Integer elderId,
         
         @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", required = true, example = "2025-07-16")
-        @RequestParam("date") String date
+        @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
         log.info("날짜별 식사 데이터 조회 요청: elderId={}, date={}", elderId, date);
         

--- a/src/main/java/com/example/medicare_call/controller/view/MentalAnalysisController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/MentalAnalysisController.java
@@ -12,11 +12,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 @Slf4j
 @RestController
@@ -55,7 +58,7 @@ public class MentalAnalysisController {
         @PathVariable("elderId") Integer elderId,
         
         @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", required = true, example = "2025-07-16")
-        @RequestParam("date") String date
+        @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
         log.info("날짜별 심리 상태 데이터 조회 요청: elderId={}, date={}", elderId, date);
         

--- a/src/main/java/com/example/medicare_call/controller/view/SleepRecordController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/SleepRecordController.java
@@ -12,11 +12,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 @Slf4j
 @RestController
@@ -55,7 +58,7 @@ public class SleepRecordController {
         @PathVariable("elderId") Integer elderId,
         
         @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", required = true, example = "2025-07-16")
-        @RequestParam("date") String date
+        @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
         log.info("날짜별 수면 데이터 조회 요청: elderId={}, date={}", elderId, date);
         

--- a/src/main/java/com/example/medicare_call/dto/DailyMealResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/DailyMealResponse.java
@@ -1,16 +1,20 @@
 package com.example.medicare_call.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDate;
 
 @Getter
 @Builder
 @Schema(description = "날짜별 식사 데이터 조회 응답")
 public class DailyMealResponse {
     
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @Schema(description = "조회한 날짜", example = "2025-07-16")
-    private String date;
+    private LocalDate date;
     
     @Schema(description = "각 식사 시간대별 기록")
     private Meals meals;

--- a/src/main/java/com/example/medicare_call/dto/DailyMentalAnalysisResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/DailyMentalAnalysisResponse.java
@@ -1,9 +1,11 @@
 package com.example.medicare_call.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -11,8 +13,9 @@ import java.util.List;
 @Schema(description = "날짜별 심리 상태 데이터 조회 응답")
 public class DailyMentalAnalysisResponse {
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @Schema(description = "조회 기준 날짜", example = "2025-07-16")
-    private String date;
+    private LocalDate date;
 
     @Schema(description = "심리 상태에 대한 사용자 입력 또는 시스템 요약 문장 리스트", 
             example = "[\"날씨가 좋아서 기분이 좋음\", \"어느 때와 비슷함\"]")

--- a/src/main/java/com/example/medicare_call/dto/DailySleepResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/DailySleepResponse.java
@@ -1,16 +1,20 @@
 package com.example.medicare_call.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDate;
 
 @Getter
 @Builder
 @Schema(description = "날짜별 수면 데이터 조회 응답")
 public class DailySleepResponse {
     
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @Schema(description = "조회 기준 날짜", example = "2025-07-16")
-    private String date;
+    private LocalDate date;
     
     @Schema(description = "총 수면 시간")
     private TotalSleep totalSleep;

--- a/src/main/java/com/example/medicare_call/dto/WeeklyBloodSugarResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/WeeklyBloodSugarResponse.java
@@ -1,10 +1,12 @@
 package com.example.medicare_call.dto;
 
 import com.example.medicare_call.global.enums.BloodSugarStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -28,19 +30,22 @@ public class WeeklyBloodSugarResponse {
     @Builder
     @Schema(description = "조회 구간")
     public static class Period {
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         @Schema(description = "조회 시작일", example = "2025-07-09")
-        private String startDate;
+        private LocalDate startDate;
 
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         @Schema(description = "조회 종료일", example = "2025-07-16")
-        private String endDate;
+        private LocalDate endDate;
     }
 
     @Getter
     @Builder
     @Schema(description = "혈당 측정 데이터")
     public static class BloodSugarData {
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         @Schema(description = "측정 날짜", example = "2025-07-09")
-        private String date;
+        private LocalDate date;
 
         @Schema(description = "혈당 수치 (mg/dL)", example = "120")
         private Integer value;

--- a/src/main/java/com/example/medicare_call/service/MealRecordService.java
+++ b/src/main/java/com/example/medicare_call/service/MealRecordService.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Slf4j
@@ -19,9 +18,7 @@ public class MealRecordService {
     
     private final MealRecordRepository mealRecordRepository;
     
-    public DailyMealResponse getDailyMeals(Integer elderId, String dateStr) {
-        LocalDate date = LocalDate.parse(dateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-        
+    public DailyMealResponse getDailyMeals(Integer elderId, LocalDate date) {
         List<MealRecord> mealRecords = mealRecordRepository.findByElderIdAndDate(elderId, date);
         
         String breakfast = null;
@@ -54,7 +51,7 @@ public class MealRecordService {
                 .build();
         
         return DailyMealResponse.builder()
-                .date(dateStr)
+                .date(date)
                 .meals(meals)
                 .build();
     }

--- a/src/main/java/com/example/medicare_call/service/MentalAnalysisService.java
+++ b/src/main/java/com/example/medicare_call/service/MentalAnalysisService.java
@@ -8,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,9 +18,7 @@ public class MentalAnalysisService {
 
     private final CareCallRecordRepository careCallRecordRepository;
 
-    public DailyMentalAnalysisResponse getDailyMentalAnalysis(Integer elderId, String dateStr) {
-        LocalDate date = LocalDate.parse(dateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-
+    public DailyMentalAnalysisResponse getDailyMentalAnalysis(Integer elderId, LocalDate date) {
         List<CareCallRecord> mentalRecords = careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(elderId, date);
 
         List<String> commentList = new ArrayList<>();
@@ -40,7 +37,7 @@ public class MentalAnalysisService {
         }
 
         return DailyMentalAnalysisResponse.builder()
-                .date(dateStr)
+                .date(date)
                 .commentList(commentList)
                 .build();
     }

--- a/src/main/java/com/example/medicare_call/service/SleepRecordService.java
+++ b/src/main/java/com/example/medicare_call/service/SleepRecordService.java
@@ -21,14 +21,12 @@ public class SleepRecordService {
     
     private final CareCallRecordRepository careCallRecordRepository;
     
-    public DailySleepResponse getDailySleep(Integer elderId, String dateStr) {
-        LocalDate date = LocalDate.parse(dateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-        
+    public DailySleepResponse getDailySleep(Integer elderId, LocalDate date) {
         List<CareCallRecord> sleepRecords = careCallRecordRepository.findByElderIdAndDateWithSleepData(elderId, date);
         
         if (sleepRecords.isEmpty()) {
             return DailySleepResponse.builder()
-                    .date(dateStr)
+                    .date(date)
                     .totalSleep(DailySleepResponse.TotalSleep.builder()
                             .hours(0)
                             .minutes(0)
@@ -72,7 +70,7 @@ public class SleepRecordService {
         }
         
         return DailySleepResponse.builder()
-                .date(dateStr)
+                .date(date)
                 .totalSleep(totalSleep)
                 .sleepTime(sleepTime)
                 .wakeTime(wakeTime)

--- a/src/main/java/com/example/medicare_call/service/WeeklyBloodSugarService.java
+++ b/src/main/java/com/example/medicare_call/service/WeeklyBloodSugarService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,8 +22,7 @@ public class WeeklyBloodSugarService {
 
     private final BloodSugarRecordRepository bloodSugarRecordRepository;
 
-    public WeeklyBloodSugarResponse getWeeklyBloodSugar(Integer elderId, String startDateStr, String typeStr) {
-        LocalDate startDate = LocalDate.parse(startDateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    public WeeklyBloodSugarResponse getWeeklyBloodSugar(Integer elderId, LocalDate startDate, String typeStr) {
         LocalDate endDate = startDate.plusDays(6); // 7일간 조회
 
         BloodSugarMeasurementType measurementType = BloodSugarMeasurementType.valueOf(typeStr);
@@ -44,8 +42,8 @@ public class WeeklyBloodSugarService {
 
         return WeeklyBloodSugarResponse.builder()
                 .period(WeeklyBloodSugarResponse.Period.builder()
-                        .startDate(startDateStr)
-                        .endDate(endDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                        .startDate(startDate)
+                        .endDate(endDate)
                         .build())
                 .data(data)
                 .average(average)
@@ -55,7 +53,7 @@ public class WeeklyBloodSugarService {
 
     private WeeklyBloodSugarResponse.BloodSugarData convertToBloodSugarData(BloodSugarRecord record) {
         return WeeklyBloodSugarResponse.BloodSugarData.builder()
-                .date(record.getRecordedAt().toLocalDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .date(record.getRecordedAt().toLocalDate())
                 .value(record.getBlood_sugar_value().intValue())
                 .status(record.getStatus())
                 .build();

--- a/src/test/java/com/example/medicare_call/controller/view/BloodSugarControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/BloodSugarControllerTest.java
@@ -17,10 +17,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
 
 @WebMvcTest(BloodSugarController.class)
 @AutoConfigureMockMvc(addFilters = false) // security 필터 비활성화
@@ -48,18 +51,18 @@ class BloodSugarControllerTest {
         String type = "BEFORE_MEAL";
 
         WeeklyBloodSugarResponse.Period period = WeeklyBloodSugarResponse.Period.builder()
-                .startDate("2025-07-09")
-                .endDate("2025-07-15")
+                .startDate(LocalDate.of(2025, 7, 9))
+                .endDate(LocalDate.of(2025, 7, 15))
                 .build();
 
         WeeklyBloodSugarResponse.BloodSugarData data1 = WeeklyBloodSugarResponse.BloodSugarData.builder()
-                .date("2025-07-09")
+                .date(LocalDate.of(2025, 7, 9))
                 .value(90)
                 .status(BloodSugarStatus.LOW)
                 .build();
 
         WeeklyBloodSugarResponse.BloodSugarData data2 = WeeklyBloodSugarResponse.BloodSugarData.builder()
-                .date("2025-07-10")
+                .date(LocalDate.of(2025, 7, 10))
                 .value(105)
                 .status(BloodSugarStatus.NORMAL)
                 .build();
@@ -81,7 +84,7 @@ class BloodSugarControllerTest {
                 .latest(latest)
                 .build();
 
-        when(weeklyBloodSugarService.getWeeklyBloodSugar(eq(elderId), eq(startDate), eq(type)))
+        when(weeklyBloodSugarService.getWeeklyBloodSugar(eq(elderId), any(LocalDate.class), eq(type)))
                 .thenReturn(expectedResponse);
 
         // when & then
@@ -113,8 +116,8 @@ class BloodSugarControllerTest {
         String type = "AFTER_MEAL";
 
         WeeklyBloodSugarResponse.Period period = WeeklyBloodSugarResponse.Period.builder()
-                .startDate("2025-07-09")
-                .endDate("2025-07-15")
+                .startDate(LocalDate.of(2025, 7, 9))
+                .endDate(LocalDate.of(2025, 7, 15))
                 .build();
 
         WeeklyBloodSugarResponse expectedResponse = WeeklyBloodSugarResponse.builder()
@@ -124,7 +127,7 @@ class BloodSugarControllerTest {
                 .latest(null)
                 .build();
 
-        when(weeklyBloodSugarService.getWeeklyBloodSugar(eq(elderId), eq(startDate), eq(type)))
+        when(weeklyBloodSugarService.getWeeklyBloodSugar(eq(elderId), any(LocalDate.class), eq(type)))
                 .thenReturn(expectedResponse);
 
         // when & then

--- a/src/test/java/com/example/medicare_call/controller/view/MealRecordControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/MealRecordControllerTest.java
@@ -13,10 +13,13 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
 
 @WebMvcTest(MealRecordController.class)
 @AutoConfigureMockMvc(addFilters = false) // security 필터 비활성화
@@ -49,11 +52,11 @@ class MealRecordControllerTest {
                 .build();
         
         DailyMealResponse expectedResponse = DailyMealResponse.builder()
-                .date(date)
+                .date(LocalDate.of(2025, 7, 16))
                 .meals(meals)
                 .build();
 
-        when(mealRecordService.getDailyMeals(eq(elderId), eq(date)))
+        when(mealRecordService.getDailyMeals(eq(elderId), any(LocalDate.class)))
                 .thenReturn(expectedResponse);
 
         // when & then
@@ -80,11 +83,11 @@ class MealRecordControllerTest {
                 .build();
         
         DailyMealResponse expectedResponse = DailyMealResponse.builder()
-                .date(date)
+                .date(LocalDate.of(2025, 7, 16))
                 .meals(meals)
                 .build();
 
-        when(mealRecordService.getDailyMeals(eq(elderId), eq(date)))
+        when(mealRecordService.getDailyMeals(eq(elderId), any(LocalDate.class)))
                 .thenReturn(expectedResponse);
 
         // when & then
@@ -111,11 +114,11 @@ class MealRecordControllerTest {
                 .build();
         
         DailyMealResponse expectedResponse = DailyMealResponse.builder()
-                .date(date)
+                .date(LocalDate.of(2025, 7, 16))
                 .meals(meals)
                 .build();
 
-        when(mealRecordService.getDailyMeals(eq(elderId), eq(date)))
+        when(mealRecordService.getDailyMeals(eq(elderId), any(LocalDate.class)))
                 .thenReturn(expectedResponse);
 
         // when & then

--- a/src/test/java/com/example/medicare_call/controller/view/MentalAnalysisControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/MentalAnalysisControllerTest.java
@@ -16,10 +16,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
 
 @WebMvcTest(MentalAnalysisController.class)
 @AutoConfigureMockMvc(addFilters = false) // security 필터 비활성화
@@ -46,11 +49,11 @@ class MentalAnalysisControllerTest {
         String date = "2025-07-16";
         
         DailyMentalAnalysisResponse expectedResponse = DailyMentalAnalysisResponse.builder()
-                .date(date)
+                .date(LocalDate.of(2025, 7, 16))
                 .commentList(Arrays.asList("날씨가 좋아서 기분이 좋음", "어느 때와 비슷함"))
                 .build();
 
-        when(mentalAnalysisService.getDailyMentalAnalysis(eq(elderId), eq(date)))
+        when(mentalAnalysisService.getDailyMentalAnalysis(eq(elderId), any(LocalDate.class)))
                 .thenReturn(expectedResponse);
 
         // when & then
@@ -71,11 +74,11 @@ class MentalAnalysisControllerTest {
         String date = "2025-07-16";
         
         DailyMentalAnalysisResponse expectedResponse = DailyMentalAnalysisResponse.builder()
-                .date(date)
+                .date(LocalDate.of(2025, 7, 16))
                 .commentList(Collections.singletonList("오늘은 기분이 좋음"))
                 .build();
 
-        when(mentalAnalysisService.getDailyMentalAnalysis(eq(elderId), eq(date)))
+        when(mentalAnalysisService.getDailyMentalAnalysis(eq(elderId), any(LocalDate.class)))
                 .thenReturn(expectedResponse);
 
         // when & then
@@ -95,11 +98,11 @@ class MentalAnalysisControllerTest {
         String date = "2025-07-16";
         
         DailyMentalAnalysisResponse expectedResponse = DailyMentalAnalysisResponse.builder()
-                .date(date)
+                .date(LocalDate.of(2025, 7, 16))
                 .commentList(Collections.emptyList())
                 .build();
 
-        when(mentalAnalysisService.getDailyMentalAnalysis(eq(elderId), eq(date)))
+        when(mentalAnalysisService.getDailyMentalAnalysis(eq(elderId), any(LocalDate.class)))
                 .thenReturn(expectedResponse);
 
         // when & then

--- a/src/test/java/com/example/medicare_call/controller/view/SleepRecordControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/SleepRecordControllerTest.java
@@ -13,10 +13,13 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
 
 @WebMvcTest(SleepRecordController.class)
 @AutoConfigureMockMvc(addFilters = false) // security 필터 비활성화
@@ -48,13 +51,13 @@ class SleepRecordControllerTest {
                 .build();
         
         DailySleepResponse expectedResponse = DailySleepResponse.builder()
-                .date(date)
+                .date(LocalDate.of(2025, 7, 16))
                 .totalSleep(totalSleep)
                 .sleepTime("22:12")
                 .wakeTime("06:00")
                 .build();
 
-        when(sleepRecordService.getDailySleep(eq(elderId), eq(date)))
+        when(sleepRecordService.getDailySleep(eq(elderId), any(LocalDate.class)))
                 .thenReturn(expectedResponse);
 
         // when & then
@@ -81,13 +84,13 @@ class SleepRecordControllerTest {
                 .build();
         
         DailySleepResponse expectedResponse = DailySleepResponse.builder()
-                .date(date)
+                .date(LocalDate.of(2025, 7, 16))
                 .totalSleep(totalSleep)
                 .sleepTime("22:00")
                 .wakeTime(null)
                 .build();
 
-        when(sleepRecordService.getDailySleep(eq(elderId), eq(date)))
+        when(sleepRecordService.getDailySleep(eq(elderId), any(LocalDate.class)))
                 .thenReturn(expectedResponse);
 
         // when & then
@@ -114,13 +117,13 @@ class SleepRecordControllerTest {
                 .build();
         
         DailySleepResponse expectedResponse = DailySleepResponse.builder()
-                .date(date)
+                .date(LocalDate.of(2025, 7, 16))
                 .totalSleep(totalSleep)
                 .sleepTime(null)
                 .wakeTime(null)
                 .build();
 
-        when(sleepRecordService.getDailySleep(eq(elderId), eq(date)))
+        when(sleepRecordService.getDailySleep(eq(elderId), any(LocalDate.class)))
                 .thenReturn(expectedResponse);
 
         // when & then

--- a/src/test/java/com/example/medicare_call/service/MealRecordServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/MealRecordServiceTest.java
@@ -78,7 +78,7 @@ class MealRecordServiceTest {
                 .thenReturn(mealRecords);
 
         // when
-        DailyMealResponse response = mealRecordService.getDailyMeals(1, dateStr);
+        DailyMealResponse response = mealRecordService.getDailyMeals(1, date);
 
         // then
         assertThat(response.getDate()).isEqualTo(dateStr);
@@ -102,7 +102,7 @@ class MealRecordServiceTest {
                 .thenReturn(mealRecords);
 
         // when
-        DailyMealResponse response = mealRecordService.getDailyMeals(1, dateStr);
+        DailyMealResponse response = mealRecordService.getDailyMeals(1, date);
 
         // then
         assertThat(response.getDate()).isEqualTo(dateStr);
@@ -121,7 +121,7 @@ class MealRecordServiceTest {
                 .thenReturn(Collections.emptyList());
 
         // when
-        DailyMealResponse response = mealRecordService.getDailyMeals(1, dateStr);
+        DailyMealResponse response = mealRecordService.getDailyMeals(1, date);
 
         // then
         assertThat(response.getDate()).isEqualTo(dateStr);

--- a/src/test/java/com/example/medicare_call/service/MentalAnalysisServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/MentalAnalysisServiceTest.java
@@ -69,7 +69,7 @@ class MentalAnalysisServiceTest {
                 .thenReturn(Arrays.asList(record1, record2));
 
         // when
-        DailyMentalAnalysisResponse response = mentalAnalysisService.getDailyMentalAnalysis(1, dateStr);
+        DailyMentalAnalysisResponse response = mentalAnalysisService.getDailyMentalAnalysis(1, testDate);
 
         // then
         assertThat(response.getDate()).isEqualTo(dateStr);
@@ -99,7 +99,7 @@ class MentalAnalysisServiceTest {
                 .thenReturn(Collections.singletonList(record));
 
         // when
-        DailyMentalAnalysisResponse response = mentalAnalysisService.getDailyMentalAnalysis(1, dateStr);
+        DailyMentalAnalysisResponse response = mentalAnalysisService.getDailyMentalAnalysis(1, testDate);
 
         // then
         assertThat(response.getDate()).isEqualTo(dateStr);
@@ -117,7 +117,7 @@ class MentalAnalysisServiceTest {
                 .thenReturn(Collections.emptyList());
 
         // when
-        DailyMentalAnalysisResponse response = mentalAnalysisService.getDailyMentalAnalysis(1, dateStr);
+        DailyMentalAnalysisResponse response = mentalAnalysisService.getDailyMentalAnalysis(1, testDate);
 
         // then
         assertThat(response.getDate()).isEqualTo(dateStr);
@@ -142,7 +142,7 @@ class MentalAnalysisServiceTest {
                 .thenReturn(Collections.singletonList(record));
 
         // when
-        DailyMentalAnalysisResponse response = mentalAnalysisService.getDailyMentalAnalysis(1, dateStr);
+        DailyMentalAnalysisResponse response = mentalAnalysisService.getDailyMentalAnalysis(1, testDate);
 
         // then
         assertThat(response.getDate()).isEqualTo(dateStr);

--- a/src/test/java/com/example/medicare_call/service/SleepRecordServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/SleepRecordServiceTest.java
@@ -82,7 +82,7 @@ class SleepRecordServiceTest {
                 .thenReturn(sleepRecords);
 
         // when
-        DailySleepResponse response = sleepRecordService.getDailySleep(1, dateStr);
+        DailySleepResponse response = sleepRecordService.getDailySleep(1, date);
 
         // then
         assertThat(response.getDate()).isEqualTo(dateStr);
@@ -114,7 +114,7 @@ class SleepRecordServiceTest {
                 .thenReturn(sleepRecords);
 
         // when
-        DailySleepResponse response = sleepRecordService.getDailySleep(1, dateStr);
+        DailySleepResponse response = sleepRecordService.getDailySleep(1, date);
 
         // then
         assertThat(response.getDate()).isEqualTo(dateStr);
@@ -134,7 +134,7 @@ class SleepRecordServiceTest {
                 .thenReturn(Collections.emptyList());
 
         // when
-        DailySleepResponse response = sleepRecordService.getDailySleep(1, dateStr);
+        DailySleepResponse response = sleepRecordService.getDailySleep(1, date);
 
         // then
         assertThat(response.getDate()).isEqualTo(dateStr);

--- a/src/test/java/com/example/medicare_call/service/WeeklyBloodSugarServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/WeeklyBloodSugarServiceTest.java
@@ -72,7 +72,7 @@ class WeeklyBloodSugarServiceTest {
                 .thenReturn(records);
 
         // when
-        WeeklyBloodSugarResponse response = weeklyBloodSugarService.getWeeklyBloodSugar(elderId, startDate, type);
+        WeeklyBloodSugarResponse response = weeklyBloodSugarService.getWeeklyBloodSugar(elderId, LocalDate.of(2025, 7, 9), type);
 
         // then
         assertThat(response).isNotNull();
@@ -100,7 +100,7 @@ class WeeklyBloodSugarServiceTest {
                 .thenReturn(Collections.emptyList());
 
         // when
-        WeeklyBloodSugarResponse response = weeklyBloodSugarService.getWeeklyBloodSugar(elderId, startDate, type);
+        WeeklyBloodSugarResponse response = weeklyBloodSugarService.getWeeklyBloodSugar(elderId, LocalDate.of(2025, 7, 9), type);
 
         // then
         assertThat(response).isNotNull();
@@ -128,7 +128,7 @@ class WeeklyBloodSugarServiceTest {
                 .thenReturn(records);
 
         // when
-        WeeklyBloodSugarResponse response = weeklyBloodSugarService.getWeeklyBloodSugar(elderId, startDate, type);
+        WeeklyBloodSugarResponse response = weeklyBloodSugarService.getWeeklyBloodSugar(elderId, LocalDate.of(2025, 7, 9), type);
 
         // then
         assertThat(response).isNotNull();


### PR DESCRIPTION
### Desc
- 컨트롤러에 ISO 8601형식으로 전될된 파라미터를 받아 String 형식의 파라미터를 LocalDate로 자동 변환
- 서비스에서 문자열 파싱 로직 제거. 컨트롤러에서 변경해준 대로 받아서 사용한다.
- DTO에서도 Jackson이 LocalDate 필드를 "yyyy-MM-dd" 형태의 문자열로 직렬화하도록 변경. 문자열로 처리하지 말자.