### PR TITLE
edit: 토큰 갱신 API 와일드카드 추가, flush 수행

### DIFF
--- a/src/main/java/com/example/medicare_call/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/medicare_call/global/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
             "/verifications/**",
             "/members",
             "/call-data",
-            "/health-data/**" // 제거 예정
+            "/health-data/**", // 제거 예정
+            "/auth/refresh"
     };
 
     private final String[] PUBLIC_GET = {

--- a/src/main/java/com/example/medicare_call/service/RefreshTokenService.java
+++ b/src/main/java/com/example/medicare_call/service/RefreshTokenService.java
@@ -14,6 +14,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -26,6 +27,7 @@ public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final MemberRepository memberRepository;
     private final JwtProvider jwtProvider;
+    private final EntityManager entityManager;
     
     @Value("${jwt.refreshTokenExpirationDays}")
     private Integer refreshTokenExpirationDays;
@@ -36,6 +38,7 @@ public class RefreshTokenService {
     public RefreshToken createRefreshToken(Member member) {
         // 기존 Refresh Token이 있다면 삭제
         refreshTokenRepository.deleteByMemberId(member.getId());
+        entityManager.flush(); // 삭제 후 변경사항 반영
         
         // 새로운 Refresh Token 생성 (UUID 기반)
         String tokenValue = UUID.randomUUID().toString();

--- a/src/test/java/com/example/medicare_call/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/RefreshTokenServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -37,6 +38,9 @@ class RefreshTokenServiceTest {
 
     @Mock
     private JwtProvider jwtProvider;
+
+    @Mock
+    private EntityManager entityManager;
 
     @InjectMocks
     private RefreshTokenService refreshTokenService;


### PR DESCRIPTION
### Desc
- jwt토큰이 만료된 경우에 토큰을 갱신하기 위한 엔드포인트는 jwt를 통한 인증을 수행하지 않아야 한다
  - POST 와일드카드에 `/auth/refresh` 추가
- 현재 API를 호출하여 토큰 갱신을 시도하면 다음과 같은 오류가 발생한다
  - `Duplicate entry '2' for key 'RefreshToken.uk_member_id'] [insert into RefreshToken (created_at,expires_at,member_id,token,updated_at) values (?,?,?,?,?)]`
  - 토큰에 대한 delete가 호출된 이후, db commit되기 전에 insert를 시도하는 것으로 추정.
  - DB에 붙어보면 기존 Refresh Token 컬럼이 제거되지 않음. 즉 Transaction Rollback이 발생한 것이지, race condition은 아니다.
    - RefreshTokenService에 class level의 `@Transactional`이 적용되어 있기 때문으로 보인다.
- 기존 token 값을 삭제한 이후, 명시적으로 flush를 하여 db에 반영하자.