### PR TITLE
feat: API Validation 추가

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/action/HealthDataController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/HealthDataController.java
@@ -31,7 +31,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import com.example.medicare_call.global.annotation.ValidDateRange;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
@@ -351,7 +354,9 @@ public class HealthDataController {
         private String transcriptionText;
         
         @Schema(description = "통화 날짜", example = "2024-01-01")
-        private String callDate;
+        @NotNull(message = "통화 날짜는 필수입니다.")
+        @ValidDateRange
+        private LocalDate callDate;
 
         // Getters and Setters
         public Integer getElderId() { return elderId; }
@@ -363,7 +368,7 @@ public class HealthDataController {
         public String getTranscriptionText() { return transcriptionText; }
         public void setTranscriptionText(String transcriptionText) { this.transcriptionText = transcriptionText; }
         
-        public String getCallDate() { return callDate; }
-        public void setCallDate(String callDate) { this.callDate = callDate; }
+        public LocalDate getCallDate() { return callDate; }
+        public void setCallDate(LocalDate callDate) { this.callDate = callDate; }
     }
 } 

--- a/src/main/java/com/example/medicare_call/dto/CareCallSettingRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/CareCallSettingRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalTime;
 
 public record CareCallSettingRequest(
@@ -14,6 +15,8 @@ public record CareCallSettingRequest(
                 format = "partial-time"
         )
         @JsonFormat(pattern = "HH:mm")
+//        Integer elderId,
+        @NotNull(message = "첫 번째 통화 시간은 필수입니다.")
         LocalTime firstCallTime,
 
         @Schema(

--- a/src/main/java/com/example/medicare_call/dto/ElderRegisterRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/ElderRegisterRequest.java
@@ -1,12 +1,13 @@
 package com.example.medicare_call.dto;
 
+import com.example.medicare_call.global.annotation.ValidBirthDate;
+import com.example.medicare_call.global.annotation.ValidPhoneNumber;
 import com.example.medicare_call.global.enums.ElderRelation;
 import com.example.medicare_call.global.enums.ResidenceType;
 import com.example.medicare_call.global.enums.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 import java.time.LocalDate;
 
@@ -18,6 +19,7 @@ public class ElderRegisterRequest {
 
     @Schema(description = "생년월일", example = "1940-05-01")
     @NotNull(message = "생년월일은 필수입니다.")
+    @ValidBirthDate
     private LocalDate birthDate;
 
     @Schema(description = "성별 (MALE: 남성, FEMALE: 여성)", example = "MALE")
@@ -26,7 +28,7 @@ public class ElderRegisterRequest {
 
     @Schema(description = "휴대폰 번호(01012345678 형식)", example = "01012345678")
     @NotBlank(message = "휴대폰 번호는 필수입니다.")
-    @Pattern(regexp = "^010\\d{8}$", message = "휴대폰 번호는 01012345678 형식이어야 합니다.")
+    @ValidPhoneNumber
     private String phone;
 
     @Schema(description = "어르신과의 관계 (CHILD: 자식, GRANDCHILD: 손자, SIBLING: 형제, RELATIVE: 친척, ACQUAINTANCE: 지인)", example = "GRANDCHILD")

--- a/src/main/java/com/example/medicare_call/dto/HealthDataExtractionRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/HealthDataExtractionRequest.java
@@ -1,10 +1,14 @@
 package com.example.medicare_call.dto;
 
+import com.example.medicare_call.global.annotation.ValidDateRange;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import java.time.LocalDate;
 
 @Getter
 @Builder
@@ -17,6 +21,7 @@ public class HealthDataExtractionRequest {
         description = "통화 내용 텍스트",
         example = "오늘 아침에 밥을 먹었고, 혈당을 측정했어요. 120이 나왔어요."
     )
+    @NotBlank(message = "통화 내용 텍스트는 필수입니다.")
     private String transcriptionText;
     
 
@@ -25,5 +30,7 @@ public class HealthDataExtractionRequest {
         description = "통화 날짜 (YYYY-MM-DD 형식)",
         example = "2024-01-01"
     )
-    private String callDate;
+    @NotNull(message = "통화 날짜는 필수입니다.")
+    @ValidDateRange
+    private LocalDate callDate;
 } 

--- a/src/main/java/com/example/medicare_call/dto/RegisterRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/RegisterRequest.java
@@ -1,9 +1,9 @@
 package com.example.medicare_call.dto;
 
+import com.example.medicare_call.global.annotation.ValidBirthDate;
 import com.example.medicare_call.global.enums.Gender;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -17,6 +17,7 @@ public class RegisterRequest {
     private String name;
 
     @NotNull(message = "생년월일은 필수입니다.")
+    @ValidBirthDate
     private LocalDate birthDate;
 
     @NotNull(message = "성별은 필수입니다.")

--- a/src/main/java/com/example/medicare_call/dto/SmsRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/SmsRequest.java
@@ -1,7 +1,7 @@
 package com.example.medicare_call.dto;
 
+import com.example.medicare_call.global.annotation.ValidPhoneNumber;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +13,6 @@ import lombok.Setter;
 @AllArgsConstructor
 public class SmsRequest {
     @NotBlank(message = "전화번호는 필수입니다.")
-    @Pattern(regexp = "^010\\d{8}$", message = "전화번호는 01012345678 형식이어야 합니다.")
+    @ValidPhoneNumber
     private String phone;
 }

--- a/src/main/java/com/example/medicare_call/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/medicare_call/global/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.extern.slf4j.Slf4j;
 import java.util.HashMap;
 import java.util.Map;
+import jakarta.validation.ConstraintViolationException;
 
 @Slf4j
 @RestControllerAdvice(
@@ -42,6 +43,25 @@ public class GlobalExceptionHandler {
                 null
         );
         log.error(e.getMessage(), e);
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+        Map<String, String> errors = new HashMap<>();
+        e.getConstraintViolations().forEach(violation -> {
+            String fieldName = violation.getPropertyPath().toString();
+            String message = violation.getMessage();
+            errors.put(fieldName, message);
+        });
+        
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "Validation 오류",
+                "입력값이 유효하지 않습니다.",
+                errors
+        );
+        log.warn("Constraint violation: {}", errors);
         return ResponseEntity.badRequest().body(errorResponse);
     }
 

--- a/src/main/java/com/example/medicare_call/global/annotation/BirthDateValidator.java
+++ b/src/main/java/com/example/medicare_call/global/annotation/BirthDateValidator.java
@@ -1,0 +1,27 @@
+package com.example.medicare_call.global.annotation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.time.LocalDate;
+
+public class BirthDateValidator implements ConstraintValidator<ValidBirthDate, LocalDate> {
+    
+    private static final LocalDate MIN_BIRTH_DATE = LocalDate.of(1900, 1, 1);
+    
+    @Override
+    public void initialize(ValidBirthDate constraintAnnotation) {
+        // 현재 어노테이션에 추가 파라미터가 없으므로 초기화 로직 불필요
+    }
+    
+    @Override
+    public boolean isValid(LocalDate birthDate, ConstraintValidatorContext context) {
+        if (birthDate == null) {
+            return true; // null 값은 @NotNull 어노테이션에서 처리
+        }
+        
+        LocalDate today = LocalDate.now();
+        
+        // 생년월일이 1900년 1월 1일 이후이고 오늘 이전이어야 함
+        return !birthDate.isBefore(MIN_BIRTH_DATE) && !birthDate.isAfter(today);
+    }
+} 

--- a/src/main/java/com/example/medicare_call/global/annotation/DateRangeValidator.java
+++ b/src/main/java/com/example/medicare_call/global/annotation/DateRangeValidator.java
@@ -1,0 +1,25 @@
+package com.example.medicare_call.global.annotation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.time.LocalDate;
+
+public class DateRangeValidator implements ConstraintValidator<ValidDateRange, LocalDate> {
+    
+    @Override
+    public void initialize(ValidDateRange constraintAnnotation) {
+        // 현재 어노테이션에 추가 파라미터가 없으므로 초기화 로직 불필요
+    }
+    
+    @Override
+    public boolean isValid(LocalDate date, ConstraintValidatorContext context) {
+        if (date == null) {
+            return true; // null 값은 @NotNull 어노테이션에서 처리
+        }
+        
+        LocalDate today = LocalDate.now();
+        
+        // 날짜가 오늘 이전이어야 함 (미래 날짜는 허용하지 않음)
+        return !date.isAfter(today);
+    }
+} 

--- a/src/main/java/com/example/medicare_call/global/annotation/PhoneNumberValidator.java
+++ b/src/main/java/com/example/medicare_call/global/annotation/PhoneNumberValidator.java
@@ -1,0 +1,22 @@
+package com.example.medicare_call.global.annotation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PhoneNumberValidator implements ConstraintValidator<ValidPhoneNumber, String> {
+    
+    @Override
+    public void initialize(ValidPhoneNumber constraintAnnotation) {
+        // 현재 어노테이션에 추가 파라미터가 없으므로 초기화 로직 불필요
+    }
+    
+    @Override
+    public boolean isValid(String phoneNumber, ConstraintValidatorContext context) {
+        if (phoneNumber == null) {
+            return true; // null 값은 @NotNull 어노테이션에서 처리
+        }
+        
+        // 010으로 시작하는 11자리 숫자인지 확인
+        return phoneNumber.matches("^010\\d{8}$");
+    }
+} 

--- a/src/main/java/com/example/medicare_call/global/annotation/ValidBirthDate.java
+++ b/src/main/java/com/example/medicare_call/global/annotation/ValidBirthDate.java
@@ -1,0 +1,15 @@
+package com.example.medicare_call.global.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = BirthDateValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidBirthDate {
+    String message() default "생년월일이 유효하지 않습니다. 1900년 1월 1일 이후부터 오늘 이전의 날짜여야 합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+} 

--- a/src/main/java/com/example/medicare_call/global/annotation/ValidDateRange.java
+++ b/src/main/java/com/example/medicare_call/global/annotation/ValidDateRange.java
@@ -1,0 +1,15 @@
+package com.example.medicare_call.global.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = DateRangeValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidDateRange {
+    String message() default "날짜가 유효하지 않습니다. 오늘 이전의 날짜여야 합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+} 

--- a/src/main/java/com/example/medicare_call/global/annotation/ValidPhoneNumber.java
+++ b/src/main/java/com/example/medicare_call/global/annotation/ValidPhoneNumber.java
@@ -1,0 +1,15 @@
+package com.example.medicare_call.global.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = PhoneNumberValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidPhoneNumber {
+    String message() default "휴대폰 번호가 유효하지 않습니다. 010으로 시작하는 11자리 숫자여야 합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+} 

--- a/src/test/java/com/example/medicare_call/global/annotation/ValidationTest.java
+++ b/src/test/java/com/example/medicare_call/global/annotation/ValidationTest.java
@@ -1,0 +1,165 @@
+package com.example.medicare_call.global.annotation;
+
+import com.example.medicare_call.dto.ElderRegisterRequest;
+import com.example.medicare_call.global.enums.ElderRelation;
+import com.example.medicare_call.global.enums.Gender;
+import com.example.medicare_call.global.enums.ResidenceType;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ValidationTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("유효한 생년월일이면 Validation을 통과한다")
+    void validBirthDate_passesValidation() {
+        // given
+        ElderRegisterRequest request = new ElderRegisterRequest();
+        request.setName("홍길동");
+        request.setBirthDate(LocalDate.of(1940, 5, 1));
+        request.setGender(Gender.MALE);
+        request.setPhone("01012345678");
+        request.setRelationship(ElderRelation.GRANDCHILD);
+        request.setResidenceType(ResidenceType.ALONE);
+        request.setGuardianId(1);
+
+        // when
+        Set<ConstraintViolation<ElderRegisterRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("미래의 생년월일이면 Validation에 실패한다")
+    void futureBirthDate_failsValidation() {
+        // given
+        ElderRegisterRequest request = new ElderRegisterRequest();
+        request.setName("홍길동");
+        request.setBirthDate(LocalDate.now().plusDays(1)); // 미래 날짜
+        request.setGender(Gender.MALE);
+        request.setPhone("01012345678");
+        request.setRelationship(ElderRelation.GRANDCHILD);
+        request.setResidenceType(ResidenceType.ALONE);
+        request.setGuardianId(1);
+
+        // when
+        Set<ConstraintViolation<ElderRegisterRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isNotEmpty();
+        assertThat(violations).anyMatch(violation -> 
+            violation.getPropertyPath().toString().equals("birthDate") &&
+            violation.getMessage().contains("생년월일이 유효하지 않습니다")
+        );
+    }
+
+    @Test
+    @DisplayName("1900년 이전의 생년월일이면 Validation에 실패한다")
+    void tooOldBirthDate_failsValidation() {
+        // given
+        ElderRegisterRequest request = new ElderRegisterRequest();
+        request.setName("홍길동");
+        request.setBirthDate(LocalDate.of(1899, 12, 31)); // 1900년 이전
+        request.setGender(Gender.MALE);
+        request.setPhone("01012345678");
+        request.setRelationship(ElderRelation.GRANDCHILD);
+        request.setResidenceType(ResidenceType.ALONE);
+        request.setGuardianId(1);
+
+        // when
+        Set<ConstraintViolation<ElderRegisterRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isNotEmpty();
+        assertThat(violations).anyMatch(violation -> 
+            violation.getPropertyPath().toString().equals("birthDate") &&
+            violation.getMessage().contains("생년월일이 유효하지 않습니다")
+        );
+    }
+
+    @Test
+    @DisplayName("유효한 휴대폰 번호면 Validation을 통과한다")
+    void validPhoneNumber_passesValidation() {
+        // given
+        ElderRegisterRequest request = new ElderRegisterRequest();
+        request.setName("홍길동");
+        request.setBirthDate(LocalDate.of(1940, 5, 1));
+        request.setGender(Gender.MALE);
+        request.setPhone("01012345678");
+        request.setRelationship(ElderRelation.GRANDCHILD);
+        request.setResidenceType(ResidenceType.ALONE);
+        request.setGuardianId(1);
+
+        // when
+        Set<ConstraintViolation<ElderRegisterRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("잘못된 형식의 휴대폰 번호면 Validation에 실패한다")
+    void invalidPhoneNumber_failsValidation() {
+        // given
+        ElderRegisterRequest request = new ElderRegisterRequest();
+        request.setName("홍길동");
+        request.setBirthDate(LocalDate.of(1940, 5, 1));
+        request.setGender(Gender.MALE);
+        request.setPhone("010-1234-5678"); // 하이픈 포함
+        request.setRelationship(ElderRelation.GRANDCHILD);
+        request.setResidenceType(ResidenceType.ALONE);
+        request.setGuardianId(1);
+
+        // when
+        Set<ConstraintViolation<ElderRegisterRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isNotEmpty();
+        assertThat(violations).anyMatch(violation -> 
+            violation.getPropertyPath().toString().equals("phone") &&
+            violation.getMessage().contains("휴대폰 번호가 유효하지 않습니다")
+        );
+    }
+
+    @Test
+    @DisplayName("010으로 시작하지 않는 휴대폰 번호면 Validation에 실패한다")
+    void phoneNumberNotStartingWith010_failsValidation() {
+        // given
+        ElderRegisterRequest request = new ElderRegisterRequest();
+        request.setName("홍길동");
+        request.setBirthDate(LocalDate.of(1940, 5, 1));
+        request.setGender(Gender.MALE);
+        request.setPhone("01112345678"); // 011로 시작
+        request.setRelationship(ElderRelation.GRANDCHILD);
+        request.setResidenceType(ResidenceType.ALONE);
+        request.setGuardianId(1);
+
+        // when
+        Set<ConstraintViolation<ElderRegisterRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isNotEmpty();
+        assertThat(violations).anyMatch(violation -> 
+            violation.getPropertyPath().toString().equals("phone") &&
+            violation.getMessage().contains("휴대폰 번호가 유효하지 않습니다")
+        );
+    }
+} 

--- a/src/test/java/com/example/medicare_call/service/CallDataServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/CallDataServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Optional;
@@ -99,6 +100,10 @@ class CallDataServiceTest {
         when(elderRepository.findById(1)).thenReturn(Optional.of(elder));
         when(careCallSettingRepository.findById(2)).thenReturn(Optional.of(setting));
         when(careCallRecordRepository.save(any(CareCallRecord.class))).thenReturn(expectedRecord);
+        
+        // Mock OpenAI health data service
+        when(openAiHealthDataService.extractHealthData(any(HealthDataExtractionRequest.class)))
+                .thenReturn(HealthDataExtractionResponse.builder().build());
 
         // when
         CareCallRecord result = callDataService.saveCallData(request);
@@ -115,7 +120,7 @@ class CallDataServiceTest {
         verify(careCallRecordRepository).save(any(CareCallRecord.class));
         verify(openAiHealthDataService).extractHealthData(argThat(healthRequest -> 
             healthRequest.getTranscriptionText().equals("고객: 안녕하세요, 오늘 컨디션은 어떠세요?\n어르신: 네, 오늘은 컨디션이 좋아요.") &&
-            healthRequest.getCallDate().equals("2025-01-27")
+            healthRequest.getCallDate().equals(LocalDate.of(2025, 1, 27))
         ));
     }
 
@@ -355,6 +360,10 @@ class CallDataServiceTest {
         when(elderRepository.findById(1)).thenReturn(Optional.of(elder));
         when(careCallSettingRepository.findById(2)).thenReturn(Optional.of(setting));
         when(careCallRecordRepository.save(any(CareCallRecord.class))).thenReturn(expectedRecord);
+        
+        // Mock OpenAI health data service
+        when(openAiHealthDataService.extractHealthData(any(HealthDataExtractionRequest.class)))
+                .thenReturn(HealthDataExtractionResponse.builder().build());
 
         // when
         CareCallRecord result = callDataService.saveCallData(request);
@@ -363,7 +372,7 @@ class CallDataServiceTest {
         assertThat(result).isNotNull();
         verify(openAiHealthDataService).extractHealthData(argThat(healthRequest -> 
             healthRequest.getTranscriptionText().equals("어르신: 오늘 아침에 밥을 먹었고, 혈당을 측정했어요. 120이 나왔어요.") &&
-            healthRequest.getCallDate().equals("2025-01-27")
+            healthRequest.getCallDate().equals(LocalDate.of(2025, 1, 27))
         ));
     }
 } 

--- a/src/test/java/com/example/medicare_call/service/HealthDataExtractionIntegrationTest.java
+++ b/src/test/java/com/example/medicare_call/service/HealthDataExtractionIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,7 +47,7 @@ class HealthDataExtractionIntegrationTest {
                     상담사: 좋은 수치네요. 기분은 어떠세요?
                     어르신: 오늘은 기분이 좋아요. 잠도 잘 잤어요.
                     """)
-                .callDate("2024-01-01")
+                .callDate(LocalDate.of(2024, 1, 1))
                 .build();
 
         String mockOpenAiResponse = """
@@ -115,7 +116,7 @@ class HealthDataExtractionIntegrationTest {
                     상담사: 좋습니다. 컨디션은 어떠세요?
                     어르신: 오늘은 머리가 좀 아파요.
                     """)
-                .callDate("2024-01-01")
+                .callDate(LocalDate.of(2024, 1, 1))
                 .build();
 
         String mockOpenAiResponse = """
@@ -174,7 +175,7 @@ class HealthDataExtractionIntegrationTest {
         // given
         HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
                 .transcriptionText("")
-                .callDate("2024-01-01")
+                .callDate(LocalDate.of(2024, 1, 1))
                 .build();
 
         String mockOpenAiResponse = """

--- a/src/test/java/com/example/medicare_call/service/OpenAiHealthDataServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/OpenAiHealthDataServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,7 +51,7 @@ class OpenAiHealthDataServiceTest {
         // given
         HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
                 .transcriptionText("오늘 아침에 밥을 먹었고, 혈당을 측정했어요. 120이 나왔어요.")
-                .callDate("2024-01-01")
+                .callDate(LocalDate.of(2024, 1, 1))
                 .build();
 
         String mockOpenAiResponse = """
@@ -122,7 +123,7 @@ class OpenAiHealthDataServiceTest {
         // given
         HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
                 .transcriptionText("테스트 통화 내용")
-                .callDate("2024-01-01")
+                .callDate(LocalDate.of(2024, 1, 1))
                 .build();
 
         when(restTemplate.postForObject(eq("https://api.openai.com/v1/chat/completions"), any(HttpEntity.class), eq(OpenAiResponse.class)))
@@ -148,7 +149,7 @@ class OpenAiHealthDataServiceTest {
         // given
         HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
                 .transcriptionText("테스트 통화 내용")
-                .callDate("2024-01-01")
+                .callDate(LocalDate.of(2024, 1, 1))
                 .build();
 
         OpenAiResponse openAiResponse = OpenAiResponse.builder()
@@ -181,7 +182,7 @@ class OpenAiHealthDataServiceTest {
         // given
         HealthDataExtractionRequest request = HealthDataExtractionRequest.builder()
                 .transcriptionText("")
-                .callDate("2024-01-01")
+                .callDate(LocalDate.of(2024, 1, 1))
                 .build();
 
         OpenAiResponse openAiResponse = OpenAiResponse.builder()


### PR DESCRIPTION
### Desc
- API에 대한 입력값 유효성 검증을 서버에서도 수행한다
- DTO에 커스텀 Annotation을 적용하는 것으로, 검증 대상 필드를 정의한다
- GlobalExceptionHandler에 Validation 실패에 대한 에러 응답을 추가
- 목록
  - 생년월일 `@ValidBirthDate`
    - 1900.01.01 ~ 오늘
  - 휴대폰 번호 `@ValidPhoneNumber`
    - 010~ 으로 시작하는 11자 형식 (현재는 국내 서비스만이 대상이고, 010으로 시작하지 않는 번호의 사용률이 낮다.)
  - 날짜 `@ValidDateRange`
    - 오늘 이전의 날짜
- 대상 API
  - 어르신 등록
    - 휴대폰 번호 형식
  - 회원 등록
    - 생년월일 날짜 범위
  - 통화 설정
    - 첫 번째 통화시간은 NotNull
  - SMS
    - 휴대폰 번호 형식
    - 통화 날짜 범위
  - 건강데이터 추출
    - 통화 텍스트 NotBlank
    - 통화 날짜 NotNull, 날짜 범위