### PR TITLE
feat: 구독정보 조회 API

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/action/SubscriptionController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/SubscriptionController.java
@@ -1,0 +1,37 @@
+package com.example.medicare_call.controller.action;
+
+import com.example.medicare_call.dto.SubscriptionResponse;
+import com.example.medicare_call.global.annotation.AuthUser;
+import com.example.medicare_call.service.SubscriptionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "구독 관리", description = "구독 관리 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/elders/subscriptions")
+public class SubscriptionController {
+
+    private final SubscriptionService subscriptionService;
+
+    @Operation(summary = "회원의 어르신 구독 정보 조회")
+    @ApiResponse(responseCode = "200", description = "어르신 구독 정보 조회 성공",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = SubscriptionResponse.class)))
+    @GetMapping
+    public ResponseEntity<List<SubscriptionResponse>> getSubscriptions(@Parameter(hidden = true) @AuthUser Long memberId) {
+        List<SubscriptionResponse> subscriptions = subscriptionService.getSubscriptionsByMember(memberId);
+        return ResponseEntity.ok(subscriptions);
+    }
+}

--- a/src/main/java/com/example/medicare_call/dto/SubscriptionResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/SubscriptionResponse.java
@@ -1,0 +1,46 @@
+package com.example.medicare_call.dto;
+
+import com.example.medicare_call.domain.Subscription;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@Schema(description = "구독 정보 응답")
+public class SubscriptionResponse {
+
+    @Schema(description = "어르신 고유 ID")
+    private Integer elderId;
+
+    @Schema(description = "어르신 성함")
+    private String name;
+
+    @Schema(description = "구독 플랜 이름")
+    private String plan;
+
+    @Schema(description = "월 요금")
+    private Integer price;
+
+    @Schema(description = "다음 결제 예정일")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate nextBillingDate;
+
+    @Schema(description = "최초 가입일")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    public static SubscriptionResponse from(Subscription subscription) {
+        return SubscriptionResponse.builder()
+                .elderId(subscription.getElder().getId())
+                .name(subscription.getElder().getName())
+                .plan(subscription.getPlan().getPlanName())
+                .price(subscription.getPrice())
+                .nextBillingDate(subscription.getNextBillingDate())
+                .startDate(subscription.getStartDate())
+                .build();
+    }
+}

--- a/src/main/java/com/example/medicare_call/service/SubscriptionService.java
+++ b/src/main/java/com/example/medicare_call/service/SubscriptionService.java
@@ -1,0 +1,37 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.dto.SubscriptionResponse;
+import com.example.medicare_call.global.ResourceNotFoundException;
+import com.example.medicare_call.repository.MemberRepository;
+import com.example.medicare_call.repository.SubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SubscriptionService {
+
+    private final SubscriptionRepository subscriptionRepository;
+    private final MemberRepository memberRepository;
+
+    public List<SubscriptionResponse> getSubscriptionsByMember(Long memberId) {
+        if (!memberRepository.existsById(memberId.intValue())) {
+            throw new ResourceNotFoundException("해당 ID의 회원을 찾을 수 없습니다: " + memberId);
+        }
+
+        List<SubscriptionResponse> subscriptions = subscriptionRepository.findByMemberId(memberId.intValue()).stream()
+                .map(SubscriptionResponse::from)
+                .collect(Collectors.toList());
+
+        if (subscriptions.isEmpty()) {
+            throw new ResourceNotFoundException("해당 회원의 구독 정보를 찾을 수 없습니다.");
+        }
+
+        return subscriptions;
+    }
+}

--- a/src/test/java/com/example/medicare_call/controller/action/SubscriptionControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/action/SubscriptionControllerTest.java
@@ -1,0 +1,80 @@
+package com.example.medicare_call.controller.action;
+
+import com.example.medicare_call.dto.SubscriptionResponse;
+import com.example.medicare_call.service.SubscriptionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import com.example.medicare_call.global.annotation.AuthUser;
+
+import java.time.LocalDate;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private SubscriptionService subscriptionService;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new SubscriptionController(subscriptionService))
+                .setCustomArgumentResolvers(new TestAuthUserArgumentResolver())
+                .build();
+    }
+
+    private static class TestAuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+        @Override
+        public boolean supportsParameter(org.springframework.core.MethodParameter parameter) {
+            return parameter.hasParameterAnnotation(AuthUser.class);
+        }
+
+        @Override
+        public Object resolveArgument(org.springframework.core.MethodParameter parameter,
+                                   org.springframework.web.method.support.ModelAndViewContainer mavContainer,
+                                   org.springframework.web.context.request.NativeWebRequest webRequest,
+                                   org.springframework.web.bind.support.WebDataBinderFactory binderFactory) {
+            return 1L;
+        }
+    }
+
+    @Test
+    @DisplayName("GET /elders/subscriptions - 회원의 구독 정보 조회 성공")
+    void getSubscriptions_Success() throws Exception {
+        // given
+        SubscriptionResponse response = SubscriptionResponse.builder()
+                .elderId(1)
+                .name("김옥자")
+                .plan("premium")
+                .price(29000)
+                .nextBillingDate(LocalDate.of(2025, 7, 10))
+                .startDate(LocalDate.of(2025, 5, 10))
+                .build();
+        given(subscriptionService.getSubscriptionsByMember(anyLong())).willReturn(Collections.singletonList(response));
+
+        // when & then
+        mockMvc.perform(get("/elders/subscriptions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].elderId").value(1))
+                .andExpect(jsonPath("$[0].name").value("김옥자"))
+                .andExpect(jsonPath("$[0].plan").value("premium"))
+                .andExpect(jsonPath("$[0].price").value(29000))
+                .andExpect(jsonPath("$[0].nextBillingDate").value("2025-07-10"))
+                .andExpect(jsonPath("$[0].startDate").value("2025-05-10"));
+    }
+}

