### PR TITLE
Fix/call request data

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/action/CallDataController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/CallDataController.java
@@ -25,6 +25,6 @@ public class CallDataController {
     public ResponseEntity<CareCallRecord> receiveCallData(@Valid @RequestBody CallDataRequest request) {
         log.info("통화 데이터 수신: elderId={}, settingId={}", request.getElderId(), request.getSettingId());
         CareCallRecord savedRecord = callDataService.saveCallData(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(savedRecord);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 } 

--- a/src/main/java/com/example/medicare_call/dto/CallDataRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/CallDataRequest.java
@@ -33,11 +33,15 @@ public class CallDataRequest {
     
     @Schema(description = "통화 종료 시간", example = "2025-07-27T21:45:00Z")
     private Instant endTime;
-    
+
     @Schema(description = "통화 상태", example = "completed")
     @NotBlank(message = "통화 상태는 필수입니다.")
     @Pattern(regexp = "^(completed|failed|busy|no-answer)$", message = "통화 상태는 completed, failed, busy, no-answer 중 하나여야 합니다.")
     private String status;
+
+    @Schema(description = "응답 여부", example = "1")
+    @NotNull(message = "응답 여부는 필수입니다.")
+    private Byte responded;
     
     @Schema(description = "통화 녹음 텍스트")
     private TranscriptionData transcription;

--- a/src/main/java/com/example/medicare_call/service/CallDataService.java
+++ b/src/main/java/com/example/medicare_call/service/CallDataService.java
@@ -49,6 +49,8 @@ public class CallDataService {
         CareCallRecord record = CareCallRecord.builder()
                 .elder(elder)
                 .setting(setting)
+                .calledAt(LocalDateTime.now())
+                .responded(request.getResponded())
                 .startTime(request.getStartTime() != null ? LocalDateTime.ofInstant(request.getStartTime(), ZoneOffset.UTC) : null)
                 .endTime(request.getEndTime() != null ? LocalDateTime.ofInstant(request.getEndTime(), ZoneOffset.UTC) : null)
                 .callStatus(request.getStatus())

--- a/src/main/java/com/example/medicare_call/service/CareCallSchedulerService.java
+++ b/src/main/java/com/example/medicare_call/service/CareCallSchedulerService.java
@@ -22,19 +22,19 @@ public class CareCallSchedulerService {
         //1차 케어콜
         List<CareCallSetting> firstTargets = settingRepository.findByFirstCallTime(now);
         for (CareCallSetting setting : firstTargets) {
-            careCallService.sendCall(setting.getElder().getId(), CallType.FIRST);
+            careCallService.sendCall(setting.getId(), setting.getElder().getId(), CallType.FIRST);
         }
 
         //2차 케어콜
         List<CareCallSetting> secondTargets = settingRepository.findBySecondCallTime(now);
         for (CareCallSetting setting : secondTargets) {
-            careCallService.sendCall(setting.getElder().getId(), CallType.SECOND);
+            careCallService.sendCall(setting.getId(), setting.getElder().getId(), CallType.SECOND);
         }
 
         //3차 케어콜
         List<CareCallSetting> thirdTargets = settingRepository.findBySecondCallTime(now);
         for (CareCallSetting setting : thirdTargets) {
-            careCallService.sendCall(setting.getElder().getId(), CallType.THIRD);
+            careCallService.sendCall(setting.getId(), setting.getElder().getId(), CallType.THIRD);
         }
     }
 }

--- a/src/test/java/com/example/medicare_call/controller/action/CallDataControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/action/CallDataControllerTest.java
@@ -69,7 +69,7 @@ class CallDataControllerTest {
                 .speaker("고객")
                 .text("안녕하세요, 오늘 컨디션은 어떠세요?")
                 .build();
-        
+
         CallDataRequest.TranscriptionData.TranscriptionSegment segment2 = CallDataRequest.TranscriptionData.TranscriptionSegment.builder()
                 .speaker("어르신")
                 .text("네, 오늘은 컨디션이 좋아요.")
@@ -86,17 +86,18 @@ class CallDataControllerTest {
                 .startTime(Instant.parse("2025-01-27T10:00:00Z"))
                 .endTime(Instant.parse("2025-01-27T10:15:00Z"))
                 .status("completed")
+                .responded((byte)1)
                 .transcription(transcriptionData)
                 .build();
 
         Elder elder = Elder.builder()
                 .id(1)
                 .build();
-        
+
         CareCallSetting setting = CareCallSetting.builder()
                 .id(2)
                 .build();
-        
+
         CareCallRecord savedRecord = CareCallRecord.builder()
                 .id(1)
                 .elder(elder)
@@ -116,10 +117,7 @@ class CallDataControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(1))
-                .andExpect(jsonPath("$.callStatus").value("completed"))
-
-                .andExpect(jsonPath("$.transcriptionText").value("고객: 안녕하세요, 오늘 컨디션은 어떠세요?\n어르신: 네, 오늘은 컨디션이 좋아요."));
+                .andExpect(content().string(""));
     }
 
     @Test
@@ -129,6 +127,7 @@ class CallDataControllerTest {
         CallDataRequest request = CallDataRequest.builder()
                 .settingId(2)
                 .status("completed")
+                .responded((byte)1)
                 .build();
 
         // when & then
@@ -195,16 +194,17 @@ class CallDataControllerTest {
                 .elderId(1)
                 .settingId(2)
                 .status("completed")
+                .responded((byte)1)
                 .build();
 
         Elder elder = Elder.builder()
                 .id(1)
                 .build();
-        
+
         CareCallSetting setting = CareCallSetting.builder()
                 .id(2)
                 .build();
-        
+
         CareCallRecord savedRecord = CareCallRecord.builder()
                 .id(1)
                 .elder(elder)
@@ -220,8 +220,6 @@ class CallDataControllerTest {
         mockMvc.perform(post("/call-data")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(1))
-                .andExpect(jsonPath("$.callStatus").value("completed"));
+                .andExpect(content().string(""));
     }
-} 
+}

--- a/src/test/java/com/example/medicare_call/service/CareCallSchedulerServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/CareCallSchedulerServiceTest.java
@@ -52,7 +52,7 @@ public class CareCallSchedulerServiceTest {
         schedulerService.checkAndSendCalls();
 
         // then
-        verify(callService).sendCall(1, CallType.FIRST);
-        verify(callService).sendCall(2, CallType.SECOND);
+        verify(callService).sendCall(firstSetting.getId(),1, CallType.FIRST);
+        verify(callService).sendCall(secondSetting.getId(),2, CallType.SECOND);
     }
 }


### PR DESCRIPTION
## Desc 
- CareCallRecord에 맞게 request 및 dto 수정
- `receiveCallData` API 에서 발생 한 오류 해결 
### 변경 전
```java
CareCallRecord savedRecord = callDataService.saveCallData(request);
return ResponseEntity.status(HttpStatus.CREATED).body(savedRecord);
```
- CareCallRecord 엔티티 자체를 HTTP 응답 본문으로 반환
- 이 엔티티 내부에는 elder, setting 등 다른 엔티티와의 연관 관계 필드가 있고,
대부분이 Lazy Loading 프록시 객체 형태로 들어있음
Jackson이 이 프록시 객체(ByteBuddyInterceptor)를 직렬화하려고 하다가 직렬화 불가 예외(No serializer found ...) 발생

### 변경 후
```java
return ResponseEntity.status(HttpStatus.OK).build();
````
- 응답 본문(body)이 없도록 변경
- 이에 따른 test 코드 변경 

