### PR TITLE
refactor: `CallDataService`, `CareCallService`

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/action/CallDataController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/CallDataController.java
@@ -2,7 +2,7 @@ package com.example.medicare_call.controller.action;
 
 import com.example.medicare_call.domain.CareCallRecord;
 import com.example.medicare_call.dto.CallDataRequest;
-import com.example.medicare_call.service.carecall.CallDataService;
+import com.example.medicare_call.service.carecall.CareCallDataProcessingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -18,13 +18,13 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/call-data")
 public class CallDataController {
-    private final CallDataService callDataService;
+    private final CareCallDataProcessingService careCallDataProcessingService;
 
     @Operation(summary = "통화 데이터 수신", description = "외부 서버로부터 통화 데이터를 받아서 저장합니다.")
     @PostMapping
     public ResponseEntity<CareCallRecord> receiveCallData(@Valid @RequestBody CallDataRequest request) {
         log.info("통화 데이터 수신: elderId={}, settingId={}", request.getElderId(), request.getSettingId());
-        CareCallRecord savedRecord = callDataService.saveCallData(request);
+        CareCallRecord savedRecord = careCallDataProcessingService.saveCallData(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 } 

--- a/src/main/java/com/example/medicare_call/controller/action/HealthDataController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/HealthDataController.java
@@ -18,7 +18,7 @@ import com.example.medicare_call.repository.ElderRepository;
 import com.example.medicare_call.repository.MemberRepository;
 import com.example.medicare_call.repository.MedicationRepository;
 import com.example.medicare_call.repository.MedicationScheduleRepository;
-import com.example.medicare_call.service.carecall.CallDataService;
+import com.example.medicare_call.service.carecall.CareCallDataProcessingService;
 import com.example.medicare_call.service.OpenAiHealthDataService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -33,10 +33,9 @@ import org.springframework.web.bind.annotation.*;
 
 import com.example.medicare_call.global.annotation.ValidDateRange;
 import jakarta.validation.constraints.NotNull;
-import java.time.Instant;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 
 @Slf4j
 @RestController
@@ -46,7 +45,7 @@ import java.time.ZoneOffset;
 public class HealthDataController {
     
     private final OpenAiHealthDataService openAiHealthDataService;
-    private final CallDataService callDataService;
+    private final CareCallDataProcessingService careCallDataProcessingService;
     private final ElderRepository elderRepository;
     private final CareCallSettingRepository careCallSettingRepository;
     private final CareCallRecordRepository careCallRecordRepository;
@@ -139,7 +138,7 @@ public class HealthDataController {
         HealthDataExtractionResponse healthData = openAiHealthDataService.extractHealthData(extractionRequest);
         
         // 건강 데이터를 DB에 저장
-        callDataService.saveHealthDataToDatabase(savedCallRecord, healthData);
+        careCallDataProcessingService.saveHealthDataToDatabase(savedCallRecord, healthData);
         
         return ResponseEntity.ok(savedCallRecord);
     }
@@ -194,7 +193,7 @@ public class HealthDataController {
         HealthDataExtractionResponse healthData = openAiHealthDataService.extractHealthData(extractionRequest);
         
         // 건강 데이터를 DB에 저장
-        callDataService.saveHealthDataToDatabase(savedCallRecord, healthData);
+        careCallDataProcessingService.saveHealthDataToDatabase(savedCallRecord, healthData);
         
         return ResponseEntity.ok(savedCallRecord);
     }
@@ -249,7 +248,7 @@ public class HealthDataController {
         HealthDataExtractionResponse healthData = openAiHealthDataService.extractHealthData(extractionRequest);
         
         // 건강 데이터를 DB에 저장
-        callDataService.saveHealthDataToDatabase(savedCallRecord, healthData);
+        careCallDataProcessingService.saveHealthDataToDatabase(savedCallRecord, healthData);
         
         return ResponseEntity.ok(savedCallRecord);
     }

--- a/src/main/java/com/example/medicare_call/controller/action/TestCareCallController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/TestCareCallController.java
@@ -1,9 +1,8 @@
 package com.example.medicare_call.controller.action;
 
 import com.example.medicare_call.dto.CareCallTestRequest;
-import com.example.medicare_call.service.carecall.CareCallService;
+import com.example.medicare_call.service.carecall.CareCallRequestSenderService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,12 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/test-care-call")
 @RequiredArgsConstructor
 public class TestCareCallController {
-    private final CareCallService careCallService;
+    private final CareCallRequestSenderService careCallRequestSenderService;
 
     @Operation(summary = "프롬프트 테스트", description = "케어콜에 전송하는 프롬프트를 직접 작성하여 전화 품질을 테스트합니다.")
     @PostMapping("")
     public ResponseEntity<String> testCareCall(@Valid @RequestBody CareCallTestRequest req) {
-        careCallService.sendTestCall(req);
+        careCallRequestSenderService.sendTestCall(req);
         return ResponseEntity.ok(req.prompt());
     }
 

--- a/src/main/java/com/example/medicare_call/service/carecall/CareCallDataProcessingService.java
+++ b/src/main/java/com/example/medicare_call/service/carecall/CareCallDataProcessingService.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class CallDataService {
+public class CareCallDataProcessingService {
     private final CareCallRecordRepository careCallRecordRepository;
     private final ElderRepository elderRepository;
     private final CareCallSettingRepository careCallSettingRepository;

--- a/src/main/java/com/example/medicare_call/service/carecall/CareCallRequestSenderService.java
+++ b/src/main/java/com/example/medicare_call/service/carecall/CareCallRequestSenderService.java
@@ -28,7 +28,7 @@ import java.util.Map;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class CareCallService {
+public class CareCallRequestSenderService {
 
     private final MemberRepository memberRepository;
     @Value("${care-call.url}")

--- a/src/main/java/com/example/medicare_call/service/carecall/CareCallSchedulerService.java
+++ b/src/main/java/com/example/medicare_call/service/carecall/CareCallSchedulerService.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class CareCallSchedulerService {
 
     private final CareCallSettingRepository settingRepository;
-    private final CareCallService careCallService;
+    private final CareCallRequestSenderService careCallRequestSenderService;
 
     public void checkAndSendCalls() {
         LocalTime now = LocalTime.now().withSecond(0).withNano(0); // 초 단위 무시
@@ -22,19 +22,19 @@ public class CareCallSchedulerService {
         //1차 케어콜
         List<CareCallSetting> firstTargets = settingRepository.findByFirstCallTime(now);
         for (CareCallSetting setting : firstTargets) {
-            careCallService.sendCall(setting.getId(), setting.getElder().getId(), CallType.FIRST);
+            careCallRequestSenderService.sendCall(setting.getId(), setting.getElder().getId(), CallType.FIRST);
         }
 
         //2차 케어콜
         List<CareCallSetting> secondTargets = settingRepository.findBySecondCallTime(now);
         for (CareCallSetting setting : secondTargets) {
-            careCallService.sendCall(setting.getId(), setting.getElder().getId(), CallType.SECOND);
+            careCallRequestSenderService.sendCall(setting.getId(), setting.getElder().getId(), CallType.SECOND);
         }
 
         //3차 케어콜
         List<CareCallSetting> thirdTargets = settingRepository.findBySecondCallTime(now);
         for (CareCallSetting setting : thirdTargets) {
-            careCallService.sendCall(setting.getId(), setting.getElder().getId(), CallType.THIRD);
+            careCallRequestSenderService.sendCall(setting.getId(), setting.getElder().getId(), CallType.THIRD);
         }
     }
 }

--- a/src/test/java/com/example/medicare_call/Integration/CareCallIntegrationTest.java
+++ b/src/test/java/com/example/medicare_call/Integration/CareCallIntegrationTest.java
@@ -8,11 +8,8 @@ import com.example.medicare_call.global.enums.ResidenceType;
 import com.example.medicare_call.repository.CareCallSettingRepository;
 import com.example.medicare_call.repository.ElderRepository;
 import com.example.medicare_call.repository.MemberRepository;
-import com.example.medicare_call.scheduler.CareCallScheduler;
 import com.example.medicare_call.service.carecall.CareCallSchedulerService;
-import com.example.medicare_call.service.carecall.CareCallService;
-import com.example.medicare_call.service.ElderService;
-import org.junit.jupiter.api.BeforeEach;
+import com.example.medicare_call.service.carecall.CareCallRequestSenderService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +36,7 @@ class CareCallIntegrationTest {
     private ElderRepository elderRepository;
 
     @Autowired
-    private CareCallService careCallService;
+    private CareCallRequestSenderService careCallRequestSenderService;
 
     @Autowired
     private MemberRepository memberRepository;

--- a/src/test/java/com/example/medicare_call/controller/action/CallDataControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/action/CallDataControllerTest.java
@@ -4,16 +4,13 @@ import com.example.medicare_call.domain.CareCallRecord;
 import com.example.medicare_call.domain.CareCallSetting;
 import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.dto.CallDataRequest;
-import com.example.medicare_call.domain.Member;
 import com.example.medicare_call.global.jwt.JwtProvider;
-import com.example.medicare_call.global.jwt.JwtUserDetails;
 import com.example.medicare_call.repository.CareCallRecordRepository;
 import com.example.medicare_call.repository.CareCallSettingRepository;
 import com.example.medicare_call.repository.ElderRepository;
 import com.example.medicare_call.repository.MemberRepository;
-import com.example.medicare_call.service.carecall.CallDataService;
+import com.example.medicare_call.service.carecall.CareCallDataProcessingService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +19,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.Instant;
@@ -46,7 +42,7 @@ class CallDataControllerTest {
     private ObjectMapper objectMapper;
 
     @MockBean
-    private CallDataService callDataService;
+    private CareCallDataProcessingService careCallDataProcessingService;
 
     @MockBean
     private ElderRepository elderRepository;
@@ -112,7 +108,7 @@ class CallDataControllerTest {
                 .healthDetails(null)
                 .build();
 
-        when(callDataService.saveCallData(any(CallDataRequest.class))).thenReturn(savedRecord);
+        when(careCallDataProcessingService.saveCallData(any(CallDataRequest.class))).thenReturn(savedRecord);
 
         // when & then
         mockMvc.perform(post("/call-data")
@@ -216,7 +212,7 @@ class CallDataControllerTest {
                 .healthDetails(null)
                 .build();
 
-        when(callDataService.saveCallData(any(CallDataRequest.class))).thenReturn(savedRecord);
+        when(careCallDataProcessingService.saveCallData(any(CallDataRequest.class))).thenReturn(savedRecord);
 
         // when & then
         mockMvc.perform(post("/call-data")

--- a/src/test/java/com/example/medicare_call/service/carecall/CareCallDataProcessingServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/carecall/CareCallDataProcessingServiceTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class CallDataServiceTest {
+class CareCallDataProcessingServiceTest {
 
     @Mock
     private CareCallRecordRepository careCallRecordRepository;
@@ -44,7 +44,7 @@ class CallDataServiceTest {
     private OpenAiHealthDataService openAiHealthDataService;
 
     @InjectMocks
-    private CallDataService callDataService;
+    private CareCallDataProcessingService careCallDataProcessingService;
 
     @Test
     @DisplayName("통화 데이터 저장 성공 - 모든 필드 포함")
@@ -103,7 +103,7 @@ class CallDataServiceTest {
                 .thenReturn(HealthDataExtractionResponse.builder().build());
 
         // when
-        CareCallRecord result = callDataService.saveCallData(request);
+        CareCallRecord result = careCallDataProcessingService.saveCallData(request);
 
         // then
         assertThat(result).isNotNull();
@@ -153,7 +153,7 @@ class CallDataServiceTest {
         when(careCallRecordRepository.save(any(CareCallRecord.class))).thenReturn(expectedRecord);
 
         // when
-        CareCallRecord result = callDataService.saveCallData(request);
+        CareCallRecord result = careCallDataProcessingService.saveCallData(request);
 
         // then
         assertThat(result).isNotNull();
@@ -204,7 +204,7 @@ class CallDataServiceTest {
         when(careCallRecordRepository.save(any(CareCallRecord.class))).thenReturn(expectedRecord);
 
         // when
-        CareCallRecord result = callDataService.saveCallData(request);
+        CareCallRecord result = careCallDataProcessingService.saveCallData(request);
 
         // then
         assertThat(result).isNotNull();
@@ -231,7 +231,7 @@ class CallDataServiceTest {
         when(elderRepository.findById(999)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> callDataService.saveCallData(request))
+        assertThatThrownBy(() -> careCallDataProcessingService.saveCallData(request))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("어르신을 찾을 수 없습니다: 999");
         
@@ -258,7 +258,7 @@ class CallDataServiceTest {
         when(careCallSettingRepository.findById(999)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> callDataService.saveCallData(request))
+        assertThatThrownBy(() -> careCallDataProcessingService.saveCallData(request))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("통화 설정을 찾을 수 없습니다: 999");
         
@@ -299,7 +299,7 @@ class CallDataServiceTest {
         when(careCallRecordRepository.save(any(CareCallRecord.class))).thenReturn(expectedRecord);
 
         // when
-        CareCallRecord result = callDataService.saveCallData(request);
+        CareCallRecord result = careCallDataProcessingService.saveCallData(request);
 
         // then
         assertThat(result).isNotNull();
@@ -363,7 +363,7 @@ class CallDataServiceTest {
                 .thenReturn(HealthDataExtractionResponse.builder().build());
 
         // when
-        CareCallRecord result = callDataService.saveCallData(request);
+        CareCallRecord result = careCallDataProcessingService.saveCallData(request);
 
         // then
         assertThat(result).isNotNull();

--- a/src/test/java/com/example/medicare_call/service/carecall/CareCallSchedulerServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/carecall/CareCallSchedulerServiceTest.java
@@ -22,7 +22,7 @@ public class CareCallSchedulerServiceTest {
     private CareCallSettingRepository careCallSettingRepository;
 
     @Mock
-    private CareCallService callService;
+    private CareCallRequestSenderService callService;
 
     @InjectMocks
     private CareCallSchedulerService schedulerService;


### PR DESCRIPTION
### Desc
- 이름만으로는 그 책임이 모호한 서비스에 대해, 명시적으로 서비스의 책임을 알 수 있도록 이름을 변경하자
- `CallDataService` -> `CareCallDataProcessingService`
  - 케어콜 전화 데이터를 받아서, 데이터 추출 및 저장, 즉 데이터 프로세싱을 담당하는 서비스
- `CareCallService` -> `CareCallRequestSenderService`
  - 케어콜 서버로 케어콜에 필요한 데이터를 취합하여 전화 요청을 날리는 서비스