### PR TITLE
feat: 주문 예약 요청 API 구현

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/action/NaverPayController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/NaverPayController.java
@@ -1,0 +1,132 @@
+package com.example.medicare_call.controller.action;
+
+import com.example.medicare_call.dto.NaverPayReserveRequest;
+import com.example.medicare_call.dto.NaverPayReserveResponse;
+import com.example.medicare_call.service.NaverPayService;
+import com.example.medicare_call.global.annotation.AuthUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+
+@Slf4j
+@RestController
+@RequestMapping("/payments")
+@RequiredArgsConstructor
+@Tag(name = "네이버페이 결제", description = "네이버페이 결제 관련 API")
+public class NaverPayController {
+
+    private final NaverPayService naverPayService;
+
+    @PostMapping("/reserve")
+    @Operation(
+        summary = "결제 요청 생성", 
+        description = "네이버페이 결제를 위한 주문 내역을 우리 서비스 DB에 생성합니다. 생성된 주문 정보는 안드로이드에서 네이버페이 SDK를 사용하여 결제를 진행하는 데 사용됩니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200", 
+            description = "주문 내역 생성 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = NaverPayReserveResponse.class),
+                examples = @ExampleObject(
+                    name = "성공 응답",
+                    value = """
+                    {
+                        "code": "Success",
+                        "message": "주문이 성공적으로 생성되었습니다.",
+                        "body": {
+                            "code": "550e8400-e29b-41d4-a716-446655440000"
+                        }
+                    }
+                    """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400", 
+            description = "잘못된 요청",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    name = "검증 오류",
+                    value = """
+                    {
+                        "status": 400,
+                        "error": "잘못된 요청 (Validation)",
+                        "message": "입력값이 올바르지 않습니다."
+                    }
+                    """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500", 
+            description = "서버 오류",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    name = "서버 오류",
+                    value = """
+                    {
+                        "status": 500,
+                        "error": "서버 오류",
+                        "message": "주문 내역 생성 중 오류가 발생했습니다."
+                    }
+                    """
+                )
+            )
+        )
+    })
+    public ResponseEntity<NaverPayReserveResponse> createPaymentReserve(
+            @Parameter(
+                description = "주문 내역 생성 요청 정보",
+                required = true,
+                content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = NaverPayReserveRequest.class),
+                    examples = @ExampleObject(
+                        name = "요청 예시",
+                        value = """
+                        {
+                            "productName": "메디케어콜 스탠다드 플랜",
+                            "productCount": 1,
+                            "totalPayAmount": 19000,
+                            "taxScopeAmount": 19000,
+                            "taxExScopeAmount": 0,
+                            "returnUrl": "https://example.com/payment/complete",
+                            "productItems": [
+                                {
+                                    "categoryType": "ETC",
+                                    "categoryId": "ETC",
+                                    "uid": "PRODUCT_123",
+                                    "name": "메디케어콜 스탠다드 플랜",
+                                    "count": 1
+                                }
+                            ]
+                        }
+                        """
+                    )
+                )
+            )
+            @Valid @RequestBody NaverPayReserveRequest request,
+            @Parameter(hidden = true) @AuthUser Long memberId) {
+        
+        log.info("결제 요청 생성 API 호출 - productName: {}, totalPayAmount: {}", 
+            request.getProductName(), request.getTotalPayAmount());
+        
+        NaverPayReserveResponse response = naverPayService.createPaymentReserve(request, memberId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/medicare_call/dto/NaverPayReserveRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/NaverPayReserveRequest.java
@@ -1,0 +1,58 @@
+package com.example.medicare_call.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "네이버페이 결제 예약 요청")
+public class NaverPayReserveRequest {
+
+    @Schema(description = "대표 상품명", example = "메디케어콜 스탠다드 플랜")
+    @JsonProperty("productName")
+    @NotBlank(message = "상품명은 필수입니다.")
+    @Size(max = 128, message = "상품명은 128자 이하여야 합니다.")
+    private String productName;
+
+    @Schema(description = "상품 수량", example = "1")
+    @JsonProperty("productCount")
+    @NotNull(message = "상품 수량은 필수입니다.")
+    @Min(value = 1, message = "상품 수량은 1 이상이어야 합니다.")
+    private Integer productCount;
+
+    @Schema(description = "총 결제 금액", example = "19000")
+    @JsonProperty("totalPayAmount")
+    @NotNull(message = "총 결제 금액은 필수입니다.")
+    @Min(value = 10, message = "총 결제 금액은 10원 이상이어야 합니다.")
+    private Integer totalPayAmount;
+
+    @Schema(description = "과세 금액", example = "15000")
+    @JsonProperty("taxScopeAmount")
+    @NotNull(message = "과세 금액은 필수입니다.")
+    @Min(value = 0, message = "과세 금액은 0원 이상이어야 합니다.")
+    private Integer taxScopeAmount;
+
+    @Schema(description = "면세 금액", example = "4000")
+    @JsonProperty("taxExScopeAmount")
+    @NotNull(message = "면세 금액은 필수입니다.")
+    @Min(value = 0, message = "면세 금액은 0원 이상이어야 합니다.")
+    private Integer taxExScopeAmount;
+
+    @Schema(description = "결제 대상 어르신 ID 목록", example = "[1, 2, 3]")
+    @JsonProperty("elderIds")
+    @NotNull(message = "어르신 ID 목록은 필수입니다.")
+    @Size(min = 1, message = "어르신 ID 목록은 최소 1개 이상이어야 합니다.")
+    private List<Long> elderIds;
+}

--- a/src/main/java/com/example/medicare_call/dto/NaverPayReserveResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/NaverPayReserveResponse.java
@@ -1,0 +1,39 @@
+package com.example.medicare_call.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "네이버페이 결제 예약 응답")
+public class NaverPayReserveResponse {
+
+    @Schema(description = "결과 코드", example = "Success")
+    @JsonProperty("code")
+    private String code;
+
+    @Schema(description = "결과 메시지", example = "결제 예약이 성공적으로 생성되었습니다.")
+    @JsonProperty("message")
+    private String message;
+
+    @Schema(description = "응답 본문")
+    @JsonProperty("body")
+    private ReserveBody body;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "결제 예약 응답 본문")
+    public static class ReserveBody {
+        @Schema(description = "주문 코드 (UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
+        @JsonProperty("code")
+        private String code;
+    }
+}

