### PR TITLE
feat: 주간 통계 데이터 API 구현

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/view/WeeklyStatsController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/WeeklyStatsController.java
@@ -1,0 +1,68 @@
+package com.example.medicare_call.controller.view;
+
+import com.example.medicare_call.dto.WeeklyStatsResponse;
+import com.example.medicare_call.service.WeeklyStatsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@Slf4j
+@RestController
+@RequestMapping("/elders")
+@RequiredArgsConstructor
+@Tag(name = "Weekly Stats", description = "주간 통계 조회 API")
+public class WeeklyStatsController {
+
+    private final WeeklyStatsService weeklyStatsService;
+
+    @Operation(
+        summary = "주간 통계 데이터 조회",
+        description = "어르신의 주간 통계 데이터를 조회합니다. 식사, 복약, 수면, 심리 상태, 혈당 등의 통계를 제공합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "주간 통계 데이터 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = WeeklyStatsResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (날짜 형식 오류 등)"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "어르신 정보를 찾을 수 없음"
+        )
+    })
+    @GetMapping("/{elderId}/weekly-stats")
+    public ResponseEntity<WeeklyStatsResponse> getWeeklyStats(
+        @Parameter(description = "어르신 식별자", required = true, example = "1")
+        @PathVariable("elderId") Integer elderId,
+
+        @Parameter(description = "주간 통계를 조회할 시작 날짜 (yyyy-MM-dd)", required = true, example = "2025-07-15")
+        @RequestParam("startDate") LocalDate startDate
+    ) {
+        log.info("주간 통계 데이터 조회 요청: elderId={}, startDate={}", elderId, startDate);
+
+        WeeklyStatsResponse response = weeklyStatsService.getWeeklyStats(elderId, startDate);
+
+        return ResponseEntity.ok(response);
+    }
+} 

--- a/src/main/java/com/example/medicare_call/dto/WeeklyStatsResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/WeeklyStatsResponse.java
@@ -1,0 +1,129 @@
+package com.example.medicare_call.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+@Schema(description = "주간 통계 데이터 조회 응답")
+public class WeeklyStatsResponse {
+
+    @Schema(description = "어르신 이름", example = "김옥자")
+    private String elderName;
+
+    @Schema(description = "주간 요약 통계 정보")
+    private SummaryStats summaryStats;
+
+    @Schema(description = "식사 횟수 통계")
+    private MealStats mealStats;
+
+    @Schema(description = "복약 통계 (약물별 상세)")
+    private Map<String, MedicationStats> medicationStats;
+
+    @Schema(description = "AI가 생성한 건강 상태 요약 문장", example = "아침, 점심 복약과 식사는 문제 없으나...")
+    private String healthSummary;
+
+    @Schema(description = "평균 수면 시간")
+    private AverageSleep averageSleep;
+
+    @Schema(description = "심리 상태 요약")
+    private PsychSummary psychSummary;
+
+    @Schema(description = "혈당 상태 통계")
+    private BloodSugar bloodSugar;
+
+    @Getter
+    @Builder
+    @Schema(description = "주간 요약 통계 정보")
+    public static class SummaryStats {
+        @Schema(description = "식사율 (%)", example = "65")
+        private Integer mealRate;
+
+        @Schema(description = "복약률 (%)", example = "57")
+        private Integer medicationRate;
+
+        @Schema(description = "건강 이상 징후 횟수", example = "3")
+        private Integer healthSignals;
+
+        @Schema(description = "주간 미응답 건수", example = "8")
+        private Integer missedCalls;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "식사 횟수 통계")
+    public static class MealStats {
+        @Schema(description = "아침 식사 횟수", example = "7")
+        private Integer breakfast;
+
+        @Schema(description = "점심 식사 횟수", example = "5")
+        private Integer lunch;
+
+        @Schema(description = "저녁 식사 횟수", example = "0")
+        private Integer dinner;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "약물별 복용 통계")
+    public static class MedicationStats {
+        @Schema(description = "복용 예정 총 횟수", example = "14")
+        private Integer totalCount;
+
+        @Schema(description = "실제 복용한 횟수", example = "0")
+        private Integer takenCount;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "평균 수면 시간")
+    public static class AverageSleep {
+        @Schema(description = "평균 수면 시간 (시 단위)", example = "7")
+        private Integer hours;
+
+        @Schema(description = "평균 수면 시간 (분 단위)", example = "12")
+        private Integer minutes;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "심리 상태 요약")
+    public static class PsychSummary {
+        @Schema(description = "좋음 횟수", example = "4")
+        private Integer good;
+
+        @Schema(description = "보통 횟수", example = "4")
+        private Integer normal;
+
+        @Schema(description = "나쁨 횟수", example = "4")
+        private Integer bad;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "혈당 상태 통계")
+    public static class BloodSugar {
+        @Schema(description = "식전 혈당")
+        private BloodSugarType beforeMeal;
+
+        @Schema(description = "식후 혈당")
+        private BloodSugarType afterMeal;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "혈당 타입별 통계")
+    public static class BloodSugarType {
+        @Schema(description = "정상 횟수", example = "5")
+        private Integer normal;
+
+        @Schema(description = "높음 횟수", example = "2")
+        private Integer high;
+
+        @Schema(description = "낮음 횟수", example = "1")
+        private Integer low;
+    }
+} 

