### PR TITLE
feat: 공지사항 api 구현

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/view/NoticeController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/NoticeController.java
@@ -1,0 +1,34 @@
+package com.example.medicare_call.controller.view;
+
+import com.example.medicare_call.dto.NoticeResponse;
+import com.example.medicare_call.service.NoticeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/notices")
+@RequiredArgsConstructor
+@Tag(name = "공지사항", description = "공지사항 관련 API")
+public class NoticeController {
+    
+    private final NoticeService noticeService;
+    
+    @GetMapping
+    @Operation(summary = "공지사항 목록 조회", description = "모든 공지사항을 게시일 기준 내림차순으로 조회합니다.")
+    public ResponseEntity<List<NoticeResponse>> getNotices() {
+        log.info("공지사항 목록 조회 요청");
+        
+        List<NoticeResponse> notices = noticeService.getAllNotices();
+        
+        return ResponseEntity.ok(notices);
+    }
+} 

--- a/src/main/java/com/example/medicare_call/domain/Notice.java
+++ b/src/main/java/com/example/medicare_call/domain/Notice.java
@@ -1,0 +1,41 @@
+package com.example.medicare_call.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notice")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notice {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false)
+    private String title;
+    
+    @Column(nullable = false)
+    private String author;
+    
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String contents;
+    
+    @Column(name = "published_at", nullable = false)
+    private LocalDate publishedAt;
+    
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+    
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+} 

--- a/src/main/java/com/example/medicare_call/dto/NoticeResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/NoticeResponse.java
@@ -1,0 +1,32 @@
+package com.example.medicare_call.dto;
+
+import com.example.medicare_call.domain.Notice;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeResponse {
+    
+    private Long id;
+    private String title;
+    private String author;
+    private String contents;
+    private String publishedAt;
+    
+    public static NoticeResponse from(Notice notice) {
+        return NoticeResponse.builder()
+                .id(notice.getId())
+                .title(notice.getTitle())
+                .author(notice.getAuthor())
+                .contents(notice.getContents())
+                .publishedAt(notice.getPublishedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .build();
+    }
+} 

--- a/src/main/java/com/example/medicare_call/repository/NoticeRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/NoticeRepository.java
@@ -1,0 +1,12 @@
+package com.example.medicare_call.repository;
+
+import com.example.medicare_call.domain.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    List<Notice> findAllByOrderByPublishedAtDesc();
+} 

--- a/src/main/java/com/example/medicare_call/service/NoticeService.java
+++ b/src/main/java/com/example/medicare_call/service/NoticeService.java
@@ -1,0 +1,35 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.Notice;
+import com.example.medicare_call.dto.NoticeResponse;
+import com.example.medicare_call.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeService {
+    
+    private final NoticeRepository noticeRepository;
+
+    public List<NoticeResponse> getAllNotices() {
+        log.info("공지사항 목록 조회 시작");
+        
+        List<Notice> notices = noticeRepository.findAllByOrderByPublishedAtDesc();
+        
+        List<NoticeResponse> responses = notices.stream()
+                .map(NoticeResponse::from)
+                .collect(Collectors.toList());
+        
+        log.info("공지사항 목록 조회 완료: {}건", responses.size());
+        
+        return responses;
+    }
+} 

