### PR TITLE
feat: DB Migrate Order Table

### DIFF
--- a/src/main/java/com/example/medicare_call/domain/Order.java
+++ b/src/main/java/com/example/medicare_call/domain/Order.java
@@ -1,0 +1,106 @@
+package com.example.medicare_call.domain;
+
+import com.example.medicare_call.global.enums.OrderStatus;
+import com.example.medicare_call.global.enums.PaymentMethod;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "Orders")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Order {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "code", nullable = false, unique = true, length = 64)
+    private String code;
+
+    // TODO: 플랜 목록들을 Enum, 혹은 테이블로 분리하여 사용
+    @Column(name = "product_name", nullable = false, length = 128)
+    private String productName;
+    
+    @Column(name = "product_count", nullable = false)
+    private Integer productCount;
+    
+    @Column(name = "total_pay_amount", nullable = false)
+    private Integer totalPayAmount;
+    
+    @Column(name = "tax_scope_amount", nullable = false)
+    private Integer taxScopeAmount; // 과세 금액
+    
+    @Column(name = "tax_ex_scope_amount", nullable = false)
+    private Integer taxExScopeAmount; // 면세 금액
+    
+    @Column(name = "naverpay_reserve_id", length = 64)
+    private String naverpayReserveId; // 네이버페이 결제 예약 번호
+    
+    @Column(name = "naverpay_payment_id", length = 64)
+    private String naverpayPaymentId; // 네이버페이 결제 번호
+    
+    @Column(name = "naverpay_hist_id", length = 64)
+    private String naverpayHistId; // 네이버페이 결제 이력 번호
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private OrderStatus status;
+    
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+    
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+    
+    @Column(name = "approved_at")
+    private LocalDateTime approvedAt;
+    
+    // 결제한 회원 정보
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+    
+    // 결제 대상 어르신 ID 목록 (JSON 형태로 저장: "[1,2,3]")
+    // TODO: 소주문 테이블로 분리 여부를 검토
+    @Column(name = "elder_ids", columnDefinition = "JSON")
+    private String elderIds;
+    
+    // 결제 수단
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_method", nullable = false, length = 20)
+    private PaymentMethod paymentMethod;
+    
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+        if (status == null) {
+            status = OrderStatus.CREATED;
+        }
+    }
+    
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    // 결제 승인 시 호출되는 메서드
+    public void approvePayment(String naverpayPaymentId, String naverpayHistId) {
+        this.naverpayPaymentId = naverpayPaymentId;
+        this.naverpayHistId = naverpayHistId;
+        this.status = OrderStatus.PAYMENT_COMPLETED;
+        this.approvedAt = LocalDateTime.now();
+    }
+    
+    // 결제 실패 시 호출되는 메서드
+    public void failPayment() {
+        this.status = OrderStatus.PAYMENT_FAILED;
+    }
+}

--- a/src/main/java/com/example/medicare_call/global/enums/OrderStatus.java
+++ b/src/main/java/com/example/medicare_call/global/enums/OrderStatus.java
@@ -1,0 +1,23 @@
+package com.example.medicare_call.global.enums;
+
+/**
+ * 주문 상태 enum
+ * 주문의 전체 생명주기를 관리합니다.
+ */
+public enum OrderStatus {
+    CREATED("주문 생성됨"),
+    PAYMENT_PENDING("결제 대기중"),
+    PAYMENT_COMPLETED("결제 완료"),
+    PAYMENT_FAILED("결제 실패"),
+    CANCELLED("주문 취소");
+    
+    private final String description;
+    
+    OrderStatus(String description) {
+        this.description = description;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/example/medicare_call/global/enums/PaymentMethod.java
+++ b/src/main/java/com/example/medicare_call/global/enums/PaymentMethod.java
@@ -1,0 +1,19 @@
+package com.example.medicare_call.global.enums;
+
+/**
+ * 결제 수단 enum
+ * 현재는 네이버페이만 지원하며, 향후 다른 결제 수단이 추가될 수 있습니다.
+ */
+public enum PaymentMethod {
+    NAVER_PAY("네이버페이");
+    
+    private final String description;
+    
+    PaymentMethod(String description) {
+        this.description = description;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/example/medicare_call/repository/OrderRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/OrderRepository.java
@@ -1,0 +1,39 @@
+package com.example.medicare_call.repository;
+
+import com.example.medicare_call.domain.Order;
+import com.example.medicare_call.global.enums.OrderStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+    
+    /**
+     * 주문 코드로 주문 조회
+     */
+    Optional<Order> findByCode(String code);
+    
+    /**
+     * 네이버페이 결제번호로 주문 조회
+     */
+    Optional<Order> findByNaverpayPaymentId(String naverpayPaymentId);
+    
+    /**
+     * 주문 코드와 상태로 주문 조회
+     */
+    Optional<Order> findByCodeAndStatus(String code, OrderStatus status);
+    
+    /**
+     * 주문 코드가 존재하는지 확인
+     */
+    boolean existsByCode(String code);
+    
+    /**
+     * 네이버페이 결제번호가 존재하는지 확인
+     */
+    boolean existsByNaverpayPaymentId(String naverpayPaymentId);
+}

--- a/src/main/resources/db/migration/V12__create_orders_table.sql
+++ b/src/main/resources/db/migration/V12__create_orders_table.sql
@@ -1,0 +1,21 @@
+-- 주문 테이블 생성
+CREATE TABLE Orders (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    code VARCHAR(64) NOT NULL UNIQUE,
+    product_name VARCHAR(128) NOT NULL,
+    product_count INT NOT NULL,
+    total_pay_amount INT NOT NULL,
+    tax_scope_amount INT NOT NULL,
+    tax_ex_scope_amount INT NOT NULL,
+    naverpay_reserve_id VARCHAR(64),
+    naverpay_payment_id VARCHAR(64),
+    naverpay_hist_id VARCHAR(64),
+    status ENUM('CREATED','PAYMENT_PENDING','PAYMENT_COMPLETED','PAYMENT_FAILED','CANCELLED') NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    approved_at DATETIME,
+    member_id INT NOT NULL,
+    elder_ids JSON,
+    payment_method ENUM('NAVER_PAY') NOT NULL,
+    FOREIGN KEY (member_id) REFERENCES Member(id)
+);


### PR DESCRIPTION
### Desc
- 서드 파티 결제 API와는 별도로, 서비스 내에서 주문을 관리하기 위한 테이블을 추가하기 위한 migration
- 현재 결제 수단은 네이버페이만을 지원하지만, 확장 가능하도록 설계하였음
  - 확장에 따라 테이블 구조 변경이 필요할 수 있는데, 이 부분은 도메인에 주석으로 설명을 추가하였음
  - 서드파티에서 사용되는 값들도 nullable한 별도 컬럼으로 추가하였음.
    - 결제 수단과 관계없이 컬럼을 통일하고 substring을 붙이는 방법도 있는데, 경험상 문제가 많았던지라 다른 방식으로 구현해보았다.
    - e.g. 주문 코드를 `naverpay_012`, `kakaopay_012` 이런식으로.. 한 컬럼에 넣는다던지..
- MVP 단계에서는 대주문, 소주문을 구분하지 않고 단일 테이블 형태로 사용하자.