### PR TITLE
edit: 날짜 기반 api 호출시 예외처리 추가

### DIFF
--- a/src/main/java/com/example/medicare_call/service/HealthAnalysisService.java
+++ b/src/main/java/com/example/medicare_call/service/HealthAnalysisService.java
@@ -24,6 +24,10 @@ public class HealthAnalysisService {
 
         List<CareCallRecord> healthRecords = careCallRecordRepository.findByElderIdAndDateWithHealthData(elderId, date);
 
+        if (healthRecords.isEmpty()) {
+            throw new ResourceNotFoundException("해당 날짜에 건강 징후 데이터가 없습니다: " + date);
+        }
+
         CareCallRecord latestRecord = healthRecords.get(healthRecords.size() - 1);
         String healthDetails = latestRecord.getHealthDetails();
         List<String> symptomList = (healthDetails == null || healthDetails.isBlank()) ? List.of() : Arrays.stream(healthDetails.split(",")).map(String::trim).toList();

--- a/src/main/java/com/example/medicare_call/service/MealRecordService.java
+++ b/src/main/java/com/example/medicare_call/service/MealRecordService.java
@@ -27,6 +27,10 @@ public class MealRecordService {
         
         List<MealRecord> mealRecords = mealRecordRepository.findByElderIdAndDate(elderId, date);
         
+        if (mealRecords.isEmpty()) {
+            throw new ResourceNotFoundException("해당 날짜에 식사 데이터가 없습니다: " + date);
+        }
+        
         String breakfast = null;
         String lunch = null;
         String dinner = null;

--- a/src/main/java/com/example/medicare_call/service/MedicationService.java
+++ b/src/main/java/com/example/medicare_call/service/MedicationService.java
@@ -93,6 +93,11 @@ public class MedicationService {
                 .orElseThrow(() -> new ResourceNotFoundException("어르신을 찾을 수 없습니다: " + elderId));
 
         List<MedicationTakenRecord> takenRecords = medicationTakenRecordRepository.findByElderIdAndDate(elderId, date);
+
+        if (takenRecords.isEmpty()) {
+            throw new ResourceNotFoundException("해당 날짜에 복용 데이터가 없습니다: " + date);
+        }
+
         List<MedicationSchedule> schedules = medicationScheduleRepository.findByElder(elder);
 
         // 약 종류별 스케줄

--- a/src/main/java/com/example/medicare_call/service/MentalAnalysisService.java
+++ b/src/main/java/com/example/medicare_call/service/MentalAnalysisService.java
@@ -27,6 +27,10 @@ public class MentalAnalysisService {
         
         List<CareCallRecord> mentalRecords = careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(elderId, date);
 
+        if (mentalRecords.isEmpty()) {
+            throw new ResourceNotFoundException("해당 날짜에 심리 상태 데이터가 없습니다: " + date);
+        }
+
         List<String> commentList = new ArrayList<>();
 
         for (CareCallRecord record : mentalRecords) {

--- a/src/main/java/com/example/medicare_call/service/SleepRecordService.java
+++ b/src/main/java/com/example/medicare_call/service/SleepRecordService.java
@@ -31,15 +31,7 @@ public class SleepRecordService {
         List<CareCallRecord> sleepRecords = careCallRecordRepository.findByElderIdAndDateWithSleepData(elderId, date);
         
         if (sleepRecords.isEmpty()) {
-            return DailySleepResponse.builder()
-                    .date(date)
-                    .totalSleep(DailySleepResponse.TotalSleep.builder()
-                            .hours(0)
-                            .minutes(0)
-                            .build())
-                    .sleepTime(null)
-                    .wakeTime(null)
-                    .build();
+            throw new ResourceNotFoundException("해당 날짜에 수면 데이터가 없습니다: " + date);
         }
         
         // 가장 최근 수면 기록 사용

--- a/src/main/java/com/example/medicare_call/service/WeeklyBloodSugarService.java
+++ b/src/main/java/com/example/medicare_call/service/WeeklyBloodSugarService.java
@@ -35,6 +35,10 @@ public class WeeklyBloodSugarService {
         List<BloodSugarRecord> records = bloodSugarRecordRepository
                 .findByElderIdAndMeasurementTypeAndDateBetween(elderId, measurementType, startDate, endDate);
 
+        if (records.isEmpty()) {
+            throw new ResourceNotFoundException("해당 기간에 혈당 데이터가 없습니다: " + startDate + " ~ " + endDate);
+        }
+
         List<WeeklyBloodSugarResponse.BloodSugarData> data = records.stream()
                 .map(this::convertToBloodSugarData)
                 .collect(Collectors.toList());

--- a/src/test/java/com/example/medicare_call/controller/view/MealRecordControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/MealRecordControllerTest.java
@@ -134,7 +134,7 @@ class MealRecordControllerTest {
 
     @Test
     @DisplayName("날짜별 식사 데이터 조회 실패 - 존재하지 않는 어르신")
-    void getDailyMeals_NotFound() throws Exception {
+    void getDailyMeals_NoElder_Returns404() throws Exception {
         // given
         Integer elderId = 999999;
         String date = "2025-07-16";
@@ -149,5 +149,24 @@ class MealRecordControllerTest {
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.error").value("리소스를 찾을 수 없음"))
                 .andExpect(jsonPath("$.message").value("어르신을 찾을 수 없습니다: " + elderId));
+    }
+
+    @Test
+    @DisplayName("날짜별 식사 데이터 조회 실패 - 데이터 없음")
+    void getDailyMeals_NoData_Returns404() throws Exception {
+        // given
+        Integer elderId = 1;
+        LocalDate date = LocalDate.of(2024, 1, 1);
+        
+        when(mealRecordService.getDailyMeals(eq(elderId), any(LocalDate.class)))
+                .thenThrow(new ResourceNotFoundException("해당 날짜에 식사 데이터가 없습니다: " + date));
+
+        // when & then
+        mockMvc.perform(get("/elders/{elderId}/meals", elderId)
+                        .param("date", "2024-01-01"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("리소스를 찾을 수 없음"))
+                .andExpect(jsonPath("$.message").value("해당 날짜에 식사 데이터가 없습니다: " + date));
     }
 } 

--- a/src/test/java/com/example/medicare_call/controller/view/MentalAnalysisControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/MentalAnalysisControllerTest.java
@@ -117,7 +117,7 @@ class MentalAnalysisControllerTest {
 
     @Test
     @DisplayName("날짜별 심리 상태 데이터 조회 실패 - 존재하지 않는 어르신")
-    void getDailyMentalAnalysis_NotFound() throws Exception {
+    void getDailyMentalAnalysis_NoElder_Returns404() throws Exception {
         // given
         Integer elderId = 999999;
         String date = "2025-07-16";
@@ -132,5 +132,24 @@ class MentalAnalysisControllerTest {
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.error").value("리소스를 찾을 수 없음"))
                 .andExpect(jsonPath("$.message").value("어르신을 찾을 수 없습니다: " + elderId));
+    }
+
+    @Test
+    @DisplayName("날짜별 심리 상태 데이터 조회 실패 - 데이터 없음")
+    void getDailyMentalAnalysis_NoData_Returns404() throws Exception {
+        // given
+        Integer elderId = 1;
+        LocalDate date = LocalDate.of(2024, 1, 1);
+        
+        when(mentalAnalysisService.getDailyMentalAnalysis(eq(elderId), any(LocalDate.class)))
+                .thenThrow(new ResourceNotFoundException("해당 날짜에 심리 상태 데이터가 없습니다: " + date));
+
+        // when & then
+        mockMvc.perform(get("/elders/{elderId}/mental-analysis", elderId)
+                        .param("date", "2024-01-01"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("리소스를 찾을 수 없음"))
+                .andExpect(jsonPath("$.message").value("해당 날짜에 심리 상태 데이터가 없습니다: " + date));
     }
 } 

--- a/src/test/java/com/example/medicare_call/controller/view/SleepRecordControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/view/SleepRecordControllerTest.java
@@ -140,7 +140,7 @@ class SleepRecordControllerTest {
 
     @Test
     @DisplayName("날짜별 수면 데이터 조회 실패 - 존재하지 않는 어르신")
-    void getDailySleep_NotFound() throws Exception {
+    void getDailySleep_NoElder_Returns404() throws Exception {
         // given
         Integer elderId = 999999;
         String date = "2025-07-16";
@@ -155,5 +155,24 @@ class SleepRecordControllerTest {
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.error").value("리소스를 찾을 수 없음"))
                 .andExpect(jsonPath("$.message").value("어르신을 찾을 수 없습니다: " + elderId));
+    }
+
+    @Test
+    @DisplayName("날짜별 수면 데이터 조회 실패 - 데이터 없음")
+    void getDailySleep_NoData_Returns404() throws Exception {
+        // given
+        Integer elderId = 1;
+        LocalDate date = LocalDate.of(2024, 1, 1);
+        
+        when(sleepRecordService.getDailySleep(eq(elderId), any(LocalDate.class)))
+                .thenThrow(new ResourceNotFoundException("해당 날짜에 수면 데이터가 없습니다: " + date));
+
+        // when & then
+        mockMvc.perform(get("/elders/{elderId}/sleep", elderId)
+                        .param("date", "2024-01-01"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("리소스를 찾을 수 없음"))
+                .andExpect(jsonPath("$.message").value("해당 날짜에 수면 데이터가 없습니다: " + date));
     }
 } 

--- a/src/test/java/com/example/medicare_call/service/MedicationServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/MedicationServiceTest.java
@@ -18,6 +18,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -399,5 +401,21 @@ class MedicationServiceTest {
         assertThatThrownBy(() -> medicationService.getDailyMedication(elderId, date))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("어르신을 찾을 수 없습니다: " + elderId);
+    }
+
+    @Test
+    @DisplayName("복약 식사 데이터 조회 실패 - 데이터 없음")
+    void getDailyMedication_ThrowsResourceNotFoundException() {
+        // given
+        Integer elderId = 1;
+        LocalDate date = LocalDate.of(2024, 1, 1);
+
+        when(elderRepository.findById(elderId)).thenReturn(Optional.of(new Elder()));
+        when(medicationTakenRecordRepository.findByElderIdAndDate(elderId, date)).thenReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> medicationService.getDailyMedication(elderId, date))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("해당 날짜에 복용 데이터가 없습니다: " + date);
     }
 } 

--- a/src/test/java/com/example/medicare_call/service/MentalAnalysisServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/MentalAnalysisServiceTest.java
@@ -18,11 +18,17 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+
+import com.example.medicare_call.global.ResourceNotFoundException;
 
 @ExtendWith(MockitoExtension.class)
 class MentalAnalysisServiceTest {
@@ -99,8 +105,8 @@ class MentalAnalysisServiceTest {
     }
 
     @Test
-    @DisplayName("심리 상태 데이터 조회 성공 - 데이터 없음")
-    void getDailyMentalAnalysis_성공_데이터없음() {
+    @DisplayName("심리 상태 데이터 조회 실패 - 데이터 없음")
+    void getDailyMentalAnalysis_NoData_ThrowsResourceNotFoundException() {
         // given
         Integer elderId = 1;
         LocalDate date = LocalDate.of(2025, 7, 16);
@@ -111,12 +117,10 @@ class MentalAnalysisServiceTest {
         when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(elderId, date))
                 .thenReturn(Collections.emptyList());
 
-        // when
-        DailyMentalAnalysisResponse response = mentalAnalysisService.getDailyMentalAnalysis(elderId, date);
-
-        // then
-        assertThat(response.getDate()).isEqualTo(date);
-        assertThat(response.getCommentList()).isEmpty();
+        // when & then
+        assertThatThrownBy(() -> mentalAnalysisService.getDailyMentalAnalysis(elderId, date))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("해당 날짜에 심리 상태 데이터가 없습니다: " + date);
     }
 
     @Test

--- a/src/test/java/com/example/medicare_call/service/SleepRecordServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/SleepRecordServiceTest.java
@@ -19,11 +19,16 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.DisplayName;
+import com.example.medicare_call.global.ResourceNotFoundException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 class SleepRecordServiceTest {
@@ -132,8 +137,8 @@ class SleepRecordServiceTest {
     }
 
     @Test
-    @DisplayName("수면 데이터 조회 성공 - 데이터 없음")
-    void getDailySleep_데이터_없음() {
+    @DisplayName("수면 데이터 조회 실패 - 데이터 없음")
+    void getDailySleep_NoData_ThrowsResourceNotFoundException() {
         // given
         Integer elderId = 1;
         LocalDate date = LocalDate.of(2025, 7, 16);
@@ -144,14 +149,9 @@ class SleepRecordServiceTest {
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(elderId, date))
                 .thenReturn(Collections.emptyList());
 
-        // when
-        DailySleepResponse response = sleepRecordService.getDailySleep(elderId, date);
-
-        // then
-        assertThat(response.getDate()).isEqualTo(date);
-        assertThat(response.getTotalSleep().getHours()).isEqualTo(0);
-        assertThat(response.getTotalSleep().getMinutes()).isEqualTo(0);
-        assertThat(response.getSleepTime()).isNull();
-        assertThat(response.getWakeTime()).isNull();
+        // when & then
+        assertThatThrownBy(() -> sleepRecordService.getDailySleep(elderId, date))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("해당 날짜에 수면 데이터가 없습니다: " + date);
     }
 } 

--- a/src/test/java/com/example/medicare_call/service/WeeklyBloodSugarServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/WeeklyBloodSugarServiceTest.java
@@ -24,9 +24,13 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.example.medicare_call.global.ResourceNotFoundException;
 
 @ExtendWith(MockitoExtension.class)
 class WeeklyBloodSugarServiceTest {
@@ -90,8 +94,8 @@ class WeeklyBloodSugarServiceTest {
     }
 
     @Test
-    @DisplayName("주간 혈당 데이터 조회 성공 - 데이터 없음")
-    void getWeeklyBloodSugar_성공_데이터없음() {
+    @DisplayName("주간 혈당 데이터 조회 실패 - 데이터 없음")
+    void getWeeklyBloodSugar_NoData_ThrowsResourceNotFoundException() {
         // given
         Integer elderId = 1;
         LocalDate startDate = LocalDate.of(2025, 7, 14);
@@ -104,15 +108,10 @@ class WeeklyBloodSugarServiceTest {
                 elderId, BloodSugarMeasurementType.BEFORE_MEAL, startDate, startDate.plusDays(6)))
                 .thenReturn(Collections.emptyList());
 
-        // when
-        WeeklyBloodSugarResponse response = weeklyBloodSugarService.getWeeklyBloodSugar(elderId, startDate, typeStr);
-
-        // then
-        assertThat(response.getPeriod().getStartDate()).isEqualTo(startDate);
-        assertThat(response.getPeriod().getEndDate()).isEqualTo(startDate.plusDays(6));
-        assertThat(response.getData()).isEmpty();
-        assertThat(response.getAverage()).isNull();
-        assertThat(response.getLatest()).isNull();
+        // when & then
+        assertThatThrownBy(() -> weeklyBloodSugarService.getWeeklyBloodSugar(elderId, startDate, typeStr))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("해당 기간에 혈당 데이터가 없습니다: " + startDate + " ~ " + startDate.plusDays(6));
     }
 
     @Test


### PR DESCRIPTION
### Desc
- elderId 파라미터 값에 대해, 매칭되는 레코드가 없을 경우, ResourceNotFound를 반환하도록 현재 api들이 구현되어 있다.
- 날짜 기반으로 api를 호출, 데이터 조회를 하는 경우, 해당 날짜에 데이터가 없다면 ResourceNotFound를 반환하도록 처리하자
- 예외 처리에 대한 단위 테스트도 추가하자