### PR TITLE
feat: RefreshToken 추가

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -52,6 +52,7 @@ jobs:
             JWT_SECRET="${{ secrets.JWT_SECRET }}"
             JWT_ACCESS_EXPIRATION="${{secrets.JWT_ACCESS_EXPIRATION}}"
             JWT_PHONE_EXPIRATION="${{secrets.JWT_PHONE_EXPIRATION}}"
+            JWT_REFRESH_EXPIRATION_DAYS="${{secrets.JWT_REFRESH_EXPIRATION_DAYS}}"
             REDIS_HOST="${{ secrets.REDIS_HOST }}"
             REDIS_PORT="${{ secrets.REDIS_PORT }}"
             SMS_KEY="${{ secrets.SMS_KEY }}"
@@ -84,6 +85,7 @@ jobs:
             -e JWT_SECRET="${JWT_SECRET}" \
             -e JWT_ACCESS_EXPIRATION="${JWT_ACCESS_EXPIRATION}" \
             -e JWT_PHONE_EXPIRATION="${JWT_PHONE_EXPIRATION}" \
+            -e JWT_REFRESH_EXPIRATION_DAYS="${JWT_REFRESH_EXPIRATION_DAYS}" \
             -e REDIS_HOST="${REDIS_HOST}" \
             -e REDIS_PORT="${REDIS_PORT}" \
             -e SMS_KEY="${SMS_KEY}" \

--- a/src/main/java/com/example/medicare_call/controller/action/MemberController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/MemberController.java
@@ -1,6 +1,7 @@
 package com.example.medicare_call.controller.action;
 
 import com.example.medicare_call.dto.RegisterRequest;
+import com.example.medicare_call.dto.TokenResponse;
 import com.example.medicare_call.global.annotation.AuthPhone;
 import com.example.medicare_call.service.AuthService;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -22,9 +23,9 @@ public class MemberController {
     private final AuthService authService;
 
     @PostMapping("")
-    public ResponseEntity<String> register(@Parameter(hidden = true) @AuthPhone String phone,
+    public ResponseEntity<TokenResponse> register(@Parameter(hidden = true) @AuthPhone String phone,
                                            @Valid @RequestBody RegisterRequest signUpDto) {
-        String accessTokenResponse = authService.register(phone,signUpDto);
-        return ResponseEntity.ok(accessTokenResponse);
+        TokenResponse tokenResponse = authService.register(phone,signUpDto);
+        return ResponseEntity.ok(tokenResponse);
     }
 }

--- a/src/main/java/com/example/medicare_call/controller/action/TokenController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/TokenController.java
@@ -1,6 +1,7 @@
 package com.example.medicare_call.controller.action;
 
 import com.example.medicare_call.dto.TokenResponse;
+import com.example.medicare_call.global.jwt.JwtProvider;
 import com.example.medicare_call.service.RefreshTokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class TokenController {
     
     private final RefreshTokenService refreshTokenService;
+    private final JwtProvider jwtProvider;
     
     @PostMapping("/refresh")
     @Operation(summary = "Access Token 갱신", description = "Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.")
@@ -35,7 +37,7 @@ public class TokenController {
         String token = authorization.replace("Bearer ", "");
         
         // 토큰에서 사용자 ID 추출
-        Long memberId = refreshTokenService.getMemberIdFromToken(token);
+        Long memberId = jwtProvider.getMemberId(token);
         
         // Refresh Token 삭제
         refreshTokenService.deleteRefreshToken(memberId.intValue());

--- a/src/main/java/com/example/medicare_call/controller/action/TokenController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/TokenController.java
@@ -1,0 +1,47 @@
+package com.example.medicare_call.controller.action;
+
+import com.example.medicare_call.dto.TokenResponse;
+import com.example.medicare_call.service.RefreshTokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+@Tag(name = "토큰 관리", description = "토큰 관련 API")
+public class TokenController {
+    
+    private final RefreshTokenService refreshTokenService;
+    
+    @PostMapping("/refresh")
+    @Operation(summary = "Access Token 갱신", description = "Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.")
+    public ResponseEntity<TokenResponse> refreshToken(@RequestHeader("Refresh-Token") String refreshToken) {
+        log.info("Access Token 갱신 요청: {}", refreshToken);
+        
+        TokenResponse tokenResponse = refreshTokenService.refreshAccessToken(refreshToken);
+        
+        return ResponseEntity.ok(tokenResponse);
+    }
+    
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "사용자의 Refresh Token을 삭제합니다.")
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authorization) {
+        // Authorization 헤더에서 토큰 추출 (Bearer 제거)
+        String token = authorization.replace("Bearer ", "");
+        
+        // 토큰에서 사용자 ID 추출
+        Long memberId = refreshTokenService.getMemberIdFromToken(token);
+        
+        // Refresh Token 삭제
+        refreshTokenService.deleteRefreshToken(memberId.intValue());
+        
+        log.info("로그아웃 완료 - Member ID: {}", memberId);
+        
+        return ResponseEntity.ok().build();
+    }
+} 

--- a/src/main/java/com/example/medicare_call/domain/RefreshToken.java
+++ b/src/main/java/com/example/medicare_call/domain/RefreshToken.java
@@ -1,0 +1,41 @@
+package com.example.medicare_call.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_token")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshToken {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "member_id", nullable = false)
+    private Integer memberId;
+    
+    @Column(nullable = false)
+    private String token;
+    
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+    
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+    
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+    
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiresAt);
+    }
+} 

