### PR TITLE
Feat/elders settings

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/view/EldersSettingController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/EldersSettingController.java
@@ -4,6 +4,7 @@ import com.example.medicare_call.dto.ElderSettingRequest;
 import com.example.medicare_call.dto.ElderSettingResponse;
 import com.example.medicare_call.global.annotation.AuthUser;
 import com.example.medicare_call.service.ElderSettingService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,10 @@ import java.util.List;
 public class EldersSettingController {
     private final ElderSettingService elderSettingService;
 
+    @Operation(
+            summary = "어르신 개인정보 설정 조회",
+            description = "로그인한 유저가 등록한 모든 어르신의 개인정보를 조회합니다."
+    )
     @GetMapping("/settings")
     public ResponseEntity<List<ElderSettingResponse>> getElderSettingInfo(@Parameter(hidden = true) @AuthUser Long memberId){
         log.info("어르신 설정 정보 조회 요청: memberId={}", memberId);
@@ -28,6 +33,10 @@ public class EldersSettingController {
         return ResponseEntity.ok(body);
     }
 
+    @Operation(
+            summary = "어르신 개인정보 설정 수정",
+            description = "어르신 정보 전체를 요청받아 값을 수정합니다."
+    )
     @PostMapping("/{elderId}/settings")
     public ResponseEntity<ElderSettingResponse> updateElderSettingInfo(
             @Parameter(hidden = true) @AuthUser Long memberId,
@@ -41,6 +50,10 @@ public class EldersSettingController {
         return ResponseEntity.ok(res);
     }
 
+    @Operation(
+            summary = "어르신 개인정보 설정 삭제",
+            description = "선택한 어르신의 개인정보를 삭제합니다."
+    )
     @DeleteMapping("/{elderId}/settings")
     public ResponseEntity<Void> deleteElderSettingInfo(
             @Parameter(hidden = true) @AuthUser Long memberId,

--- a/src/main/java/com/example/medicare_call/controller/view/EldersSettingController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/EldersSettingController.java
@@ -1,0 +1,32 @@
+package com.example.medicare_call.controller.view;
+
+import com.example.medicare_call.dto.ElderSettingResponse;
+import com.example.medicare_call.global.annotation.AuthUser;
+import com.example.medicare_call.service.ElderSettingService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/elders")
+@RequiredArgsConstructor
+@Tag(name = "Elder Setting", description = "어르신 개인정보 설정 API")
+public class EldersSettingController {
+    private final ElderSettingService elderSettingService;
+
+    @GetMapping("/settings")
+    public ResponseEntity<List<ElderSettingResponse>> getElderSettingInfo(@Parameter(hidden = true) @AuthUser Long memberId){
+        log.info("memberId from @AuthUser = {}", memberId);
+        List<ElderSettingResponse> body = elderSettingService.getElderSetting(memberId.intValue());
+        return ResponseEntity.ok(body);
+    }
+}

--- a/src/main/java/com/example/medicare_call/controller/view/EldersSettingController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/EldersSettingController.java
@@ -1,5 +1,6 @@
 package com.example.medicare_call.controller.view;
 
+import com.example.medicare_call.dto.ElderSettingRequest;
 import com.example.medicare_call.dto.ElderSettingResponse;
 import com.example.medicare_call.global.annotation.AuthUser;
 import com.example.medicare_call.service.ElderSettingService;
@@ -8,10 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -28,5 +26,15 @@ public class EldersSettingController {
         log.info("memberId from @AuthUser = {}", memberId);
         List<ElderSettingResponse> body = elderSettingService.getElderSetting(memberId.intValue());
         return ResponseEntity.ok(body);
+    }
+
+    @PostMapping("/{elderId}/settings")
+    public ResponseEntity<ElderSettingResponse> updateElderSettingInfo(
+            @Parameter(hidden = true) @AuthUser Long memberId,
+            @PathVariable Integer elderId,
+            ElderSettingRequest req
+    ){
+        ElderSettingResponse res = elderSettingService.updateElderSetting(memberId.intValue(), elderId, req);
+        return ResponseEntity.ok(res);
     }
 }

--- a/src/main/java/com/example/medicare_call/controller/view/EldersSettingController.java
+++ b/src/main/java/com/example/medicare_call/controller/view/EldersSettingController.java
@@ -23,7 +23,7 @@ public class EldersSettingController {
 
     @GetMapping("/settings")
     public ResponseEntity<List<ElderSettingResponse>> getElderSettingInfo(@Parameter(hidden = true) @AuthUser Long memberId){
-        log.info("memberId from @AuthUser = {}", memberId);
+        log.info("어르신 설정 정보 조회 요청: memberId={}", memberId);
         List<ElderSettingResponse> body = elderSettingService.getElderSetting(memberId.intValue());
         return ResponseEntity.ok(body);
     }
@@ -34,7 +34,20 @@ public class EldersSettingController {
             @PathVariable Integer elderId,
             ElderSettingRequest req
     ){
+        log.info("어르신 설정 정보 수정 요청: memberId={}, elderId={}, name={}, birthDate={}, gender={}, phone={}, relationship={}, residenceType={}",
+                memberId, elderId, req.name(), req.birthDate(), req.gender(), req.phone(), req.relationship(), req.residenceType());
+
         ElderSettingResponse res = elderSettingService.updateElderSetting(memberId.intValue(), elderId, req);
         return ResponseEntity.ok(res);
+    }
+
+    @DeleteMapping("/{elderId}/settings")
+    public ResponseEntity<Void> deleteElderSettingInfo(
+            @Parameter(hidden = true) @AuthUser Long memberId,
+            @PathVariable Integer elderId
+    ){
+        log.info("어르신 설정 정보 삭제 요청: memberId={}, elderId={}", memberId, elderId);
+        elderSettingService.deleteElderSetting(memberId.intValue(), elderId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/medicare_call/domain/Elder.java
+++ b/src/main/java/com/example/medicare_call/domain/Elder.java
@@ -6,6 +6,9 @@ import lombok.Builder;
 
 import jakarta.persistence.*;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.example.medicare_call.global.enums.ElderRelation;
 import com.example.medicare_call.global.enums.ResidenceType;
 import lombok.Setter;
@@ -44,6 +47,12 @@ public class Elder {
     @Enumerated(EnumType.STRING)
     @Column(name = "residence_type", nullable = false, length = 20)
     private ResidenceType residenceType;
+
+    @OneToMany(mappedBy = "elder", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private final List<CareCallRecord> careCallRecords = new ArrayList<>();
+
+    @OneToOne(mappedBy = "elder", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
+    private CareCallSetting careCallSetting;
 
     @Builder
     public Elder(Integer id, Member guardian, String name, LocalDate birthDate, Byte gender, String phone, ElderRelation relationship, ResidenceType residenceType) {

--- a/src/main/java/com/example/medicare_call/domain/Elder.java
+++ b/src/main/java/com/example/medicare_call/domain/Elder.java
@@ -56,4 +56,19 @@ public class Elder {
         this.relationship = relationship;
         this.residenceType = residenceType;
     }
+
+    // setting update를 post로 구현
+    public void applySettings(String name,
+                              LocalDate birthDate,
+                              Byte gender,
+                              String phone,
+                              ElderRelation relationship,
+                              ResidenceType residenceType) {
+        this.name = name;
+        this.birthDate = birthDate;
+        this.gender = gender;
+        this.phone = phone;
+        this.relationship = relationship;
+        this.residenceType = residenceType;
+    }
 } 

--- a/src/main/java/com/example/medicare_call/domain/Elder.java
+++ b/src/main/java/com/example/medicare_call/domain/Elder.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import java.time.LocalDate;
 import com.example.medicare_call.global.enums.ElderRelation;
 import com.example.medicare_call.global.enums.ResidenceType;
+import lombok.Setter;
 
 @Entity
 @Table(name = "Elder")
@@ -19,6 +20,7 @@ public class Elder {
     @Column(name = "id")
     private Integer id;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "guardian_id", nullable = false)
     private Member guardian;

--- a/src/main/java/com/example/medicare_call/domain/Member.java
+++ b/src/main/java/com/example/medicare_call/domain/Member.java
@@ -3,6 +3,9 @@ package com.example.medicare_call.domain;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.Builder;
@@ -34,6 +37,9 @@ public class Member {
     @Column(name = "plan") //처음 회원가입 시 plan이 없으므로  nullable=false 조건 삭제
     private Byte plan;
 
+    @OneToMany(mappedBy = "guardian", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Elder> elders = new ArrayList<>();
+
     public Member() {}
 
     @Builder
@@ -45,5 +51,15 @@ public class Member {
         this.gender = gender;
         this.termsAgreedAt = termsAgreedAt;
         this.plan = plan;
+    }
+
+    public void addElder(Elder elder) {
+        elders.add(elder);
+        elder.setGuardian(this);
+    }
+
+    public void removeElder(Elder elder) {
+        elders.remove(elder);
+        elder.setGuardian(null);
     }
 } 

--- a/src/main/java/com/example/medicare_call/dto/ElderSettingRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/ElderSettingRequest.java
@@ -1,0 +1,35 @@
+package com.example.medicare_call.dto;
+
+import com.example.medicare_call.global.annotation.ValidBirthDate;
+import com.example.medicare_call.global.annotation.ValidPhoneNumber;
+import com.example.medicare_call.global.enums.ElderRelation;
+import com.example.medicare_call.global.enums.Gender;
+import com.example.medicare_call.global.enums.ResidenceType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+@Schema(description = "어르신 개인정보 설정 응답")
+public record ElderSettingRequest(
+        @Schema(description = "어르신 이름", example = "홍길동")
+        String name,
+
+        @ValidBirthDate
+        @Schema(description = "생년월일", example = "1945-08-15")
+        LocalDate birthDate,
+
+        @Schema(description = "성별", example = "MALE")
+        Gender gender,
+
+        @ValidPhoneNumber
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        String phone,
+
+        @Schema(description = "관계", example = "CHILD")
+        ElderRelation relationship,
+
+        @Schema(description = "거주 형태", example = "ALONE")
+        ResidenceType residenceType
+) {
+
+}

--- a/src/main/java/com/example/medicare_call/dto/ElderSettingResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/ElderSettingResponse.java
@@ -1,0 +1,39 @@
+package com.example.medicare_call.dto;
+
+import com.example.medicare_call.global.annotation.ValidBirthDate;
+import com.example.medicare_call.global.annotation.ValidPhoneNumber;
+import com.example.medicare_call.global.enums.ElderRelation;
+import com.example.medicare_call.global.enums.Gender;
+import com.example.medicare_call.global.enums.ResidenceType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+
+@Schema(description = "어르신 개인정보 설정 응답")
+public record ElderSettingResponse(
+
+        @Schema(description = "어르신 ID", example = "1")
+        Integer elderId,
+
+        @Schema(description = "어르신 이름", example = "홍길동")
+        String name,
+
+        @ValidBirthDate
+        @Schema(description = "생년월일", example = "1945-08-15")
+        LocalDate birthDate,
+
+        @Schema(description = "성별", example = "MALE")
+        Gender gender,
+
+        @ValidPhoneNumber
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        String phone,
+
+        @Schema(description = "관계", example = "CHILD")
+        ElderRelation relationship,
+
+        @Schema(description = "거주 형태", example = "ALONE")
+        ResidenceType residenceType
+) {
+}

--- a/src/main/java/com/example/medicare_call/global/annotation/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/example/medicare_call/global/annotation/AuthenticationArgumentResolver.java
@@ -10,14 +10,14 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-//@Jwt가 붙은 파라미터에 실제 memberId를 주입하는 로직
+//@AuthUser가 붙은 파라미터에 실제 memberId를 주입하는 로직
 @Component
 public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
 
     //이 파라미터에 값을 바인딩할 지 결정
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(AuthUser.class) && //@Jwt가 붙어있고
+        return parameter.hasParameterAnnotation(AuthUser.class) && //@AuthUser가 붙어있고
                 parameter.getParameterType().equals(Long.class); //타입이 Long인 경우 resolcer 동작
     }
 

--- a/src/main/java/com/example/medicare_call/service/ElderSettingService.java
+++ b/src/main/java/com/example/medicare_call/service/ElderSettingService.java
@@ -1,28 +1,32 @@
 package com.example.medicare_call.service;
 
+import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.domain.Member;
+import com.example.medicare_call.dto.ElderSettingRequest;
 import com.example.medicare_call.dto.ElderSettingResponse;
 import com.example.medicare_call.global.enums.Gender;
 import com.example.medicare_call.repository.ElderRepository;
 import com.example.medicare_call.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ElderSettingService {
     private final MemberRepository memberRepository;
+    private final ElderRepository elderRepository;
 
     public List<ElderSettingResponse> getElderSetting(Integer memberId){
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
 
-        log.info("memberId from @AuthUser = {}", memberId);
         return member.getElders().stream()
                 .map(elder -> new ElderSettingResponse(
                         elder.getId(),
@@ -35,5 +39,30 @@ public class ElderSettingService {
                 ))
                 .toList();
 
+    }
+
+    public ElderSettingResponse updateElderSetting(Integer memberId, Integer elderId, ElderSettingRequest req) {
+        Elder updateElder = elderRepository.findById(elderId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 어르신입니다."));
+        if(!updateElder.getGuardian().getId().equals(memberId)) throw new AccessDeniedException("해당 어르신에 대한 권한이 없습니다.");
+
+        updateElder.applySettings(
+                req.name(),
+                req.birthDate(),
+                req.gender().getCode(),
+                req.phone(),
+                req.relationship(),
+                req.residenceType()
+        );
+
+        return new ElderSettingResponse(
+                updateElder.getId(),
+                updateElder.getName(),
+                updateElder.getBirthDate(),
+                Gender.fromCode(updateElder.getGender()),
+                updateElder.getPhone(),
+                updateElder.getRelationship(),
+                updateElder.getResidenceType()
+        );
     }
 }

--- a/src/main/java/com/example/medicare_call/service/ElderSettingService.java
+++ b/src/main/java/com/example/medicare_call/service/ElderSettingService.java
@@ -1,0 +1,39 @@
+package com.example.medicare_call.service;
+
+import com.example.medicare_call.domain.Member;
+import com.example.medicare_call.dto.ElderSettingResponse;
+import com.example.medicare_call.global.enums.Gender;
+import com.example.medicare_call.repository.ElderRepository;
+import com.example.medicare_call.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ElderSettingService {
+    private final MemberRepository memberRepository;
+
+    public List<ElderSettingResponse> getElderSetting(Integer memberId){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+        log.info("memberId from @AuthUser = {}", memberId);
+        return member.getElders().stream()
+                .map(elder -> new ElderSettingResponse(
+                        elder.getId(),
+                        elder.getName(),
+                        elder.getBirthDate(),
+                        Gender.fromCode(elder.getGender()),
+                        elder.getPhone(),
+                        elder.getRelationship(),
+                        elder.getResidenceType()
+                ))
+                .toList();
+
+    }
+}

--- a/src/main/java/com/example/medicare_call/service/ElderSettingService.java
+++ b/src/main/java/com/example/medicare_call/service/ElderSettingService.java
@@ -17,7 +17,6 @@ import java.util.List;
 
 @Slf4j
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class ElderSettingService {
     private final MemberRepository memberRepository;
@@ -41,6 +40,7 @@ public class ElderSettingService {
 
     }
 
+    @Transactional
     public ElderSettingResponse updateElderSetting(Integer memberId, Integer elderId, ElderSettingRequest req) {
         Elder updateElder = elderRepository.findById(elderId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 어르신입니다."));
@@ -64,5 +64,14 @@ public class ElderSettingService {
                 updateElder.getRelationship(),
                 updateElder.getResidenceType()
         );
+    }
+
+    @Transactional
+    public void deleteElderSetting(Integer memberId, Integer elderId) {
+        Elder elder = elderRepository.findById(elderId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 어르신입니다."));
+        if(!elder.getGuardian().getId().equals(memberId)) throw new AccessDeniedException("해당 어르신에 대한 권한이 없습니다.");
+
+        elderRepository.delete(elder);
     }
 }


### PR DESCRIPTION
어르신 개인정보 api 구현
## Desc
1. 조회 (GET /elders/settings)
- 로그인한 회원(@AuthUser)이 등록한 모든 어르신의 개인정보를 조회
- 응답: List<ElderSettingResponse>
- 권한: 해당 회원 본인의 데이터만 조회 가능

2. 수정 (POST /elders/{elderId}/settings)
- 요청 바디(ElderSettingRequest) 전체 값으로 어르신 개인정보 수정
- 권한 검증: 요청한 memberId가 해당 어르신의 guardian인지 확인
- 변경 감지(Dirty Checking)로 수정 반영, 별도의 save() 호출 없음
3. 삭제 (DELETE /elders/{elderId}/settings)
- 지정한 어르신 데이터 삭제
- 권한 검증: 요청한 memberId가 해당 어르신의 guardian인지 확인
- cascade = REMOVE, orphanRemoval = true 설정으로 연관 엔티티(CareCallSetting, CareCallRecord 등) 자동 삭제