--- a/src/test/java/com/example/medicare_call/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/SubscriptionServiceTest.java
@@ -1,0 +1,97 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.Elder;
+import com.example.medicare_call.domain.Member;
+import com.example.medicare_call.domain.Subscription;
+import com.example.medicare_call.dto.SubscriptionResponse;
+import com.example.medicare_call.global.ResourceNotFoundException;
+import com.example.medicare_call.global.enums.SubscriptionPlan;
+import com.example.medicare_call.global.enums.SubscriptionStatus;
+import com.example.medicare_call.repository.MemberRepository;
+import com.example.medicare_call.repository.SubscriptionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Subscription 서비스 테스트")
+class SubscriptionServiceTest {
+
+    @InjectMocks
+    private SubscriptionService subscriptionService;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("구독 정보 조회 성공")
+    void getSubscriptions_Success() {
+        // given
+        Long memberId = 1L;
+        Member member = Member.builder().id(memberId.intValue()).name("테스트회원").build();
+        Elder elder = Elder.builder().id(1).name("김어르신").guardian(member).build();
+        Subscription subscription = Subscription.builder()
+                .id(1L)
+                .member(member)
+                .elder(elder)
+                .plan(SubscriptionPlan.PREMIUM)
+                .price(29000)
+                .status(SubscriptionStatus.ACTIVE)
+                .startDate(LocalDate.now())
+                .nextBillingDate(LocalDate.now().plusMonths(1))
+                .build();
+
+        given(memberRepository.existsById(memberId.intValue())).willReturn(true);
+        given(subscriptionRepository.findByMemberId(memberId.intValue())).willReturn(Collections.singletonList(subscription));
+
+        // when
+        List<SubscriptionResponse> responses = subscriptionService.getSubscriptionsByMember(memberId);
+
+        // then
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getElderId()).isEqualTo(elder.getId());
+        assertThat(responses.get(0).getName()).isEqualTo(elder.getName());
+        assertThat(responses.get(0).getPlan()).isEqualTo(subscription.getPlan().getPlanName());
+    }
+
+    @Test
+    @DisplayName("구독 정보 조회 실패 - 회원 없음")
+    void getSubscriptions_Fail_MemberNotFound() {
+        // given
+        Long memberId = 999L;
+        given(memberRepository.existsById(memberId.intValue())).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> subscriptionService.getSubscriptionsByMember(memberId))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("해당 ID의 회원을 찾을 수 없습니다:");
+    }
+
+    @Test
+    @DisplayName("구독 정보 조회 실패 - 구독 정보 없음")
+    void getSubscriptions_Fail_NoSubscriptions() {
+        // given
+        Long memberId = 1L;
+        given(memberRepository.existsById(memberId.intValue())).willReturn(true);
+        given(subscriptionRepository.findByMemberId(memberId.intValue())).willReturn(Collections.emptyList());
+
+        // when & then
+        assertThatThrownBy(() -> subscriptionService.getSubscriptionsByMember(memberId))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("해당 회원의 구독 정보를 찾을 수 없습니다.");
+    }
+}


### PR DESCRIPTION
### Desc
- 회원이 결제하여 서비스를 제공받고 있는 대상 어르신에 대한 정보를 반환한다.
- 결제 서비스에서 기존에는 주문 상태값만 업데이트하고 있었는데, 주문 상태값을 업데이트하는 과정에서 구독 정보도 생성, 갱신하도록 변경
- 하기 API에서는 이 때 생성, 갱신된 구독 정보를 jwt 토큰에 포함된 memberId 기준으로 조회하게 된다.

### API Spec
`GET /elders/subscriptions`
- Response
```
[
  {
    "elderId": 1,
    "name": "테스트 어르신",
    "plan": "standard",
    "price": 19000,
    "nextBillingDate": "2025-09-10",
    "startDate": "2025-08-10"
  },
  {
    "elderId": 2,
    "name": "홍길동",
    "plan": "standard",
    "price": 19000,
    "nextBillingDate": "2025-09-10",
    "startDate": "2025-08-10"
  }
]
```