### PR TITLE
refactor: `ResourceNotFoundException`

### DIFF
--- a/src/main/java/com/example/medicare_call/service/CallDataService.java
+++ b/src/main/java/com/example/medicare_call/service/CallDataService.java
@@ -4,6 +4,7 @@ import com.example.medicare_call.domain.*;
 import com.example.medicare_call.dto.CallDataRequest;
 import com.example.medicare_call.dto.HealthDataExtractionRequest;
 import com.example.medicare_call.dto.HealthDataExtractionResponse;
+import com.example.medicare_call.global.ResourceNotFoundException;
 import com.example.medicare_call.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,10 +33,10 @@ public class CallDataService {
         log.info("통화 데이터 저장 시작: elderId={}, settingId={}", request.getElderId(), request.getSettingId());
         
         Elder elder = elderRepository.findById(request.getElderId())
-                .orElseThrow(() -> new IllegalArgumentException("어르신을 찾을 수 없습니다: " + request.getElderId()));
+                .orElseThrow(() -> new ResourceNotFoundException("어르신을 찾을 수 없습니다: " + request.getElderId()));
         
         CareCallSetting setting = careCallSettingRepository.findById(request.getSettingId())
-                .orElseThrow(() -> new IllegalArgumentException("통화 설정을 찾을 수 없습니다: " + request.getSettingId()));
+                .orElseThrow(() -> new ResourceNotFoundException("통화 설정을 찾을 수 없습니다: " + request.getSettingId()));
         
         String transcriptionText = null;
         if (request.getTranscription() != null && request.getTranscription().getFullText() != null) {

--- a/src/main/java/com/example/medicare_call/service/ElderHealthInfoService.java
+++ b/src/main/java/com/example/medicare_call/service/ElderHealthInfoService.java
@@ -2,6 +2,7 @@ package com.example.medicare_call.service;
 
 import com.example.medicare_call.dto.ElderHealthRegisterRequest;
 import com.example.medicare_call.domain.*;
+import com.example.medicare_call.global.ResourceNotFoundException;
 import com.example.medicare_call.repository.*;
 import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ public class ElderHealthInfoService {
     public void registerElderHealthInfo(Integer elderId, ElderHealthRegisterRequest request) {
         // TODO : 이쪽 Exception에 대한 Monitoring 추가 필요. 데이터의 무결성이 깨졌을 확률이 높다
        Elder elder = elderRepository.findById(elderId)
-               .orElseThrow(() -> new IllegalArgumentException("어르신을 찾을 수 없습니다. elderId: " + elderId));
+               .orElseThrow(() -> new ResourceNotFoundException("어르신을 찾을 수 없습니다. elderId: " + elderId));
 
        // 질환 등록
        for (String diseaseName : request.getDiseaseNames()) {

--- a/src/main/java/com/example/medicare_call/service/ElderService.java
+++ b/src/main/java/com/example/medicare_call/service/ElderService.java
@@ -2,6 +2,7 @@ package com.example.medicare_call.service;
 
 import com.example.medicare_call.dto.ElderRegisterRequest;
 import com.example.medicare_call.domain.Elder;
+import com.example.medicare_call.global.ResourceNotFoundException;
 import com.example.medicare_call.global.enums.Gender;
 import com.example.medicare_call.repository.ElderRepository;
 import com.example.medicare_call.repository.MemberRepository;
@@ -20,7 +21,7 @@ public class ElderService {
     @Transactional
     public Elder registerElder(@Valid ElderRegisterRequest request) {
         Member guardian = memberRepository.findById(request.getGuardianId())
-            .orElseThrow(() -> new IllegalArgumentException("보호자 없음"));
+            .orElseThrow(() -> new ResourceNotFoundException("보호자를 찾을 수 없습니다: " + request.getGuardianId()));
         Elder elder = Elder.builder()
             .name(request.getName())
             .birthDate(request.getBirthDate())

--- a/src/main/java/com/example/medicare_call/service/HomeService.java
+++ b/src/main/java/com/example/medicare_call/service/HomeService.java
@@ -7,6 +7,7 @@ import com.example.medicare_call.domain.MealRecord;
 import com.example.medicare_call.domain.MedicationSchedule;
 import com.example.medicare_call.domain.MedicationTakenRecord;
 import com.example.medicare_call.dto.HomeResponse;
+import com.example.medicare_call.global.ResourceNotFoundException;
 import com.example.medicare_call.global.enums.MealType;
 import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import com.example.medicare_call.repository.BloodSugarRecordRepository;
@@ -48,7 +49,7 @@ public class HomeService {
 
         // 어르신 정보 조회
         Elder elder = elderRepository.findById(elderId)
-                .orElseThrow(() -> new RuntimeException("어르신을 찾을 수 없습니다: " + elderId));
+                .orElseThrow(() -> new ResourceNotFoundException("어르신을 찾을 수 없습니다: " + elderId));
 
         // 오늘의 식사 기록 조회
         List<MealRecord> todayMeals = mealRecordRepository.findByElderIdAndDate(elderId, today);

--- a/src/test/java/com/example/medicare_call/service/CallDataServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/CallDataServiceTest.java
@@ -6,6 +6,7 @@ import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.dto.CallDataRequest;
 import com.example.medicare_call.dto.HealthDataExtractionRequest;
 import com.example.medicare_call.dto.HealthDataExtractionResponse;
+import com.example.medicare_call.global.ResourceNotFoundException;
 import com.example.medicare_call.repository.CareCallRecordRepository;
 import com.example.medicare_call.repository.CareCallSettingRepository;
 import com.example.medicare_call.repository.ElderRepository;
@@ -229,7 +230,7 @@ class CallDataServiceTest {
 
         // when & then
         assertThatThrownBy(() -> callDataService.saveCallData(request))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("어르신을 찾을 수 없습니다: 999");
         
         verify(elderRepository).findById(999);
@@ -256,7 +257,7 @@ class CallDataServiceTest {
 
         // when & then
         assertThatThrownBy(() -> callDataService.saveCallData(request))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("통화 설정을 찾을 수 없습니다: 999");
         
         verify(elderRepository).findById(1);

--- a/src/test/java/com/example/medicare_call/service/ElderHealthInfoServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/ElderHealthInfoServiceTest.java
@@ -2,6 +2,7 @@ package com.example.medicare_call.service;
 
 import com.example.medicare_call.domain.*;
 import com.example.medicare_call.dto.ElderHealthRegisterRequest;
+import com.example.medicare_call.global.ResourceNotFoundException;
 import com.example.medicare_call.global.enums.ElderHealthNoteType;
 import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import com.example.medicare_call.repository.*;
@@ -14,6 +15,7 @@ import org.mockito.MockitoAnnotations;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -56,5 +58,22 @@ class ElderHealthInfoServiceTest {
         verify(elderDiseaseRepository, times(1)).save(any(ElderDisease.class));
         verify(medicationScheduleRepository, times(1)).save(any(MedicationSchedule.class));
         verify(elderHealthInfoRepository, times(1)).save(any(ElderHealthInfo.class));
+    }
+
+    @Test
+    void registerElderHealthInfo_fail_elderNotFound() {
+        // given
+        ElderHealthRegisterRequest request = ElderHealthRegisterRequest.builder()
+                .diseaseNames(List.of("당뇨"))
+                .medicationSchedules(List.of())
+                .notes(List.of())
+                .build();
+
+        when(elderRepository.findById(999)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> elderHealthInfoService.registerElderHealthInfo(999, request))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("어르신을 찾을 수 없습니다. elderId: 999");
     }
 } 

--- a/src/test/java/com/example/medicare_call/service/ElderServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/ElderServiceTest.java
@@ -2,6 +2,7 @@ package com.example.medicare_call.service;
 
 import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.dto.ElderRegisterRequest;
+import com.example.medicare_call.global.ResourceNotFoundException;
 import com.example.medicare_call.global.enums.ElderRelation;
 import com.example.medicare_call.global.enums.ResidenceType;
 import com.example.medicare_call.global.enums.Gender;
@@ -20,6 +21,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -61,5 +63,26 @@ class ElderServiceTest {
 
         Elder result = elderService.registerElder(req);
         assertThat(result.getName()).isEqualTo("홍길동");
+    }
+
+    @Test
+    @DisplayName("어르신 등록 실패 - 보호자를 찾을 수 없음")
+    void registerElder_fail_guardianNotFound() {
+        // given
+        ElderRegisterRequest req = new ElderRegisterRequest();
+        req.setName("홍길동");
+        req.setBirthDate(LocalDate.of(1940, 5, 1));
+        req.setGender(Gender.MALE);
+        req.setPhone("01012345678");
+        req.setRelationship(ElderRelation.GRANDCHILD);
+        req.setResidenceType(ResidenceType.ALONE);
+        req.setGuardianId(999);
+
+        when(memberRepository.findById(999)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> elderService.registerElder(req))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("보호자를 찾을 수 없습니다: 999");
     }
 } 

--- a/src/test/java/com/example/medicare_call/service/HomeServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/HomeServiceTest.java
@@ -6,6 +6,7 @@ import com.example.medicare_call.domain.Medication;
 import com.example.medicare_call.domain.MedicationSchedule;
 import com.example.medicare_call.domain.MedicationTakenRecord;
 import com.example.medicare_call.dto.HomeResponse;
+import com.example.medicare_call.global.ResourceNotFoundException;
 import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import com.example.medicare_call.repository.BloodSugarRecordRepository;
 import com.example.medicare_call.repository.CareCallRecordRepository;
@@ -122,8 +123,8 @@ class HomeServiceTest {
 
         // when & then
         assertThatThrownBy(() -> homeService.getHomeData(elderId))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("어르신을 찾을 수 없습니다");
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("어르신을 찾을 수 없습니다: 999");
     }
 
                     @Test


### PR DESCRIPTION
### Desc
- API 요청시, 파라미터로 전달받은 값을 바탕으로 DB에서 엔티티를 찾지 못하는 상황에 대해서는 `ResourceNotFoundException`이 적절하다
- `IllegalArgumentException`을 사용하던 부분들, 테스트를 알맞게 수정하자.