--- a/src/main/resources/db/migration/V10__create_notice_table.sql
+++ b/src/main/resources/db/migration/V10__create_notice_table.sql
@@ -1,0 +1,14 @@
+-- 공지사항 테이블 생성
+CREATE TABLE notice (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    author VARCHAR(100) NOT NULL,
+    contents TEXT NOT NULL,
+    published_at DATE NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 샘플 데이터 삽입
+INSERT INTO notice (title, author, contents, published_at) VALUES
+('메디케어콜 서비스 안내', '관리자', '안녕하세요. 메디케어콜 서비스입니다. 많은 이용 부탁드립니다.', '2025-07-01');

--- a/src/test/java/com/example/medicare_call/controller/view/NoticeControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/NoticeControllerTest.java
@@ -1,0 +1,98 @@
+package com.example.medicare_call.controller.view;
+
+import com.example.medicare_call.dto.NoticeResponse;
+import com.example.medicare_call.global.jwt.JwtProvider;
+import com.example.medicare_call.service.NoticeService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(NoticeController.class)
+@TestPropertySource(properties = {
+    "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration"
+})
+class NoticeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private NoticeService noticeService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("공지사항 목록 조회 성공")
+    void getNotices_success() throws Exception {
+        // given
+        List<NoticeResponse> notices = Arrays.asList(
+                NoticeResponse.builder()
+                        .id(1L)
+                        .title("메디케어콜 서비스 오픈 안내")
+                        .author("관리자")
+                        .contents("안녕하세요. 메디케어콜 서비스를 정식 오픈합니다.")
+                        .publishedAt("2025-07-01")
+                        .build(),
+                NoticeResponse.builder()
+                        .id(2L)
+                        .title("7월 정기 점검 안내")
+                        .author("운영팀")
+                        .contents("7월 15일(월) 오전 2시부터 4시까지 정기 점검이 진행됩니다.")
+                        .publishedAt("2025-07-10")
+                        .build()
+        );
+
+        when(noticeService.getAllNotices()).thenReturn(notices);
+
+        // when & then
+        mockMvc.perform(get("/notices")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].title").value("메디케어콜 서비스 오픈 안내"))
+                .andExpect(jsonPath("$[0].author").value("관리자"))
+                .andExpect(jsonPath("$[0].contents").value("안녕하세요. 메디케어콜 서비스를 정식 오픈합니다."))
+                .andExpect(jsonPath("$[0].publishedAt").value("2025-07-01"))
+                .andExpect(jsonPath("$[1].id").value(2))
+                .andExpect(jsonPath("$[1].title").value("7월 정기 점검 안내"))
+                .andExpect(jsonPath("$[1].author").value("운영팀"))
+                .andExpect(jsonPath("$[1].contents").value("7월 15일(월) 오전 2시부터 4시까지 정기 점검이 진행됩니다."))
+                .andExpect(jsonPath("$[1].publishedAt").value("2025-07-10"));
+    }
+
+    @Test
+    @DisplayName("공지사항 목록 조회 - 빈 목록")
+    void getNotices_empty() throws Exception {
+        // given
+        when(noticeService.getAllNotices()).thenReturn(Arrays.asList());
+
+        // when & then
+        mockMvc.perform(get("/notices")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+} 

--- a/src/test/java/com/example/medicare_call/service/NoticeServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/NoticeServiceTest.java
@@ -1,0 +1,82 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.Notice;
+import com.example.medicare_call.dto.NoticeResponse;
+import com.example.medicare_call.repository.NoticeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeServiceTest {
+
+    @Mock
+    private NoticeRepository noticeRepository;
+
+    @InjectMocks
+    private NoticeService noticeService;
+
+    @Test
+    @DisplayName("공지사항 목록 조회 성공")
+    void getAllNotices_success() {
+        // given
+        Notice notice1 = Notice.builder()
+                .id(1L)
+                .title("메디케어콜 서비스 오픈 안내")
+                .author("관리자")
+                .contents("안녕하세요. 메디케어콜 서비스를 정식 오픈합니다.")
+                .publishedAt(LocalDate.of(2025, 7, 1))
+                .build();
+
+        Notice notice2 = Notice.builder()
+                .id(2L)
+                .title("7월 정기 점검 안내")
+                .author("운영팀")
+                .contents("7월 15일(월) 오전 2시부터 4시까지 정기 점검이 진행됩니다.")
+                .publishedAt(LocalDate.of(2025, 7, 10))
+                .build();
+
+        List<Notice> notices = Arrays.asList(notice1, notice2);
+        when(noticeRepository.findAllByOrderByPublishedAtDesc()).thenReturn(notices);
+
+        // when
+        List<NoticeResponse> result = noticeService.getAllNotices();
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(1L);
+        assertThat(result.get(0).getTitle()).isEqualTo("메디케어콜 서비스 오픈 안내");
+        assertThat(result.get(0).getAuthor()).isEqualTo("관리자");
+        assertThat(result.get(0).getContents()).isEqualTo("안녕하세요. 메디케어콜 서비스를 정식 오픈합니다.");
+        assertThat(result.get(0).getPublishedAt()).isEqualTo("2025-07-01");
+
+        assertThat(result.get(1).getId()).isEqualTo(2L);
+        assertThat(result.get(1).getTitle()).isEqualTo("7월 정기 점검 안내");
+        assertThat(result.get(1).getAuthor()).isEqualTo("운영팀");
+        assertThat(result.get(1).getContents()).isEqualTo("7월 15일(월) 오전 2시부터 4시까지 정기 점검이 진행됩니다.");
+        assertThat(result.get(1).getPublishedAt()).isEqualTo("2025-07-10");
+    }
+
+    @Test
+    @DisplayName("공지사항 목록 조회 - 빈 목록")
+    void getAllNotices_empty() {
+        // given
+        when(noticeRepository.findAllByOrderByPublishedAtDesc()).thenReturn(Arrays.asList());
+
+        // when
+        List<NoticeResponse> result = noticeService.getAllNotices();
+
+        // then
+        assertThat(result).isEmpty();
+    }
+} 


### PR DESCRIPTION
### Desc
- 앱에서 공지사항을 조회하기 위한 API 추가
- API SPEC
  - https://www.notion.so/API-23e6196331d28022b2b8f2593f659bda
- 공지사항 등록은 별도로 엔드포인트를 구현하지 않음. 관리자용 계정 구현이 필요할듯?