--- a/src/main/java/com/example/medicare_call/dto/SmsVerificationResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/SmsVerificationResponse.java
@@ -10,18 +10,19 @@ public class SmsVerificationResponse {
     private boolean verified;
     private String message;
     private MemberStatus memberStatus;
-    private String nextAction;
-    private String token; // 기존 회원인 경우
+    private String token; // 신규 회원인 경우 phone verification token
+    private String accessToken; // 기존 회원인 경우 access token
+    private String refreshToken; // 기존 회원인 경우 refresh token
 
 
 
-    public static SmsVerificationResponse forExistingMember(String accessToken) {
+    public static SmsVerificationResponse forExistingMember(String accessToken, String refreshToken) {
         return SmsVerificationResponse.builder()
                 .verified(true)
                 .message("인증이 완료되었습니다. 로그인되었습니다.")
                 .memberStatus(MemberStatus.EXISTING_MEMBER)
-                .nextAction("HOME")
-                .token(accessToken)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 
@@ -30,7 +31,6 @@ public class SmsVerificationResponse {
                 .verified(true)
                 .message("인증이 완료되었습니다. 회원 정보를 입력해주세요.")
                 .memberStatus(MemberStatus.NEW_MEMBER)
-                .nextAction("REGISTER")
                 .token(phoneVerificationToken)
                 .build();
     }

--- a/src/main/java/com/example/medicare_call/dto/TokenResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/TokenResponse.java
@@ -1,0 +1,27 @@
+package com.example.medicare_call.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponse {
+    
+    private String accessToken;
+    private String refreshToken;
+    @Builder.Default
+    private String tokenType = "Bearer";
+    private Long expiresIn; // Access Token 만료 시간 (초)
+    
+    public static TokenResponse of(String accessToken, String refreshToken, Long expiresIn) {
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .expiresIn(expiresIn)
+                .build();
+    }
+} 

--- a/src/main/java/com/example/medicare_call/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/medicare_call/global/jwt/JwtAuthenticationFilter.java
@@ -46,15 +46,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private Authentication getAuthentication(String token) {
         try {
-            // Access Token인지 확인 (id 클레임 존재)
-            Long memberId = jwtProvider.getMemberId(token);
-            log.info("Extracted memberId from Access Token: {}", memberId);
-            return new JwtTokenAuthentication(memberId);
+            // Access Token인지 확인
+            if (jwtProvider.isAccessToken(token)) {
+                Long memberId = jwtProvider.getMemberId(token);
+                log.info("Extracted memberId from Access Token: {}", memberId);
+                return new JwtTokenAuthentication(memberId);
+            } else {
+                // Phone Token인 경우
+                String phone = jwtProvider.getPhone(token);
+                log.info("Extracted phone from Phone Token: {}", phone);
+                return new JwtPhoneTokenAuthentication(phone);
+            }
         } catch (Exception e) {
-            // Phone Token인 경우 (phone 클레임 존재)
-            String phone = jwtProvider.getPhone(token);
-            log.info("Extracted phone from Phone Token: {}", phone);
-            return new JwtTokenAuthentication(-1L);
+            log.error("토큰 인증 처리 중 오류 발생: {}", e.getMessage());
+            return null;
         }
     }
 }

--- a/src/main/java/com/example/medicare_call/global/jwt/JwtProvider.java
+++ b/src/main/java/com/example/medicare_call/global/jwt/JwtProvider.java
@@ -95,6 +95,25 @@ public class JwtProvider {
     public Long getMemberId(String token) {
         return Long.parseLong(getClaims(token).get("id").toString());
     }
-    public String getPhone(String token) {return  getClaims(token).get("phone").toString();}
+    
+    public String getPhone(String token) {
+        return getClaims(token).get("phone").toString();
+    }
+    
+    public String getTokenCategory(String token) {
+        return getClaims(token).get("category").toString();
+    }
+    
+    public boolean isAccessToken(String token) {
+        try {
+            return "access".equals(getTokenCategory(token));
+        } catch (Exception e) {
+            return false;
+        }
+    }
+    
+    public Long getAccessTokenExpirationMillis() {
+        return ACCESS_TOKEN_EXPIRE_MILLIS;
+    }
 
 }

--- a/src/main/java/com/example/medicare_call/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/RefreshTokenRepository.java
@@ -1,0 +1,25 @@
+package com.example.medicare_call.repository;
+
+import com.example.medicare_call.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    
+    Optional<RefreshToken> findByToken(String token);
+    
+    Optional<RefreshToken> findByMemberId(Integer memberId);
+    
+    @Modifying
+    @Query("DELETE FROM RefreshToken rt WHERE rt.expiresAt < :now")
+    void deleteExpiredTokens(@Param("now") LocalDateTime now);
+    
+    void deleteByMemberId(Integer memberId);
+} 

--- a/src/main/java/com/example/medicare_call/service/RefreshTokenService.java
+++ b/src/main/java/com/example/medicare_call/service/RefreshTokenService.java
@@ -1,0 +1,111 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.Member;
+import com.example.medicare_call.domain.RefreshToken;
+import com.example.medicare_call.dto.TokenResponse;
+import com.example.medicare_call.global.ResourceNotFoundException;
+import com.example.medicare_call.global.jwt.JwtProvider;
+import com.example.medicare_call.repository.MemberRepository;
+import com.example.medicare_call.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RefreshTokenService {
+    
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
+    
+    @Value("${jwt.refreshTokenExpirationDays}")
+    private Integer refreshTokenExpirationDays;
+    
+    /**
+     * Refresh Token을 생성하고 DB에 저장
+     */
+    public RefreshToken createRefreshToken(Member member) {
+        // 기존 Refresh Token이 있다면 삭제
+        refreshTokenRepository.deleteByMemberId(member.getId());
+        
+        // 새로운 Refresh Token 생성 (UUID 기반)
+        String tokenValue = UUID.randomUUID().toString();
+        LocalDateTime expiresAt = LocalDateTime.now().plusDays(refreshTokenExpirationDays);
+        
+        RefreshToken refreshToken = RefreshToken.builder()
+                .memberId(member.getId())
+                .token(tokenValue)
+                .expiresAt(expiresAt)
+                .build();
+        
+        return refreshTokenRepository.save(refreshToken);
+    }
+    
+    /**
+     * Refresh Token으로 새로운 Access Token을 발급
+     */
+    public TokenResponse refreshAccessToken(String refreshTokenValue) {
+        // Refresh Token 조회
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
+                .orElseThrow(() -> new ResourceNotFoundException("유효하지 않은 Refresh Token입니다."));
+        
+        // 만료시 SMS 재인증 필요
+        if (refreshToken.isExpired()) {
+            refreshTokenRepository.delete(refreshToken);
+            throw new IllegalArgumentException("만료된 Refresh Token입니다.");
+        }
+        
+        // Member 조회
+        Member member = memberRepository.findById(refreshToken.getMemberId())
+                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
+        
+        // 새로운 Access Token 생성
+        String newAccessToken = jwtProvider.createAccessToken(member);
+        
+        // 새로운 Refresh Token 생성 (Rotation)
+        RefreshToken newRefreshToken = createRefreshToken(member);
+        
+        log.info("Refresh Token Rotation 완료 - Member ID: {}", member.getId());
+        
+        return TokenResponse.of(
+                newAccessToken,
+                newRefreshToken.getToken(),
+                jwtProvider.getAccessTokenExpirationMillis() / 1000
+        );
+    }
+    
+    /**
+     * 사용자의 Refresh Token을 삭제 (로그아웃)
+     */
+    public void deleteRefreshToken(Integer memberId) {
+        refreshTokenRepository.deleteByMemberId(memberId);
+        log.info("Refresh Token 삭제 완료 - Member ID: {}", memberId);
+    }
+
+    /**
+     * 토큰에서 사용자 ID를 추출
+     */
+    public Long getMemberIdFromToken(String token) {
+        return jwtProvider.getMemberId(token);
+    }
+    
+    /**
+     * 만료된 Refresh Token들을 정리 (매일 새벽 2시 실행)
+     */
+    @Scheduled(cron = "0 0 2 * * ?")
+    @Transactional
+    public void cleanupExpiredTokens() {
+        LocalDateTime now = LocalDateTime.now();
+        refreshTokenRepository.deleteExpiredTokens(now);
+        log.info("만료된 Refresh Token 정리 완료 - {}", now);
+    }
+} 

--- a/src/main/java/com/example/medicare_call/service/RefreshTokenService.java
+++ b/src/main/java/com/example/medicare_call/service/RefreshTokenService.java
@@ -90,13 +90,6 @@ public class RefreshTokenService {
         refreshTokenRepository.deleteByMemberId(memberId);
         log.info("Refresh Token 삭제 완료 - Member ID: {}", memberId);
     }
-
-    /**
-     * 토큰에서 사용자 ID를 추출
-     */
-    public Long getMemberIdFromToken(String token) {
-        return jwtProvider.getMemberId(token);
-    }
     
     /**
      * 만료된 Refresh Token들을 정리 (매일 새벽 2시 실행)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,7 @@ jwt:
   secret: ${JWT_SECRET}
   accessTokenExpiration: ${JWT_ACCESS_EXPIRATION}
   phoneTokenExpiration: ${JWT_PHONE_EXPIRATION}
+  refreshTokenExpirationDays: ${JWT_REFRESH_EXPIRATION_DAYS}
 
 ---
 spring:

--- a/src/main/resources/db/migration/V11__create_refresh_token_table.sql
+++ b/src/main/resources/db/migration/V11__create_refresh_token_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE refresh_token (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id INT NOT NULL,
+    token VARCHAR(500) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
+    UNIQUE KEY uk_member_id (member_id),
+    INDEX idx_token (token(100)),
+    INDEX idx_expires_at (expires_at)
+); 

--- a/src/test/java/com/example/medicare_call/controller/action/SmsControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/action/SmsControllerTest.java
@@ -71,7 +71,6 @@ class SmsControllerTest {
                         .verified(true)
                         .message("인증이 완료되었습니다. 로그인되었습니다.")
                         .memberStatus(MemberStatus.EXISTING_MEMBER)
-                        .nextAction("HOME")
                         .token("sample-access-token")
                         .build()
         );
@@ -81,8 +80,7 @@ class SmsControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.verified").value(true))
-                .andExpect(jsonPath("$.memberStatus").value("EXISTING_MEMBER"))
-                .andExpect(jsonPath("$.nextAction").value("HOME"));
+                .andExpect(jsonPath("$.memberStatus").value("EXISTING_MEMBER"));
     }
 
     @Test
@@ -98,7 +96,6 @@ class SmsControllerTest {
                         .verified(true)
                         .message("인증이 완료되었습니다. 회원 정보를 입력해주세요.")
                         .memberStatus(MemberStatus.NEW_MEMBER)
-                        .nextAction("REGISTER")
                         .token("sample-phone-token")
                         .build()
         );
@@ -108,8 +105,7 @@ class SmsControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.verified").value(true))
-                .andExpect(jsonPath("$.memberStatus").value("NEW_MEMBER"))
-                .andExpect(jsonPath("$.nextAction").value("REGISTER"));
+                .andExpect(jsonPath("$.memberStatus").value("NEW_MEMBER"));
     }
 
     @Test

--- a/src/test/java/com/example/medicare_call/controller/action/TokenControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/action/TokenControllerTest.java
@@ -70,7 +70,7 @@ class TokenControllerTest {
         String authorization = "Bearer " + accessToken;
         Long memberId = 1L;
 
-        when(refreshTokenService.getMemberIdFromToken(accessToken)).thenReturn(memberId);
+        when(jwtProvider.getMemberId(accessToken)).thenReturn(memberId);
 
         // when & then
         mockMvc.perform(post("/auth/logout")

--- a/src/test/java/com/example/medicare_call/controller/action/TokenControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/action/TokenControllerTest.java
@@ -1,0 +1,85 @@
+package com.example.medicare_call.controller.action;
+
+import com.example.medicare_call.dto.TokenResponse;
+import com.example.medicare_call.global.jwt.JwtProvider;
+import com.example.medicare_call.service.RefreshTokenService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(TokenController.class)
+@TestPropertySource(properties = {
+    "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration"
+})
+class TokenControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RefreshTokenService refreshTokenService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("Access Token 갱신 성공")
+    void refreshToken_success() throws Exception {
+        // given
+        String refreshToken = "valid-refresh-token";
+        TokenResponse tokenResponse = TokenResponse.builder()
+                .accessToken("new-access-token")
+                .refreshToken("new-refresh-token")
+                .tokenType("Bearer")
+                .expiresIn(3600L)
+                .build();
+
+        when(refreshTokenService.refreshAccessToken(refreshToken)).thenReturn(tokenResponse);
+
+        // when & then
+        mockMvc.perform(post("/auth/refresh")
+                        .header("Refresh-Token", refreshToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.accessToken").value("new-access-token"))
+                .andExpect(jsonPath("$.refreshToken").value("new-refresh-token"))
+                .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                .andExpect(jsonPath("$.expiresIn").value(3600));
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공")
+    void logout_success() throws Exception {
+        // given
+        String accessToken = "valid-access-token";
+        String authorization = "Bearer " + accessToken;
+        Long memberId = 1L;
+
+        when(refreshTokenService.getMemberIdFromToken(accessToken)).thenReturn(memberId);
+
+        // when & then
+        mockMvc.perform(post("/auth/logout")
+                        .header("Authorization", authorization)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        // verify that deleteRefreshToken was called
+        // Note: Since we're using MockMvc, we can't directly verify service method calls
+        // In a real scenario, you might want to use @SpringBootTest for integration testing
+    }
+} 

--- a/src/test/java/com/example/medicare_call/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/RefreshTokenServiceTest.java
@@ -181,19 +181,4 @@ class RefreshTokenServiceTest {
         // then
         verify(refreshTokenRepository).deleteByMemberId(memberId);
     }
-
-    @Test
-    @DisplayName("토큰에서 사용자 ID 추출 성공")
-    void getMemberIdFromToken_success() {
-        // given
-        String token = "valid-token";
-        when(jwtProvider.getMemberId(token)).thenReturn(1L);
-
-        // when
-        Long result = refreshTokenService.getMemberIdFromToken(token);
-
-        // then
-        assertThat(result).isEqualTo(1L);
-        verify(jwtProvider).getMemberId(token);
-    }
 } 

--- a/src/test/java/com/example/medicare_call/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/RefreshTokenServiceTest.java
@@ -1,0 +1,199 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.Member;
+import com.example.medicare_call.domain.RefreshToken;
+import com.example.medicare_call.dto.TokenResponse;
+import com.example.medicare_call.global.ResourceNotFoundException;
+import com.example.medicare_call.global.jwt.JwtProvider;
+import com.example.medicare_call.repository.MemberRepository;
+import com.example.medicare_call.repository.RefreshTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.*;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+    
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(refreshTokenService, "refreshTokenExpirationDays", 30);
+    }
+
+    @Test
+    @DisplayName("Refresh Token 생성 성공")
+    void createRefreshToken_success() {
+        // given
+        Member member = Member.builder()
+                .id(1)
+                .name("테스트")
+                .phone("01012345678")
+                .build();
+
+        RefreshToken savedToken = RefreshToken.builder()
+                .id(1L)
+                .memberId(1)
+                .token("test-refresh-token")
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .build();
+
+        doNothing().when(refreshTokenRepository).deleteByMemberId(1);
+        when(refreshTokenRepository.save(any(RefreshToken.class))).thenReturn(savedToken);
+
+        // when
+        RefreshToken result = refreshTokenService.createRefreshToken(member);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getMemberId()).isEqualTo(1);
+        assertThat(result.getToken()).isEqualTo("test-refresh-token");
+        assertThat(result.isExpired()).isFalse();
+
+        verify(refreshTokenRepository).deleteByMemberId(1);
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("Access Token 갱신 성공")
+    void refreshAccessToken_success() {
+        // given
+        String refreshTokenValue = "valid-refresh-token";
+        String newAccessToken = "new-access-token";
+        String newRefreshToken = "new-refresh-token";
+
+        RefreshToken existingToken = RefreshToken.builder()
+                .id(1L)
+                .memberId(1)
+                .token(refreshTokenValue)
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .build();
+
+        Member member = Member.builder()
+                .id(1)
+                .name("테스트")
+                .phone("01012345678")
+                .build();
+
+        RefreshToken newToken = RefreshToken.builder()
+                .id(2L)
+                .memberId(1)
+                .token(newRefreshToken)
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .build();
+
+        when(refreshTokenRepository.findByToken(refreshTokenValue)).thenReturn(Optional.of(existingToken));
+        when(memberRepository.findById(1)).thenReturn(Optional.of(member));
+        when(jwtProvider.createAccessToken(member)).thenReturn(newAccessToken);
+        when(jwtProvider.getAccessTokenExpirationMillis()).thenReturn(3600000L); // 1시간
+        doNothing().when(refreshTokenRepository).deleteByMemberId(1);
+        when(refreshTokenRepository.save(any(RefreshToken.class))).thenReturn(newToken);
+
+        // when
+        TokenResponse result = refreshTokenService.refreshAccessToken(refreshTokenValue);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getAccessToken()).isEqualTo(newAccessToken);
+        assertThat(result.getRefreshToken()).isEqualTo(newRefreshToken);
+        assertThat(result.getExpiresIn()).isEqualTo(3600L);
+
+        verify(refreshTokenRepository).findByToken(refreshTokenValue);
+        verify(memberRepository).findById(1);
+        verify(jwtProvider).createAccessToken(member);
+    }
+
+    @Test
+    @DisplayName("Access Token 갱신 실패 - 유효하지 않은 Refresh Token")
+    void refreshAccessToken_fail_invalidToken() {
+        // given
+        String invalidToken = "invalid-refresh-token";
+        when(refreshTokenRepository.findByToken(invalidToken)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> refreshTokenService.refreshAccessToken(invalidToken))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("유효하지 않은 Refresh Token입니다.");
+
+        verify(refreshTokenRepository).findByToken(invalidToken);
+        verify(memberRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("Access Token 갱신 실패 - 만료된 Refresh Token")
+    void refreshAccessToken_fail_expiredToken() {
+        // given
+        String expiredToken = "expired-refresh-token";
+        RefreshToken expiredRefreshToken = RefreshToken.builder()
+                .id(1L)
+                .memberId(1)
+                .token(expiredToken)
+                .expiresAt(LocalDateTime.now().minusDays(1)) // 만료된 토큰
+                .build();
+
+        when(refreshTokenRepository.findByToken(expiredToken)).thenReturn(Optional.of(expiredRefreshToken));
+
+        // when & then
+        assertThatThrownBy(() -> refreshTokenService.refreshAccessToken(expiredToken))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("만료된 Refresh Token입니다.");
+
+        verify(refreshTokenRepository).findByToken(expiredToken);
+        verify(refreshTokenRepository).delete(expiredRefreshToken);
+        verify(memberRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("Refresh Token 삭제 성공")
+    void deleteRefreshToken_success() {
+        // given
+        Integer memberId = 1;
+        doNothing().when(refreshTokenRepository).deleteByMemberId(memberId);
+
+        // when
+        refreshTokenService.deleteRefreshToken(memberId);
+
+        // then
+        verify(refreshTokenRepository).deleteByMemberId(memberId);
+    }
+
+    @Test
+    @DisplayName("토큰에서 사용자 ID 추출 성공")
+    void getMemberIdFromToken_success() {
+        // given
+        String token = "valid-token";
+        when(jwtProvider.getMemberId(token)).thenReturn(1L);
+
+        // when
+        Long result = refreshTokenService.getMemberIdFromToken(token);
+
+        // then
+        assertThat(result).isEqualTo(1L);
+        verify(jwtProvider).getMemberId(token);
+    }
+} 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -24,6 +24,7 @@ jwt:
   secret: test-secret-key-for-testing-purposes-only
   accessTokenExpiration: 1
   phoneTokenExpiration: 1
+  refreshTokenExpirationDays: 1
 care-call:
   url: test
 


### PR DESCRIPTION
### Desc
- 현재는 문자 인증번호를 입력하였을 경우, response에서 Access Token만을 발급해준다.
  - Access Token이 만료가 되어 401이 뜨는 경우에는 다시 문자 인증하는 과정을 거쳐야 하는데, Refresh Token을 도입하여 사용성을 개선하자.
  - 인증번호로 인증한 뒤에, 이미 가입된 회원에 대한 `SmsVerificationResponse`에 `refreshToken`필드 추가
  - 회원 가입 API 호출시의 응답에 `refreshToken`필드 추가
- filter에서는 Access Token인 경우에만 인증을 허용.
- Access Token이 만료되어 401이 뜨는 경우, 클라이언트에서 토큰을 갱신하기 위한 엔드포인트를 추가
  - `/auth/refresh`
  - `refreshTokenService.refreshAccessToken`를 통해 새로운 토큰 쌍을 `tokenResponse`으로 발급받을 수 있다.
    - Refresh Token Rotation 방식
- Refresh Token은 UUID 방식으로 구현하여 stateful하다. 따라서 DB 테이블에 그 목록을 저장하여 관리한다.
  - 만료된 RefreshToken은 매일 새벽 2시에 cleanUp 처리
  - 마이그레이션 추가
- 문자 인증 API에서 불필요한 필드 제거
  - `nextAction`
  - `memberStatus` 필드 만으로도 가입 유무를 판단할 수 있어, 안드로이드에서 분기 처리가 가능하다. 