### PR TITLE
fix: 네이버페이 오류 발생시, 500에러가 발생하는 문제

### DIFF
--- a/src/main/java/com/example/medicare_call/dto/NaverPayApplyResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/NaverPayApplyResponse.java
@@ -1,5 +1,6 @@
 package com.example.medicare_call.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(description = "네이버페이 결제 승인 응답")
 public class NaverPayApplyResponse {
 


### PR DESCRIPTION
### Desc
- 네이버페이 쪽에서 에러가 발생하여 응답 Response가 NaverPayApplyResponse의 형태가 아닐 경우, 현재는 Json Parsing 과정에서 에러가 발생하여 500에러를 뱉는다.
  - 서버에서는 try catch로 감싸서 전부 에러를 그대로 밖으로 던지고 있어, 상황과는 관계없이 외부에서 전부 internal server error으로 뱉어주는게 좋은 설계는 아니다.
- 일단 `@JsonIgnoreProperties(ignoreUnknown = true)`으로 임시 처리하여 매칭되는 필드만 처리. 이 경우에 결제 상태값은 제대로 파싱하여 주문 데이터의 상태를 변경하는 것에는 성공한다.

### Todo
- 현재는 모든 컨트롤러가 에러를 일반적인 형태로 던지고, 이를 GlobalExceptionHandler에서 일괄 처리해주고 있는데, 추후에는 다양한 커스텀 에러를 정의하고, 상황에 맞는 에러를 던져서 클라이언트에서 상황을 식별할 수 있도록  대규모 리팩토링을 하는게 좋아보인다.