### PR TITLE
feat: 주간 통계 데이터 API AI 요약 추가

### DIFF
--- a/src/main/java/com/example/medicare_call/dto/WeeklySummaryDto.java
+++ b/src/main/java/com/example/medicare_call/dto/WeeklySummaryDto.java
@@ -1,0 +1,20 @@
+package com.example.medicare_call.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import com.example.medicare_call.dto.WeeklyStatsResponse;
+
+@Getter
+@Builder
+public class WeeklySummaryDto {
+    private final int mealCount;
+    private final int mealRate;
+    private final double averageSleepHours;
+    private final WeeklyStatsResponse.BloodSugar bloodSugar;
+    private final int medicationTakenCount;
+    private final int medicationMissedCount;
+    private final int positivePsychologicalCount;
+    private final int negativePsychologicalCount;
+    private final int healthSignals;
+    private final int missedCalls;
+}

--- a/src/main/java/com/example/medicare_call/service/OpenAiWeeklyStatsSummaryService.java
+++ b/src/main/java/com/example/medicare_call/service/OpenAiWeeklyStatsSummaryService.java
@@ -1,0 +1,130 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.dto.WeeklySummaryDto;
+import com.example.medicare_call.dto.OpenAiRequest;
+import com.example.medicare_call.dto.OpenAiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OpenAiWeeklyStatsSummaryService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${openai.api.key}")
+    private String openaiApiKey;
+
+    @Value("${openai.api.url}")
+    private String openaiApiUrl;
+
+    @Value("${openai.model}")
+    private String openaiModel;
+
+    public String getWeeklyStatsSummary(WeeklySummaryDto weeklySummaryDto) {
+        try {
+            log.info("OpenAI API를 통한 주간 건강 데이터 요약 시작");
+
+            String prompt = buildPrompt(weeklySummaryDto);
+
+            OpenAiRequest openAiRequest = OpenAiRequest.builder()
+                    .model(openaiModel)
+                    .messages(List.of(
+                            OpenAiRequest.Message.builder()
+                                    .role("system")
+                                    .content("당신은 주간 건강 데이터를 분석하여 보호자를 위한 주간 건강 보고서를 작성하는 전문가입니다. " +
+                                            "제공된 데이터를 기반으로 어르신의 건강 상태를 객관적으로 요약하고, " +
+                                            "보호자가 주의 깊게 살펴봐야 할 가장 중요한 사항 1~2가지를 중심으로 조언을 제공해주세요.")
+                                    .build(),
+                            OpenAiRequest.Message.builder()
+                                    .role("user")
+                                    .content(prompt)
+                                    .build()
+                    ))
+                    .temperature(0.7) // 다양한 피드백을 위해 약간 높게 설정
+                    .build();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(openaiApiKey);
+
+            HttpEntity<OpenAiRequest> entity = new HttpEntity<>(openAiRequest, headers);
+
+            OpenAiResponse response = restTemplate.postForObject(openaiApiUrl, entity, OpenAiResponse.class);
+
+            if (response != null && !response.getChoices().isEmpty()) {
+                String content = response.getChoices().get(0).getMessage().getContent();
+                log.info("OpenAI 응답: {}", content);
+                return content;
+            } else {
+                log.error("OpenAI API 응답이 비어있습니다");
+                return "주간 건강 데이터 요약에 실패했습니다.";
+            }
+
+        } catch (Exception e) {
+            log.error("OpenAI API 호출 중 오류 발생", e);
+            return "주간 건강 데이터 요약 중 오류가 발생했습니다.";
+        }
+    }
+
+    private String buildPrompt(WeeklySummaryDto weeklySummaryDto) {
+        return String.format("""
+            다음은 어르신의 한 주간 건강 데이터입니다. 이 데이터를 바탕으로 보호자를 위한 주간 건강 보고서를 작성해주세요.
+            결과는 반드시 공백 포함 80자 이상 100자 미만으로, 존댓말로 작성해주세요.
+
+            [주요 건강 데이터]
+            - 주간 총 식사 횟수: %d회 (총 21끼 기준)
+            - 식사율: %d%% (목표: 100%%)
+            - 평균 수면 시간: %.1f시간 (권장: 7-8시간)
+            - 약 복용 횟수: %d회
+            - 놓친 약 횟수: %d회
+            - 긍정적 심리 상태: %d회
+            - 부정적 심리 상태: %d회
+            - 건강 이상 신호: %d회
+            - 주간 케어콜 미응답 건수: %d회
+            - 혈당 측정 결과 (정상/고혈당/저혈당 횟수):
+              - 식전: %s
+              - 식후: %s
+
+            [분석 및 보고 가이드라인]
+            - 식사율이 70%% 미만이면 식사를 잘 챙기실 수 있도록 보호자의 관심이 필요함을 언급해주세요.
+            - 놓친 약이 있다면 약 복용의 중요성을 보호자에게 상기시켜주세요.
+            - 건강 이상 신호가 1회 이상 감지되었다면, 이 점을 가장 중요한 문제로 보고하고 보호자의 주의를 당부해주세요.
+            - 미응답 건수가 1회 이상이면, 어르신의 안위를 확인해볼 필요가 있음을 조언해주세요.
+            - 부정적 심리 상태가 긍정적 상태보다 많거나 비슷하면 어르신의 정신 건강에 대한 보호자의 관심을 유도해주세요.
+            - 데이터를 종합하여 보호자가 가장 주의해야 할 점 1~2가지를 중심으로 보고서를 작성해주세요.
+            """,
+                weeklySummaryDto.getMealCount(),
+                weeklySummaryDto.getMealRate(),
+                weeklySummaryDto.getAverageSleepHours(),
+                weeklySummaryDto.getMedicationTakenCount(),
+                weeklySummaryDto.getMedicationMissedCount(),
+                weeklySummaryDto.getPositivePsychologicalCount(),
+                weeklySummaryDto.getNegativePsychologicalCount(),
+                weeklySummaryDto.getHealthSignals(),
+                weeklySummaryDto.getMissedCalls(),
+                formatBloodSugarStats(weeklySummaryDto.getBloodSugar().getBeforeMeal()),
+                formatBloodSugarStats(weeklySummaryDto.getBloodSugar().getAfterMeal())
+        );
+    }
+
+    private String formatBloodSugarStats(com.example.medicare_call.dto.WeeklyStatsResponse.BloodSugarType bloodSugarType) {
+        if (bloodSugarType == null) {
+            return "측정 기록 없음";
+        }
+        return String.format("정상 %d회, 고혈당 %d회, 저혈당 %d회",
+                bloodSugarType.getNormal(),
+                bloodSugarType.getHigh(),
+                bloodSugarType.getLow());
+    }
+}