--- a/src/main/java/com/example/medicare_call/repository/BloodSugarRecordRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/BloodSugarRecordRepository.java
@@ -30,4 +30,11 @@ public interface BloodSugarRecordRepository extends JpaRepository<BloodSugarReco
            "AND DATE(bsr.recordedAt) = :date " +
            "ORDER BY bsr.recordedAt")
     List<BloodSugarRecord> findByElderIdAndDate(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
+
+    @Query("SELECT bsr FROM BloodSugarRecord bsr " +
+           "JOIN bsr.careCallRecord ccr " +
+           "WHERE ccr.elder.id = :elderId " +
+           "AND DATE(bsr.recordedAt) BETWEEN :startDate AND :endDate " +
+           "ORDER BY bsr.recordedAt")
+    List<BloodSugarRecord> findByElderIdAndDateBetween(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 } 

--- a/src/main/java/com/example/medicare_call/repository/CareCallRecordRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/CareCallRecordRepository.java
@@ -32,4 +32,31 @@ public interface CareCallRecordRepository extends JpaRepository<CareCallRecord, 
                    "AND ccr.healthDetails IS NOT NULL " +
                    "ORDER BY ccr.startTime")
             List<CareCallRecord> findByElderIdAndDateWithHealthData(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
+
+    @Query("SELECT ccr FROM CareCallRecord ccr " +
+           "WHERE ccr.elder.id = :elderId " +
+           "AND DATE(ccr.startTime) BETWEEN :startDate AND :endDate " +
+           "AND ccr.sleepStart IS NOT NULL " +
+           "ORDER BY ccr.startTime")
+    List<CareCallRecord> findByElderIdAndDateBetweenWithSleepData(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
+    @Query("SELECT ccr FROM CareCallRecord ccr " +
+           "WHERE ccr.elder.id = :elderId " +
+           "AND DATE(ccr.startTime) BETWEEN :startDate AND :endDate " +
+           "AND ccr.psychologicalDetails IS NOT NULL " +
+           "ORDER BY ccr.startTime")
+    List<CareCallRecord> findByElderIdAndDateBetweenWithPsychologicalData(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
+    @Query("SELECT ccr FROM CareCallRecord ccr " +
+           "WHERE ccr.elder.id = :elderId " +
+           "AND DATE(ccr.startTime) BETWEEN :startDate AND :endDate " +
+           "AND ccr.healthDetails IS NOT NULL " +
+           "ORDER BY ccr.startTime")
+    List<CareCallRecord> findByElderIdAndDateBetweenWithHealthData(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
+    @Query("SELECT ccr FROM CareCallRecord ccr " +
+           "WHERE ccr.elder.id = :elderId " +
+           "AND DATE(ccr.startTime) BETWEEN :startDate AND :endDate " +
+           "ORDER BY ccr.startTime")
+    List<CareCallRecord> findByElderIdAndDateBetween(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 } 

--- a/src/main/java/com/example/medicare_call/repository/MealRecordRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/MealRecordRepository.java
@@ -16,4 +16,11 @@ public interface MealRecordRepository extends JpaRepository<MealRecord, Integer>
            "AND DATE(mr.recordedAt) = :date " +
            "ORDER BY mr.recordedAt")
     List<MealRecord> findByElderIdAndDate(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
+
+    @Query("SELECT mr FROM MealRecord mr " +
+           "JOIN mr.careCallRecord ccr " +
+           "WHERE ccr.elder.id = :elderId " +
+           "AND DATE(mr.recordedAt) BETWEEN :startDate AND :endDate " +
+           "ORDER BY mr.recordedAt")
+    List<MealRecord> findByElderIdAndDateBetween(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 } 

--- a/src/main/java/com/example/medicare_call/repository/MedicationScheduleRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/MedicationScheduleRepository.java
@@ -3,9 +3,15 @@ package com.example.medicare_call.repository;
 import com.example.medicare_call.domain.MedicationSchedule;
 import com.example.medicare_call.domain.Elder;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface MedicationScheduleRepository extends JpaRepository<MedicationSchedule, Integer> {
     List<MedicationSchedule> findByElder(Elder elder);
+    
+    @Query("SELECT ms FROM MedicationSchedule ms " +
+           "WHERE ms.elder.id = :elderId")
+    List<MedicationSchedule> findByElderId(@Param("elderId") Integer elderId);
 } 

--- a/src/main/java/com/example/medicare_call/repository/MedicationTakenRecordRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/MedicationTakenRecordRepository.java
@@ -15,4 +15,10 @@ public interface MedicationTakenRecordRepository extends JpaRepository<Medicatio
            "WHERE ccr.elder.id = :elderId " +
            "AND DATE(mtr.recordedAt) = :date")
     List<MedicationTakenRecord> findByElderIdAndDate(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
+
+    @Query("SELECT mtr FROM MedicationTakenRecord mtr " +
+           "JOIN mtr.careCallRecord ccr " +
+           "WHERE ccr.elder.id = :elderId " +
+           "AND DATE(mtr.recordedAt) BETWEEN :startDate AND :endDate")
+    List<MedicationTakenRecord> findByElderIdAndDateBetween(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 } 

--- a/src/main/java/com/example/medicare_call/service/WeeklyStatsService.java
+++ b/src/main/java/com/example/medicare_call/service/WeeklyStatsService.java
@@ -1,0 +1,271 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.*;
+import com.example.medicare_call.dto.WeeklyStatsResponse;
+import com.example.medicare_call.global.enums.BloodSugarMeasurementType;
+import com.example.medicare_call.global.enums.BloodSugarStatus;
+import com.example.medicare_call.global.enums.MealType;
+import com.example.medicare_call.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WeeklyStatsService {
+
+    private final ElderRepository elderRepository;
+    private final MealRecordRepository mealRecordRepository;
+    private final MedicationScheduleRepository medicationScheduleRepository;
+    private final MedicationTakenRecordRepository medicationTakenRecordRepository;
+    private final CareCallRecordRepository careCallRecordRepository;
+    private final BloodSugarRecordRepository bloodSugarRecordRepository;
+
+    public WeeklyStatsResponse getWeeklyStats(Integer elderId, LocalDate startDate) {
+        LocalDate endDate = startDate.plusDays(6); // 7일간 조회
+
+        // 어르신 정보 조회
+        Elder elder = elderRepository.findById(elderId)
+                .orElseThrow(() -> new RuntimeException("어르신을 찾을 수 없습니다."));
+
+        // 1. 식사 통계
+        WeeklyStatsResponse.MealStats mealStats = getMealStats(elderId, startDate, endDate);
+
+        // 2. 복약 통계
+        Map<String, WeeklyStatsResponse.MedicationStats> medicationStats = getMedicationStats(elderId, startDate, endDate);
+
+        // 3. 수면 통계
+        WeeklyStatsResponse.AverageSleep averageSleep = getAverageSleep(elderId, startDate, endDate);
+
+        // 4. 심리 상태 통계
+        WeeklyStatsResponse.PsychSummary psychSummary = getPsychSummary(elderId, startDate, endDate);
+
+        // 5. 혈당 통계
+        WeeklyStatsResponse.BloodSugar bloodSugar = getBloodSugarStats(elderId, startDate, endDate);
+
+        // 6. 요약 통계 계산
+        WeeklyStatsResponse.SummaryStats summaryStats = calculateSummaryStats(
+                mealStats, medicationStats, elderId, startDate, endDate);
+
+        return WeeklyStatsResponse.builder()
+                .elderName(elder.getName())
+                .summaryStats(summaryStats)
+                .mealStats(mealStats)
+                .medicationStats(medicationStats)
+                .healthSummary("TODO: AI 요약 기능 구현 필요") // TODO: AI 요약 기능 구현
+                .averageSleep(averageSleep)
+                .psychSummary(psychSummary)
+                .bloodSugar(bloodSugar)
+                .build();
+    }
+
+    private WeeklyStatsResponse.MealStats getMealStats(Integer elderId, LocalDate startDate, LocalDate endDate) {
+        List<MealRecord> mealRecords = mealRecordRepository.findByElderIdAndDateBetween(elderId, startDate, endDate);
+
+        int breakfast = 0, lunch = 0, dinner = 0;
+
+        for (MealRecord record : mealRecords) {
+            MealType mealType = MealType.fromValue(record.getMealType());
+            if (mealType != null) {
+                switch (mealType) {
+                    case BREAKFAST:
+                        breakfast++;
+                        break;
+                    case LUNCH:
+                        lunch++;
+                        break;
+                    case DINNER:
+                        dinner++;
+                        break;
+                }
+            }
+        }
+
+        return WeeklyStatsResponse.MealStats.builder()
+                .breakfast(breakfast)
+                .lunch(lunch)
+                .dinner(dinner)
+                .build();
+    }
+
+    private Map<String, WeeklyStatsResponse.MedicationStats> getMedicationStats(Integer elderId, LocalDate startDate, LocalDate endDate) {
+        // 약물별 스케줄 조회
+        List<MedicationSchedule> schedules = medicationScheduleRepository.findByElderId(elderId);
+        Map<String, List<MedicationSchedule>> medicationSchedules = schedules.stream()
+                .collect(Collectors.groupingBy(schedule -> schedule.getMedication().getName()));
+
+        // 약물별 복용 기록 조회
+        List<MedicationTakenRecord> takenRecords = medicationTakenRecordRepository.findByElderIdAndDateBetween(elderId, startDate, endDate);
+        Map<String, Long> takenCounts = takenRecords.stream()
+                .collect(Collectors.groupingBy(
+                        record -> record.getMedicationSchedule().getMedication().getName(),
+                        Collectors.counting()
+                ));
+
+        Map<String, WeeklyStatsResponse.MedicationStats> result = new HashMap<>();
+
+        for (Map.Entry<String, List<MedicationSchedule>> entry : medicationSchedules.entrySet()) {
+            String medicationName = entry.getKey();
+            List<MedicationSchedule> medicationScheduleList = entry.getValue();
+
+            int totalCount = medicationScheduleList.size() * 7;
+            int takenCount = takenCounts.getOrDefault(medicationName, 0L).intValue();
+
+            result.put(medicationName, WeeklyStatsResponse.MedicationStats.builder()
+                    .totalCount(totalCount)
+                    .takenCount(takenCount)
+                    .build());
+        }
+
+        return result;
+    }
+
+    private WeeklyStatsResponse.AverageSleep getAverageSleep(Integer elderId, LocalDate startDate, LocalDate endDate) {
+        List<CareCallRecord> sleepRecords = careCallRecordRepository.findByElderIdAndDateBetweenWithSleepData(elderId, startDate, endDate);
+
+        if (sleepRecords.isEmpty()) {
+            return WeeklyStatsResponse.AverageSleep.builder()
+                    .hours(0)
+                    .minutes(0)
+                    .build();
+        }
+
+        long totalMinutes = 0;
+        int validRecords = 0;
+
+        for (CareCallRecord record : sleepRecords) {
+            if (record.getSleepStart() != null && record.getSleepEnd() != null) {
+                long minutes = ChronoUnit.MINUTES.between(record.getSleepStart(), record.getSleepEnd());
+                if (minutes > 0) {
+                    totalMinutes += minutes;
+                    validRecords++;
+                }
+            }
+        }
+
+        if (validRecords == 0) {
+            return WeeklyStatsResponse.AverageSleep.builder()
+                    .hours(0)
+                    .minutes(0)
+                    .build();
+        }
+
+        long averageMinutes = totalMinutes / validRecords;
+        int hours = (int) (averageMinutes / 60);
+        int minutes = (int) (averageMinutes % 60);
+
+        return WeeklyStatsResponse.AverageSleep.builder()
+                .hours(hours)
+                .minutes(minutes)
+                .build();
+    }
+
+    private WeeklyStatsResponse.PsychSummary getPsychSummary(Integer elderId, LocalDate startDate, LocalDate endDate) {
+        List<CareCallRecord> mentalRecords = careCallRecordRepository.findByElderIdAndDateBetweenWithPsychologicalData(elderId, startDate, endDate);
+
+        int good = 0, normal = 0, bad = 0;
+
+        for (CareCallRecord record : mentalRecords) {
+            if (record.getPsychStatus() != null) {
+                // psychStatus는 Byte 타입: 1=좋음, 0=나쁨
+                // TODO: refactor into Enum
+                if (record.getPsychStatus() == 1) {
+                    good++;
+                } else if (record.getPsychStatus() == 0) {
+                    bad++;
+                }
+            }
+        }
+
+        return WeeklyStatsResponse.PsychSummary.builder()
+                .good(good)
+                .normal(normal)
+                .bad(bad)
+                .build();
+    }
+
+    private WeeklyStatsResponse.BloodSugar getBloodSugarStats(Integer elderId, LocalDate startDate, LocalDate endDate) {
+        List<BloodSugarRecord> bloodSugarRecords = bloodSugarRecordRepository.findByElderIdAndDateBetween(elderId, startDate, endDate);
+
+        Map<BloodSugarMeasurementType, Map<BloodSugarStatus, Integer>> stats = new HashMap<>();
+        stats.put(BloodSugarMeasurementType.BEFORE_MEAL, new HashMap<>());
+        stats.put(BloodSugarMeasurementType.AFTER_MEAL, new HashMap<>());
+
+        for (BloodSugarRecord record : bloodSugarRecords) {
+            BloodSugarMeasurementType type = record.getMeasurementType();
+            BloodSugarStatus status = record.getStatus();
+
+            if (type != null && status != null) {
+                Map<BloodSugarStatus, Integer> typeStats = stats.get(type);
+                typeStats.put(status, typeStats.getOrDefault(status, 0) + 1);
+            }
+        }
+
+        WeeklyStatsResponse.BloodSugarType beforeMeal = WeeklyStatsResponse.BloodSugarType.builder()
+                .normal(stats.get(BloodSugarMeasurementType.BEFORE_MEAL).getOrDefault(BloodSugarStatus.NORMAL, 0))
+                .high(stats.get(BloodSugarMeasurementType.BEFORE_MEAL).getOrDefault(BloodSugarStatus.HIGH, 0))
+                .low(stats.get(BloodSugarMeasurementType.BEFORE_MEAL).getOrDefault(BloodSugarStatus.LOW, 0))
+                .build();
+
+        WeeklyStatsResponse.BloodSugarType afterMeal = WeeklyStatsResponse.BloodSugarType.builder()
+                .normal(stats.get(BloodSugarMeasurementType.AFTER_MEAL).getOrDefault(BloodSugarStatus.NORMAL, 0))
+                .high(stats.get(BloodSugarMeasurementType.AFTER_MEAL).getOrDefault(BloodSugarStatus.HIGH, 0))
+                .low(stats.get(BloodSugarMeasurementType.AFTER_MEAL).getOrDefault(BloodSugarStatus.LOW, 0))
+                .build();
+
+        return WeeklyStatsResponse.BloodSugar.builder()
+                .beforeMeal(beforeMeal)
+                .afterMeal(afterMeal)
+                .build();
+    }
+
+    private WeeklyStatsResponse.SummaryStats calculateSummaryStats(
+            WeeklyStatsResponse.MealStats mealStats,
+            Map<String, WeeklyStatsResponse.MedicationStats> medicationStats,
+            Integer elderId, LocalDate startDate, LocalDate endDate) {
+
+        // 식사율 계산 (7일 * 3끼 = 21끼 중 실제 식사한 횟수), 소숫점 버림
+        int totalMeals = mealStats.getBreakfast() + mealStats.getLunch() + mealStats.getDinner();
+        int mealRate = totalMeals == 0 ? 0 : (int) Math.round((double) totalMeals / 21 * 100);
+
+        // 복약률 계산
+        int totalMedicationCount = 0;
+        int totalTakenCount = 0;
+        for (WeeklyStatsResponse.MedicationStats stats : medicationStats.values()) {
+            totalMedicationCount += stats.getTotalCount();
+            totalTakenCount += stats.getTakenCount();
+        }
+        int medicationRate = totalMedicationCount == 0 ? 0 : (int) Math.round((double) totalTakenCount / totalMedicationCount * 100);
+
+        // 건강 이상 징후 횟수 (CareCallRecord에서 healthDetails가 있는 건수)
+        List<CareCallRecord> healthRecords = careCallRecordRepository.findByElderIdAndDateBetweenWithHealthData(elderId, startDate, endDate);
+        int healthSignals = (int) healthRecords.stream()
+                .filter(record -> record.getHealthDetails() != null && !record.getHealthDetails().trim().isEmpty())
+                .count();
+
+        // 미응답 건수 (callStatus가 failed인 건수)
+        // TODO: Twilio에서 실제 상태값이 어떻게 정의되는지를 확인하고, 이에 알맞도록 수정
+        List<CareCallRecord> callRecords = careCallRecordRepository.findByElderIdAndDateBetween(elderId, startDate, endDate);
+        int missedCalls = (int) callRecords.stream()
+                .filter(record -> "failed".equals(record.getCallStatus()))
+                .count();
+
+        return WeeklyStatsResponse.SummaryStats.builder()
+                .mealRate(mealRate)
+                .medicationRate(medicationRate)
+                .healthSignals(healthSignals)
+                .missedCalls(missedCalls)
+                .build();
+    }
+} 

--- a/src/test/java/com/example/medicare_call/controller/view/WeeklyStatsControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/WeeklyStatsControllerTest.java
@@ -1,0 +1,143 @@
+package com.example.medicare_call.controller.view;
+
+import com.example.medicare_call.dto.WeeklyStatsResponse;
+import com.example.medicare_call.global.jwt.JwtProvider;
+import com.example.medicare_call.service.WeeklyStatsService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(WeeklyStatsController.class)
+@AutoConfigureMockMvc(addFilters = false) // security 필터 비활성화
+@ActiveProfiles("test")
+class WeeklyStatsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private WeeklyStatsService weeklyStatsService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("주간 통계 데이터 조회 성공")
+    void getWeeklyStats_성공() throws Exception {
+        // given
+        Integer elderId = 1;
+        LocalDate startDate = LocalDate.of(2025, 7, 15);
+
+        WeeklyStatsResponse.SummaryStats summaryStats = WeeklyStatsResponse.SummaryStats.builder()
+                .mealRate(65)
+                .medicationRate(57)
+                .healthSignals(3)
+                .missedCalls(8)
+                .build();
+
+        WeeklyStatsResponse.MealStats mealStats = WeeklyStatsResponse.MealStats.builder()
+                .breakfast(7)
+                .lunch(5)
+                .dinner(0)
+                .build();
+
+        Map<String, WeeklyStatsResponse.MedicationStats> medicationStats = new HashMap<>();
+        medicationStats.put("혈압약", WeeklyStatsResponse.MedicationStats.builder()
+                .totalCount(14)
+                .takenCount(0)
+                .build());
+        medicationStats.put("영양제", WeeklyStatsResponse.MedicationStats.builder()
+                .totalCount(7)
+                .takenCount(4)
+                .build());
+
+        WeeklyStatsResponse.AverageSleep averageSleep = WeeklyStatsResponse.AverageSleep.builder()
+                .hours(7)
+                .minutes(12)
+                .build();
+
+        WeeklyStatsResponse.PsychSummary psychSummary = WeeklyStatsResponse.PsychSummary.builder()
+                .good(4)
+                .normal(4)
+                .bad(4)
+                .build();
+
+        WeeklyStatsResponse.BloodSugarType beforeMeal = WeeklyStatsResponse.BloodSugarType.builder()
+                .normal(5)
+                .high(2)
+                .low(1)
+                .build();
+
+        WeeklyStatsResponse.BloodSugarType afterMeal = WeeklyStatsResponse.BloodSugarType.builder()
+                .normal(5)
+                .high(0)
+                .low(2)
+                .build();
+
+        WeeklyStatsResponse.BloodSugar bloodSugar = WeeklyStatsResponse.BloodSugar.builder()
+                .beforeMeal(beforeMeal)
+                .afterMeal(afterMeal)
+                .build();
+
+        WeeklyStatsResponse expectedResponse = WeeklyStatsResponse.builder()
+                .elderName("김옥자")
+                .summaryStats(summaryStats)
+                .mealStats(mealStats)
+                .medicationStats(medicationStats)
+                .healthSummary("아침, 점심 복약과 식사는 문제 없으나...")
+                .averageSleep(averageSleep)
+                .psychSummary(psychSummary)
+                .bloodSugar(bloodSugar)
+                .build();
+
+        when(weeklyStatsService.getWeeklyStats(eq(elderId), eq(startDate)))
+                .thenReturn(expectedResponse);
+
+        // when & then
+        mockMvc.perform(get("/elders/{elderId}/weekly-stats", elderId)
+                        .param("startDate", startDate.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.elderName").value("김옥자"))
+                .andExpect(jsonPath("$.summaryStats.mealRate").value(65))
+                .andExpect(jsonPath("$.summaryStats.medicationRate").value(57))
+                .andExpect(jsonPath("$.summaryStats.healthSignals").value(3))
+                .andExpect(jsonPath("$.summaryStats.missedCalls").value(8))
+                .andExpect(jsonPath("$.mealStats.breakfast").value(7))
+                .andExpect(jsonPath("$.mealStats.lunch").value(5))
+                .andExpect(jsonPath("$.mealStats.dinner").value(0))
+                .andExpect(jsonPath("$.medicationStats.혈압약.totalCount").value(14))
+                .andExpect(jsonPath("$.medicationStats.혈압약.takenCount").value(0))
+                .andExpect(jsonPath("$.medicationStats.영양제.totalCount").value(7))
+                .andExpect(jsonPath("$.medicationStats.영양제.takenCount").value(4))
+                .andExpect(jsonPath("$.healthSummary").value("아침, 점심 복약과 식사는 문제 없으나..."))
+                .andExpect(jsonPath("$.averageSleep.hours").value(7))
+                .andExpect(jsonPath("$.averageSleep.minutes").value(12))
+                .andExpect(jsonPath("$.psychSummary.good").value(4))
+                .andExpect(jsonPath("$.psychSummary.normal").value(4))
+                .andExpect(jsonPath("$.psychSummary.bad").value(4))
+                .andExpect(jsonPath("$.bloodSugar.beforeMeal.normal").value(5))
+                .andExpect(jsonPath("$.bloodSugar.beforeMeal.high").value(2))
+                .andExpect(jsonPath("$.bloodSugar.beforeMeal.low").value(1))
+                .andExpect(jsonPath("$.bloodSugar.afterMeal.normal").value(5))
+                .andExpect(jsonPath("$.bloodSugar.afterMeal.high").value(0))
+                .andExpect(jsonPath("$.bloodSugar.afterMeal.low").value(2));
+    }
+} 

--- a/src/test/java/com/example/medicare_call/service/WeeklyStatsServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/WeeklyStatsServiceTest.java
@@ -1,0 +1,164 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.*;
+import com.example.medicare_call.dto.WeeklyStatsResponse;
+import com.example.medicare_call.global.enums.BloodSugarMeasurementType;
+import com.example.medicare_call.global.enums.BloodSugarStatus;
+import com.example.medicare_call.global.enums.MealType;
+import com.example.medicare_call.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WeeklyStatsServiceTest {
+
+    @Mock
+    private ElderRepository elderRepository;
+
+    @Mock
+    private MealRecordRepository mealRecordRepository;
+
+    @Mock
+    private MedicationScheduleRepository medicationScheduleRepository;
+
+    @Mock
+    private MedicationTakenRecordRepository medicationTakenRecordRepository;
+
+    @Mock
+    private CareCallRecordRepository careCallRecordRepository;
+
+    @Mock
+    private BloodSugarRecordRepository bloodSugarRecordRepository;
+
+    @InjectMocks
+    private WeeklyStatsService weeklyStatsService;
+
+    private Elder testElder;
+    private CareCallRecord testCallRecord;
+    private Medication testMedication;
+    private MedicationSchedule testMedicationSchedule;
+
+    @BeforeEach
+    void setUp() {
+        testElder = Elder.builder()
+                .id(1)
+                .name("김옥자")
+                .build();
+
+        testCallRecord = CareCallRecord.builder()
+                .id(1)
+                .elder(testElder)
+                .startTime(LocalDateTime.now())
+                .build();
+
+        testMedication = Medication.builder()
+                .id(1)
+                .name("혈압약")
+                .build();
+
+        testMedicationSchedule = MedicationSchedule.builder()
+                .id(1)
+                .medication(testMedication)
+                .scheduleTime("MORNING")
+                .build();
+    }
+
+    @Test
+    @DisplayName("주간 통계 데이터 조회 성공")
+    void getWeeklyStats_성공() {
+        // given
+        Integer elderId = 1;
+        LocalDate startDate = LocalDate.of(2025, 7, 15);
+        LocalDate endLocalDate = LocalDate.of(2025, 7, 21);
+
+        when(elderRepository.findById(elderId)).thenReturn(java.util.Optional.of(testElder));
+
+        // 식사 기록 모킹
+        List<MealRecord> mealRecords = Arrays.asList(
+                createMealRecord(1, MealType.BREAKFAST),
+                createMealRecord(2, MealType.LUNCH)
+        );
+        when(mealRecordRepository.findByElderIdAndDateBetween(eq(elderId), eq(startDate), eq(endLocalDate)))
+                .thenReturn(mealRecords);
+
+        // 복약 스케줄 모킹
+        when(medicationScheduleRepository.findByElderId(elderId))
+                .thenReturn(Arrays.asList(testMedicationSchedule));
+
+        // 복용 기록 모킹
+        when(medicationTakenRecordRepository.findByElderIdAndDateBetween(eq(elderId), eq(startDate), eq(endLocalDate)))
+                .thenReturn(Collections.emptyList());
+
+        // 수면 기록 모킹
+        when(careCallRecordRepository.findByElderIdAndDateBetweenWithSleepData(eq(elderId), eq(startDate), eq(endLocalDate)))
+                .thenReturn(Collections.emptyList());
+
+        // 심리 상태 기록 모킹
+        when(careCallRecordRepository.findByElderIdAndDateBetweenWithPsychologicalData(eq(elderId), eq(startDate), eq(endLocalDate)))
+                .thenReturn(Collections.emptyList());
+
+        // 혈당 기록 모킹
+        when(bloodSugarRecordRepository.findByElderIdAndDateBetween(eq(elderId), eq(startDate), eq(endLocalDate)))
+                .thenReturn(Collections.emptyList());
+
+        // 건강 상태 기록 모킹
+        when(careCallRecordRepository.findByElderIdAndDateBetweenWithHealthData(eq(elderId), eq(startDate), eq(endLocalDate)))
+                .thenReturn(Collections.emptyList());
+
+        // 통화 기록 모킹
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), eq(startDate), eq(endLocalDate)))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        WeeklyStatsResponse response = weeklyStatsService.getWeeklyStats(elderId, startDate);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getElderName()).isEqualTo("김옥자");
+        assertThat(response.getSummaryStats().getMealRate()).isEqualTo(10); // 2/21 * 100 ≈ 10
+        assertThat(response.getSummaryStats().getMedicationRate()).isEqualTo(0);
+        assertThat(response.getSummaryStats().getHealthSignals()).isEqualTo(0);
+        assertThat(response.getSummaryStats().getMissedCalls()).isEqualTo(0);
+        assertThat(response.getMealStats().getBreakfast()).isEqualTo(1);
+        assertThat(response.getMealStats().getLunch()).isEqualTo(1);
+        assertThat(response.getMealStats().getDinner()).isEqualTo(0);
+        assertThat(response.getAverageSleep().getHours()).isEqualTo(0);
+        assertThat(response.getAverageSleep().getMinutes()).isEqualTo(0);
+        assertThat(response.getPsychSummary().getGood()).isEqualTo(0);
+        assertThat(response.getPsychSummary().getNormal()).isEqualTo(0);
+        assertThat(response.getPsychSummary().getBad()).isEqualTo(0);
+        assertThat(response.getBloodSugar().getBeforeMeal().getNormal()).isEqualTo(0);
+        assertThat(response.getBloodSugar().getBeforeMeal().getHigh()).isEqualTo(0);
+        assertThat(response.getBloodSugar().getBeforeMeal().getLow()).isEqualTo(0);
+        assertThat(response.getBloodSugar().getAfterMeal().getNormal()).isEqualTo(0);
+        assertThat(response.getBloodSugar().getAfterMeal().getHigh()).isEqualTo(0);
+        assertThat(response.getBloodSugar().getAfterMeal().getLow()).isEqualTo(0);
+    }
+
+    private MealRecord createMealRecord(Integer id, MealType mealType) {
+        return MealRecord.builder()
+                .id(id)
+                .careCallRecord(testCallRecord)
+                .mealType(mealType.getValue())
+                .responseSummary("식사 내용")
+                .recordedAt(LocalDateTime.now())
+                .build();
+    }
+} 


### PR DESCRIPTION
### Desc
- API SPEC
  - https://www.notion.so/API-23e6196331d28059b817c3de77ad76f3
- 별도로 job을 돌릴 필요 없이, db 쿼리 만으로도 통계 산출이 가능한 정보들이 대부분이라 단순 API로 구현
- 홈 화면 조회 API와 동일하게, AI 코멘트 쪽은 아직 미구현. 리터럴을 내려주고 있고 후속으로 구현 예정. 별다른 특이사항이 없다면 API 호출시마다 서드파티 api를 호출할 것 같다.
- 전화 미응답 횟수를 필드로 내려주는데, 이 부분은 Twilio쪽 전화 실데이터가 DB에 쌓일 때, 상태값이 어떻게 들어오는지를 보고 다시 한 번 수정해줘야 함
- `psychStatus`를 단순 바이트 컬럼으로 쓰고 있는데 이것도 후속으로 Enum으로 마이그레이션 예정에 있다.
- `GET http://localhost:8080/api/elders/1/weekly-stats?guardianId=1&startDate=2025-08-01`
```
{
  "elderName": "테스트 어르신",
  "summaryStats": {
    "mealRate": 24,
    "medicationRate": 14,
    "healthSignals": 11,
    "missedCalls": 0
  },
  "mealStats": {
    "breakfast": 5,
    "lunch": 0,
    "dinner": 0
  },
  "medicationStats": {
    "혈압약": {
      "totalCount": 7,
      "takenCount": 1
    }
  },
  "healthSummary": "TODO: AI 요약 기능 구현 필요",
  "averageSleep": {
    "hours": 8,
    "minutes": 37
  },
  "psychSummary": {
    "good": 5,
    "normal": 0,
    "bad": 2
  },
  "bloodSugar": {
    "fasting": {
      "normal": 0,
      "high": 0,
      "low": 0
    },
    "postMeal": {
      "normal": 1,
      "high": 0,
      "low": 0
    }
  }
}
```