### PR TITLE
fix: 복약 데이터에 복약 상태값이 저장되지 않는 문제

### DIFF
--- a/src/main/java/com/example/medicare_call/service/OpenAiHealthDataService.java
+++ b/src/main/java/com/example/medicare_call/service/OpenAiHealthDataService.java
@@ -115,7 +115,7 @@ public class OpenAiHealthDataService {
                - 혈당 상태 (식전/식후 여부를 고려하여 LOW/NORMAL/HIGH 판단)
             6. 복약 데이터
                - 약의 종류
-               - 복약 여부
+               - 복약 여부 (반드시 "복용함" 또는 "복용하지 않음"으로 응답)
                - 복용 시간
             7. 건강 징후 데이터
                - 건강 징후 상세 내용 (짧은 문장들로 요약)
@@ -143,7 +143,7 @@ public class OpenAiHealthDataService {
               },
               "medicationData": {
                 "medicationType": "약 종류",
-                "taken": "복용 여부",
+                "taken": "복용함/복용하지 않음",
                 "takenTime": "복용 시간"
               },
               "healthSigns": ["건강 징후 상세 내용 1", "건강 징후 상세 내용 2"],


### PR DESCRIPTION
### Desc
- 현태 프롬프트에서는 복용 여부를 "예", "아니오"의 형태로 내려주고 있다.
- `MedicationTakenStatus`에는 상태값이 "복용함", "복용하지 않음"의 2가지로 정의되어 있어, 위의 복용 여부 응답과 매칭되지 않는 상황
- OpenAI 프롬프팅을 변경하여 값이 일관되게 "복용함", "복용하지 않음"으로 처리되도록 수정하여 `MedicationTakenStatus.fromDescription()`으로 처리할 수 있도록 수정하자