--- a/src/test/java/com/example/medicare_call/service/OpenAiWeeklyStatsSummaryServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/OpenAiWeeklyStatsSummaryServiceTest.java
@@ -1,0 +1,143 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.dto.WeeklyStatsResponse;
+import com.example.medicare_call.dto.WeeklySummaryDto;
+import com.example.medicare_call.dto.OpenAiResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OpenAiWeeklyStatsSummaryServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private OpenAiWeeklyStatsSummaryService openAiWeeklyStatsSummaryService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(openAiWeeklyStatsSummaryService, "openaiApiKey", "test-api-key");
+        ReflectionTestUtils.setField(openAiWeeklyStatsSummaryService, "openaiApiUrl", "https://api.openai.com/v1/chat/completions");
+        ReflectionTestUtils.setField(openAiWeeklyStatsSummaryService, "openaiModel", "gpt-3.5-turbo");
+    }
+
+    @Test
+    @DisplayName("주간 건강 데이터 요약 성공")
+    void getWeeklyStatsSummary_success() {
+        // given
+        WeeklyStatsResponse.BloodSugarType beforeMeal = WeeklyStatsResponse.BloodSugarType.builder().normal(5).high(1).low(0).build();
+        WeeklyStatsResponse.BloodSugarType afterMeal = WeeklyStatsResponse.BloodSugarType.builder().normal(4).high(2).low(0).build();
+        WeeklyStatsResponse.BloodSugar bloodSugar = WeeklyStatsResponse.BloodSugar.builder().beforeMeal(beforeMeal).afterMeal(afterMeal).build();
+
+        WeeklySummaryDto weeklySummaryDto = WeeklySummaryDto.builder()
+                .mealCount(15)
+                .mealRate(71)
+                .averageSleepHours(7.5)
+                .bloodSugar(bloodSugar)
+                .medicationTakenCount(10)
+                .medicationMissedCount(2)
+                .positivePsychologicalCount(5)
+                .negativePsychologicalCount(1)
+                .healthSignals(3)
+                .missedCalls(1)
+                .build();
+
+        String expectedSummary = "이번 주 어르신은 건강 이상 신호가 3회, 케어콜 미응답이 1회 있었습니다. 어르신께 무슨 일이 없는지 확인이 필요해 보입니다. 약도 2회 누락되어 꾸준한 복용 지도가 필요합니다.";
+        
+        OpenAiResponse.Message message = OpenAiResponse.Message.builder()
+                .content(expectedSummary)
+                .build();
+        OpenAiResponse.Choice choice = OpenAiResponse.Choice.builder()
+                .message(message)
+                .build();
+        OpenAiResponse openAiResponse = OpenAiResponse.builder()
+                .choices(Collections.singletonList(choice))
+                .build();
+
+        when(restTemplate.postForObject(any(String.class), any(), eq(OpenAiResponse.class)))
+                .thenReturn(openAiResponse);
+
+        // when
+        String actualSummary = openAiWeeklyStatsSummaryService.getWeeklyStatsSummary(weeklySummaryDto);
+
+        // then
+        assertEquals(expectedSummary, actualSummary);
+    }
+    
+    @Test
+    @DisplayName("OpenAI API 응답이 비어있을 때")
+    void getWeeklyStatsSummary_emptyResponse() {
+        // given
+        WeeklyStatsResponse.BloodSugarType beforeMeal = WeeklyStatsResponse.BloodSugarType.builder().normal(5).high(1).low(0).build();
+        WeeklyStatsResponse.BloodSugarType afterMeal = WeeklyStatsResponse.BloodSugarType.builder().normal(4).high(2).low(0).build();
+        WeeklyStatsResponse.BloodSugar bloodSugar = WeeklyStatsResponse.BloodSugar.builder().beforeMeal(beforeMeal).afterMeal(afterMeal).build();
+
+        WeeklySummaryDto weeklySummaryDto = WeeklySummaryDto.builder()
+                .mealCount(15)
+                .mealRate(71)
+                .averageSleepHours(7.5)
+                .bloodSugar(bloodSugar)
+                .medicationTakenCount(10)
+                .medicationMissedCount(2)
+                .positivePsychologicalCount(5)
+                .negativePsychologicalCount(1)
+                .healthSignals(3)
+                .missedCalls(1)
+                .build();
+        
+        when(restTemplate.postForObject(any(String.class), any(), eq(OpenAiResponse.class)))
+                .thenReturn(null);
+        
+        // when
+        String summary = openAiWeeklyStatsSummaryService.getWeeklyStatsSummary(weeklySummaryDto);
+        
+        // then
+        assertEquals("주간 건강 데이터 요약에 실패했습니다.", summary);
+    }
+
+    @Test
+    @DisplayName("OpenAI API 호출 중 예외 발생")
+    void getWeeklyStatsSummary_exception() {
+        // given
+        WeeklyStatsResponse.BloodSugarType beforeMeal = WeeklyStatsResponse.BloodSugarType.builder().normal(5).high(1).low(0).build();
+        WeeklyStatsResponse.BloodSugarType afterMeal = WeeklyStatsResponse.BloodSugarType.builder().normal(4).high(2).low(0).build();
+        WeeklyStatsResponse.BloodSugar bloodSugar = WeeklyStatsResponse.BloodSugar.builder().beforeMeal(beforeMeal).afterMeal(afterMeal).build();
+
+        WeeklySummaryDto weeklySummaryDto = WeeklySummaryDto.builder()
+                .mealCount(15)
+                .mealRate(71)
+                .averageSleepHours(7.5)
+                .bloodSugar(bloodSugar)
+                .medicationTakenCount(10)
+                .medicationMissedCount(2)
+                .positivePsychologicalCount(5)
+                .negativePsychologicalCount(1)
+                .healthSignals(3)
+                .missedCalls(1)
+                .build();
+
+        when(restTemplate.postForObject(any(String.class), any(), eq(OpenAiResponse.class)))
+                .thenThrow(new RuntimeException("API Error"));
+
+        // when
+        String summary = openAiWeeklyStatsSummaryService.getWeeklyStatsSummary(weeklySummaryDto);
+
+        // then
+        assertEquals("주간 건강 데이터 요약 중 오류가 발생했습니다.", summary);
+    }
+}