--- a/src/main/java/com/example/medicare_call/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/medicare_call/global/GlobalExceptionHandler.java
@@ -84,6 +84,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
     }
 
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException e) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "서버 오류",
+                e.getMessage()
+        );
+        log.error("RuntimeException: {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGenericException(Exception e) {
         ErrorResponse errorResponse = new ErrorResponse(

--- a/src/main/java/com/example/medicare_call/service/NaverPayService.java
+++ b/src/main/java/com/example/medicare_call/service/NaverPayService.java
@@ -1,0 +1,158 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.Order;
+import com.example.medicare_call.domain.Member;
+import com.example.medicare_call.dto.NaverPayReserveRequest;
+import com.example.medicare_call.dto.NaverPayReserveResponse;
+import com.example.medicare_call.repository.OrderRepository;
+import com.example.medicare_call.repository.MemberRepository;
+import com.example.medicare_call.repository.ElderRepository;
+import com.example.medicare_call.global.enums.OrderStatus;
+import com.example.medicare_call.global.enums.PaymentMethod;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NaverPayService {
+
+    private final RestTemplate restTemplate;
+    private final OrderRepository orderRepository;
+    private final MemberRepository memberRepository;
+    private final ElderRepository elderRepository;
+    private final ObjectMapper objectMapper;
+
+    @Value("${naverpay.client.id}")
+    private String clientId;
+
+    @Value("${naverpay.client.secret}")
+    private String clientSecret;
+
+    @Value("${naverpay.chain.id}")
+    private String chainId;
+
+    @Value("${naverpay.api.url}")
+    private String apiUrl;
+
+    @Value("${naverpay.partner.id}")
+    private String partnerId;
+
+    /**
+     * 네이버페이 결제 예약 생성
+     * 안드로이드에서는 이 주문 정보를 바탕으로 네이버페이 SDK를 사용하여 결제를 진행합니다.
+     * 
+     * @param request 결제 예약 요청 정보
+     * @return 결제 예약 응답
+     */
+    @Transactional
+    public NaverPayReserveResponse createPaymentReserve(NaverPayReserveRequest request, Long memberId) {
+        log.info("네이버페이 결제 예약 생성 시작 - memberId: {}", memberId);
+
+        // 주문 내역 검증
+        validateReserveRequest(request);
+        
+        // UUID v4로 고유 주문 코드 생성
+        String orderCode;
+        int maxRetries = 3;
+        int retryCount = 0;
+        do {
+            orderCode = UUID.randomUUID().toString();
+            if (retryCount++ > maxRetries) {
+                throw new IllegalStateException("주문 번호 생성에 " + maxRetries + "회 실패했습니다.");
+            }
+        } while (orderRepository.existsByCode(orderCode));
+        
+        // 회원 정보 조회
+        Member member = memberRepository.findById(memberId.intValue())
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다: " + memberId));
+        
+        // 어르신 정보 검증
+        validateElderIds(request.getElderIds());
+        
+        // elderIds를 JSON 형태로 변환
+        String elderIdsJson;
+        try {
+            elderIdsJson = objectMapper.writeValueAsString(request.getElderIds());
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("어르신 ID 목록을 JSON으로 변환하는 중 오류가 발생했습니다.", e);
+        }
+        
+        // 주문 내역 생성 및 DB 저장
+        Order order = Order.builder()
+            .code(orderCode)
+            .productName(request.getProductName())
+            .productCount(request.getProductCount())
+            .totalPayAmount(request.getTotalPayAmount())
+            .taxScopeAmount(request.getTaxScopeAmount())
+            .taxExScopeAmount(request.getTaxExScopeAmount())
+            .naverpayReserveId("ORDER_" + System.currentTimeMillis())
+            .status(OrderStatus.CREATED)
+            .member(member)
+            .elderIds(elderIdsJson)
+            .paymentMethod(PaymentMethod.NAVER_PAY)
+            .build();
+        
+        Order savedOrder = orderRepository.save(order);
+        
+        NaverPayReserveResponse response = NaverPayReserveResponse.builder()
+            .code("Success")
+            .message("주문이 성공적으로 생성되었습니다.")
+            .body(NaverPayReserveResponse.ReserveBody.builder()
+                .code(savedOrder.getCode())
+                .build())
+            .build();
+
+        log.info("네이버페이 결제 예약 생성 성공 - code: {}, naverpayReserveId: {}, orderId: {}, memberId: {}, elderIds: {}", 
+            savedOrder.getCode(), savedOrder.getNaverpayReserveId(), savedOrder.getId(), memberId, request.getElderIds());
+
+        return response;
+    }
+
+    /**
+     * 결제 예약 요청 검증
+     * @param request 결제 예약 요청
+     */
+    private void validateReserveRequest(NaverPayReserveRequest request) {
+        if (request.getProductName() == null || request.getProductName().trim().isEmpty()) {
+            throw new IllegalArgumentException("상품명은 필수입니다.");
+        }
+        if (request.getTotalPayAmount() == null || request.getTotalPayAmount() < 10) {
+            throw new IllegalArgumentException("총 결제 금액은 10원 이상이어야 합니다.");
+        }
+        if (request.getTaxScopeAmount() == null || request.getTaxScopeAmount() < 0) {
+            throw new IllegalArgumentException("과세 금액은 0원 이상이어야 합니다.");
+        }
+        if (request.getTaxExScopeAmount() == null || request.getTaxExScopeAmount() < 0) {
+            throw new IllegalArgumentException("면세 금액은 0원 이상이어야 합니다.");
+        }
+        // 과세 금액 + 면세 금액 = 총 결제 금액 검증
+        if (request.getTaxScopeAmount() + request.getTaxExScopeAmount() != request.getTotalPayAmount()) {
+            throw new IllegalArgumentException("과세 금액과 면세 금액의 합이 총 결제 금액과 일치해야 합니다.");
+        }
+        if (request.getElderIds() == null || request.getElderIds().isEmpty()) {
+            throw new IllegalArgumentException("어르신 ID 목록은 필수입니다.");
+        }
+    }
+
+    /**
+     * 어르신 ID 목록 검증
+     * @param elderIds 어르신 ID 목록
+     */
+    private void validateElderIds(List<Long> elderIds) {
+        for (Long elderId : elderIds) {
+            if (!elderRepository.existsById(elderId.intValue())) {
+                throw new IllegalArgumentException("존재하지 않는 어르신입니다: " + elderId);
+            }
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,6 +63,17 @@ openai:
     url: ${OPENAI_API_URL}
   model: ${OPENAI_API_MODEL}
 
+naverpay:
+  client:
+    id: ${NAVERPAY_CLIENT_ID}
+    secret: ${NAVERPAY_CLIENT_SECRET}
+  chain:
+    id: ${NAVERPAY_CHAIN_ID}
+  partner:
+    id: ${NAVERPAY_PARTNER_ID}
+  api:
+    url: ${NAVERPAY_API_URL}
+
 ---
 spring:
   config:
@@ -117,3 +128,14 @@ openai:
     key: ${OPENAI_API_KEY}
     url: ${OPENAI_API_URL}
   model: ${OPENAI_API_MODEL}
+
+naverpay:
+  client:
+    id: ${NAVERPAY_CLIENT_ID}
+    secret: ${NAVERPAY_CLIENT_SECRET}
+  chain:
+    id: ${NAVERPAY_CHAIN_ID}
+  partner:
+    id: ${NAVERPAY_PARTNER_ID}
+  api:
+    url: ${NAVERPAY_API_URL}

--- a/src/test/java/com/example/medicare_call/controller/action/NaverPayControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/action/NaverPayControllerTest.java
@@ -1,0 +1,129 @@
+package com.example.medicare_call.controller.action;
+
+import com.example.medicare_call.dto.NaverPayReserveRequest;
+import com.example.medicare_call.dto.NaverPayReserveResponse;
+import com.example.medicare_call.global.annotation.AuthUser;
+import com.example.medicare_call.global.jwt.JwtProvider;
+import com.example.medicare_call.repository.ElderRepository;
+import com.example.medicare_call.service.NaverPayService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import com.example.medicare_call.global.GlobalExceptionHandler;
+
+import java.util.Arrays;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(NaverPayController.class)
+class NaverPayControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private NaverPayService naverPayService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private ElderRepository elderRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        // @AuthUser 어노테이션을 처리하기 위한 커스텀 ArgumentResolver 설정
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new NaverPayController(naverPayService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new TestAuthUserArgumentResolver())
+                .build();
+    }
+
+    // @AuthUser 어노테이션을 테스트용으로 처리하는 ArgumentResolver
+    private static class TestAuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+        @Override
+        public boolean supportsParameter(org.springframework.core.MethodParameter parameter) {
+            return parameter.hasParameterAnnotation(AuthUser.class);
+        }
+
+        @Override
+        public Object resolveArgument(org.springframework.core.MethodParameter parameter, 
+                                   org.springframework.web.method.support.ModelAndViewContainer mavContainer,
+                                   org.springframework.web.context.request.NativeWebRequest webRequest, 
+                                   org.springframework.web.bind.support.WebDataBinderFactory binderFactory) {
+            return 1L; // 테스트용 고정 memberId
+        }
+    }
+
+    @Test
+    @DisplayName("주문 내역 생성 성공")
+    void createPaymentReserve_success() throws Exception {
+        // given
+        NaverPayReserveRequest request = NaverPayReserveRequest.builder()
+                .productName("의료 상담 서비스")
+                .productCount(1)
+                .totalPayAmount(10000)
+                .taxScopeAmount(10000)
+                .taxExScopeAmount(0)
+                .elderIds(Arrays.asList(1L, 2L))
+                .build();
+
+        NaverPayReserveResponse response = NaverPayReserveResponse.builder()
+                .body(NaverPayReserveResponse.ReserveBody.builder()
+                        .code("550e8400-e29b-41d4-a716-446655440000")
+                        .build())
+                .build();
+
+        when(naverPayService.createPaymentReserve(any(NaverPayReserveRequest.class), any(Long.class)))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/payments/reserve")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.body.code").value("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    @Test
+    @DisplayName("주문 내역 생성 실패")
+    void createPaymentReserve_failure() throws Exception {
+        // given
+        NaverPayReserveRequest request = NaverPayReserveRequest.builder()
+                .productName("의료 상담 서비스")
+                .productCount(1)
+                .totalPayAmount(10000)
+                .taxScopeAmount(10000)
+                .taxExScopeAmount(0)
+                .elderIds(Arrays.asList(1L))
+                .build();
+
+        when(naverPayService.createPaymentReserve(any(NaverPayReserveRequest.class), any(Long.class)))
+                .thenThrow(new RuntimeException("주문 내역 생성 중 오류가 발생했습니다."));
+
+        // when & then
+        mockMvc.perform(post("/payments/reserve")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.error").value("서버 오류"))
+                .andExpect(jsonPath("$.message").value("주문 내역 생성 중 오류가 발생했습니다."));
+    }
+}

--- a/src/test/java/com/example/medicare_call/service/NaverPayServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/NaverPayServiceTest.java
@@ -1,0 +1,188 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.Order;
+import com.example.medicare_call.domain.Member;
+import com.example.medicare_call.domain.Elder;
+import com.example.medicare_call.dto.NaverPayReserveRequest;
+import com.example.medicare_call.dto.NaverPayReserveResponse;
+import com.example.medicare_call.repository.OrderRepository;
+import com.example.medicare_call.repository.MemberRepository;
+import com.example.medicare_call.repository.ElderRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.*;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import com.example.medicare_call.global.enums.PaymentMethod;
+import com.example.medicare_call.global.enums.OrderStatus;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+@ExtendWith(MockitoExtension.class)
+class NaverPayServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ElderRepository elderRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private NaverPayService naverPayService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(naverPayService, "clientId", "test_client_id");
+        ReflectionTestUtils.setField(naverPayService, "clientSecret", "test_client_secret");
+        ReflectionTestUtils.setField(naverPayService, "chainId", "test_chain_id");
+        ReflectionTestUtils.setField(naverPayService, "apiUrl", "https://test-api.naver.com");
+        ReflectionTestUtils.setField(naverPayService, "partnerId", "test_partner_id");
+        ReflectionTestUtils.setField(naverPayService, "objectMapper", objectMapper);
+    }
+
+    @Test
+    @DisplayName("주문 내역 생성 성공")
+    void createPaymentReserve_success() throws Exception {
+        // given
+        NaverPayReserveRequest request = NaverPayReserveRequest.builder()
+                .productName("의료 상담 서비스")
+                .productCount(1)
+                .totalPayAmount(10000)
+                .taxScopeAmount(8000)
+                .taxExScopeAmount(2000)
+                .elderIds(Arrays.asList(1L, 2L))
+                .build();
+
+        // Mock: 중복 주문 확인 (UUID는 중복될 가능성이 거의 없음)
+        when(orderRepository.existsByCode(anyString())).thenReturn(false);
+
+        // Mock: 회원 조회
+        Member member = Member.builder()
+                .id(1)
+                .name("테스트 회원")
+                .phone("010-1234-5678")
+                .gender((byte) 1)
+                .termsAgreedAt(LocalDateTime.now())
+                .plan((byte) 0)
+                .build();
+        when(memberRepository.findById(1)).thenReturn(Optional.of(member));
+
+        // Mock: 어르신 존재 확인
+        when(elderRepository.existsById(1)).thenReturn(true);
+        when(elderRepository.existsById(2)).thenReturn(true);
+
+        // Mock: JSON 변환 - ObjectMapper는 실제 객체를 사용하므로 Mocking 제거
+
+        // Mock: 주문 저장
+        Order savedOrder = Order.builder()
+                .id(1L)
+                .code("550e8400-e29b-41d4-a716-446655440000")
+                .productName("의료 상담 서비스")
+                .productCount(1)
+                .totalPayAmount(10000)
+                .taxScopeAmount(8000)
+                .taxExScopeAmount(2000)
+                .naverpayReserveId("ORDER_123456789")
+                .status(OrderStatus.CREATED)
+                .member(member)
+                .elderIds("[1,2]")
+                .paymentMethod(PaymentMethod.NAVER_PAY)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+        when(orderRepository.save(any(Order.class))).thenReturn(savedOrder);
+
+        // when
+        NaverPayReserveResponse result = naverPayService.createPaymentReserve(request, 1L);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getCode()).isEqualTo("Success");
+        assertThat(result.getMessage()).isEqualTo("주문이 성공적으로 생성되었습니다.");
+        assertThat(result.getBody().getCode()).isEqualTo("550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    @Test
+    @DisplayName("주문 내역 생성 실패 - 중복 주문")
+    void createPaymentReserve_failure_duplicate() throws JsonProcessingException {
+        // given
+        NaverPayReserveRequest request = NaverPayReserveRequest.builder()
+                .productName("의료 상담 서비스")
+                .productCount(1)
+                .totalPayAmount(10000)
+                .taxScopeAmount(10000)
+                .taxExScopeAmount(0)
+                .elderIds(Arrays.asList(1L))
+                .build();
+
+        // Mock: 중복 주문 확인
+        when(orderRepository.existsByCode(anyString()))
+                .thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> naverPayService.createPaymentReserve(request, 1L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("주문 번호 생성에 3회 실패했습니다.");
+    }
+
+    @Test
+    @DisplayName("주문 내역 생성 실패 - 필수 파라미터 누락")
+    void createPaymentReserve_failure() {
+        // given
+        NaverPayReserveRequest request = NaverPayReserveRequest.builder()
+                .productName("") // 빈 값
+                .productCount(1)
+                .totalPayAmount(10000)
+                .taxScopeAmount(10000)
+                .taxExScopeAmount(0)
+                .elderIds(Arrays.asList(1L))
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> naverPayService.createPaymentReserve(request, 1L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("상품명은 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("주문 내역 생성 실패 - 금액 부족")
+    void createPaymentReserve_failure_lowAmount() {
+        // given
+        NaverPayReserveRequest request = NaverPayReserveRequest.builder()
+                .productName("의료 상담 서비스")
+                .productCount(1)
+                .totalPayAmount(5) // 10원 미만
+                .taxScopeAmount(5)
+                .taxExScopeAmount(0)
+                .elderIds(Arrays.asList(1L))
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> naverPayService.createPaymentReserve(request, 1L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("총 결제 금액은 10원 이상이어야 합니다.");
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -34,3 +34,14 @@ openai:
     url: https://api.openai.com/v1/chat/completions
   model: gpt-4
 
+
+naverpay:
+  client:
+    id: test-client-id
+    secret: test-client-secret
+  chain:
+    id: test-chain-id
+  partner:
+    id: test-partner-id
+  api:
+    url: https://example.com


### PR DESCRIPTION
### 배경
- 네이버페이를 통한 상품 결제 시, 자사 DB에 주문 정보를 생성하기 위한 엔드포인트
- 호출 시점: 실결제를 진행하기 이전, 메디케어콜 서비스 DB에 주문 관련 정보들을 생성하고, 주문 고유 코드를 발급하기 위해 호출
  - 네이버페이 결제의 경우, SDK를 통해 네이버페이 결제 화면을 호출하기 전에 호출하여 주문 고유 코드를 응답으로 받고, 이 주문 고유 코드를 사용하여 sdk에서 결제 화면에 진입

### API Spec
`POST /payments/reserve`
- Request Body
```
{
  "productName": "메디케어콜 스탠다드 플랜",
  "productCount": 1,
  "totalPayAmount": 19000,
  "taxScopeAmount": 15000,
  "taxExScopeAmount": 4000,
  "elderIds": [
    2
  ]
}
```

- Response
```
{
  "code": "Success",
  "message": "주문이 성공적으로 생성되었습니다.",
  "body": {
    "code": "f9924f75-7a40-41ad-adb8-eb3818cf9811"
  }
}
```

### TODO
- 네이버페이 관련 환경 변수들을 API에서 내려줄지, 안드로이드에서 보관할지 결정하여 API Spec을 결정해야 한다
  - Secret까지는 노출되지 않지만, 양쪽 다 패킷 언패킹, apk 언패킹으로 인한 환경변수 노출 리스크는 있을듯
  - sdk에서 주문 창을 호출해오기 위해 정보가 필요해서, 어느 쪽으로든 안드로이드에 정보 제공이 필요하다
- 주문을 승인하는 엔드포인트 구현 필요. 실결제를 진행하고, 주문을 승인하는 api를 호출하면 서드파티 api를 호출하여 우리쪽 DB와 서드파티DB의 주문 정보를 대조한다. 변조가 없다면 주문 결제를 최종 승인 처리하는 방식
- 주문이 승인되지 않은 채로 장기간 pending상태인 주문에는 따로 Background Job에서 일괄 주문 상태변경 처리를 주기적으로 해줄 필요가 있다. MVP 단계에서는 불필요할듯
- 주문 대상이 되는 elderId가 결제를 진행하는 member과 fk관계인지 검토하는 로직이 필요할 수도 있다. critical한 문제는 아닌듯