--- a/src/test/java/com/example/medicare_call/service/WeeklyStatsServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/WeeklyStatsServiceTest.java
@@ -47,6 +47,9 @@ class WeeklyStatsServiceTest {
     @Mock
     private BloodSugarRecordRepository bloodSugarRecordRepository;
 
+    @Mock
+    private OpenAiWeeklyStatsSummaryService openAiWeeklyStatsSummaryService;
+
     @InjectMocks
     private WeeklyStatsService weeklyStatsService;
 
@@ -126,6 +129,9 @@ class WeeklyStatsServiceTest {
         when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), eq(startDate), eq(endLocalDate)))
                 .thenReturn(Collections.emptyList());
 
+        when(openAiWeeklyStatsSummaryService.getWeeklyStatsSummary(any(com.example.medicare_call.dto.WeeklySummaryDto.class)))
+                .thenReturn("AI 요약 테스트");
+
         // when
         WeeklyStatsResponse response = weeklyStatsService.getWeeklyStats(elderId, startDate);
 
@@ -150,6 +156,7 @@ class WeeklyStatsServiceTest {
         assertThat(response.getBloodSugar().getAfterMeal().getNormal()).isEqualTo(0);
         assertThat(response.getBloodSugar().getAfterMeal().getHigh()).isEqualTo(0);
         assertThat(response.getBloodSugar().getAfterMeal().getLow()).isEqualTo(0);
+        assertThat(response.getHealthSummary()).isEqualTo("AI 요약 테스트");
     }
 
     private MealRecord createMealRecord(Integer id, MealType mealType) {


### PR DESCRIPTION
### Desc
- 기존에는 주간 통계 데이터 조회시, AI 요약이 이루어지는 부분을 리터럴 값을 내려주고 있었다.
- 실제로 AI API를 호출하여, 보호자에게 안내하는 어투로 데이터를 요약하도록 구현
- 현재는 요청마다 다른 톤으로 응답이 가도록 매번 OpenAI API를 호출한다. 비용이 과도하게 과금될 수 있어, 후속으로 같은 기간에 대한 요약 데이터를 DB에 저장하고 조회하도록 구현할 필요가 있다.