### PR TITLE
edit: Elder Register API 수정

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/action/ElderController.java
+++ b/src/main/java/com/example/medicare_call/controller/action/ElderController.java
@@ -28,8 +28,10 @@ public class ElderController {
 
     @Operation(summary = "어르신 등록", description = "이름, 생년월일, 성별, 휴대폰, 관계, 거주방식 정보를 입력받아 어르신을 등록합니다.")
     @PostMapping
-    public ResponseEntity<ElderResponse> registerElder(@Valid @RequestBody ElderRegisterRequest request) {
-        Elder elder = elderService.registerElder(request);
+    public ResponseEntity<ElderResponse> registerElder(
+            @Parameter(hidden = true) @AuthUser Long memberId,
+            @Valid @RequestBody ElderRegisterRequest request) {
+        Elder elder = elderService.registerElder(memberId.intValue(), request);
         ElderResponse response = ElderResponse.builder()
             .id(elder.getId())
             .name(elder.getName())

--- a/src/main/java/com/example/medicare_call/dto/ElderRegisterRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/ElderRegisterRequest.java
@@ -38,8 +38,4 @@ public class ElderRegisterRequest {
     @Schema(description = "어르신 거주방식 (ALONE: 혼자 계세요, WITH_FAMILY: 가족과 함께 살아요)", example = "ALONE")
     @NotNull(message = "어르신 거주방식은 필수입니다.")
     private ResidenceType residenceType;
-
-    @Schema(description = "보호자 ID", example = "1")
-    @NotNull(message = "보호자 ID는 필수입니다.")
-    private Integer guardianId;
 }

--- a/src/main/java/com/example/medicare_call/service/ElderService.java
+++ b/src/main/java/com/example/medicare_call/service/ElderService.java
@@ -24,9 +24,9 @@ public class ElderService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public Elder registerElder(@Valid ElderRegisterRequest request) {
-        Member guardian = memberRepository.findById(request.getGuardianId())
-            .orElseThrow(() -> new ResourceNotFoundException("보호자를 찾을 수 없습니다: " + request.getGuardianId()));
+    public Elder registerElder(Integer memberId, @Valid ElderRegisterRequest request) {
+        Member guardian = memberRepository.findById(memberId)
+            .orElseThrow(() -> new ResourceNotFoundException("보호자를 찾을 수 없습니다: " + memberId));
         Elder elder = Elder.builder()
             .name(request.getName())
             .birthDate(request.getBirthDate())

--- a/src/test/java/com/example/medicare_call/global/annotation/ValidationTest.java
+++ b/src/test/java/com/example/medicare_call/global/annotation/ValidationTest.java
@@ -38,7 +38,6 @@ class ValidationTest {
         request.setPhone("01012345678");
         request.setRelationship(ElderRelation.GRANDCHILD);
         request.setResidenceType(ResidenceType.ALONE);
-        request.setGuardianId(1);
 
         // when
         Set<ConstraintViolation<ElderRegisterRequest>> violations = validator.validate(request);
@@ -58,7 +57,6 @@ class ValidationTest {
         request.setPhone("01012345678");
         request.setRelationship(ElderRelation.GRANDCHILD);
         request.setResidenceType(ResidenceType.ALONE);
-        request.setGuardianId(1);
 
         // when
         Set<ConstraintViolation<ElderRegisterRequest>> violations = validator.validate(request);
@@ -82,7 +80,6 @@ class ValidationTest {
         request.setPhone("01012345678");
         request.setRelationship(ElderRelation.GRANDCHILD);
         request.setResidenceType(ResidenceType.ALONE);
-        request.setGuardianId(1);
 
         // when
         Set<ConstraintViolation<ElderRegisterRequest>> violations = validator.validate(request);
@@ -106,7 +103,6 @@ class ValidationTest {
         request.setPhone("01012345678");
         request.setRelationship(ElderRelation.GRANDCHILD);
         request.setResidenceType(ResidenceType.ALONE);
-        request.setGuardianId(1);
 
         // when
         Set<ConstraintViolation<ElderRegisterRequest>> violations = validator.validate(request);
@@ -126,7 +122,6 @@ class ValidationTest {
         request.setPhone("010-1234-5678"); // 하이픈 포함
         request.setRelationship(ElderRelation.GRANDCHILD);
         request.setResidenceType(ResidenceType.ALONE);
-        request.setGuardianId(1);
 
         // when
         Set<ConstraintViolation<ElderRegisterRequest>> violations = validator.validate(request);
@@ -150,7 +145,6 @@ class ValidationTest {
         request.setPhone("01112345678"); // 011로 시작
         request.setRelationship(ElderRelation.GRANDCHILD);
         request.setResidenceType(ResidenceType.ALONE);
-        request.setGuardianId(1);
 
         // when
         Set<ConstraintViolation<ElderRegisterRequest>> violations = validator.validate(request);

--- a/src/test/java/com/example/medicare_call/service/ElderServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/ElderServiceTest.java
@@ -54,14 +54,13 @@ class ElderServiceTest {
         req.setPhone("01012345678");
         req.setRelationship(ElderRelation.GRANDCHILD);
         req.setResidenceType(ResidenceType.ALONE);
-        req.setGuardianId(1);
 
         Elder saved = Elder.builder()
             .name(req.getName())
             .build();
         when(elderRepository.save(any(Elder.class))).thenReturn(saved);
 
-        Elder result = elderService.registerElder(req);
+        Elder result = elderService.registerElder(1, req);
         assertThat(result.getName()).isEqualTo("홍길동");
     }
 
@@ -76,12 +75,11 @@ class ElderServiceTest {
         req.setPhone("01012345678");
         req.setRelationship(ElderRelation.GRANDCHILD);
         req.setResidenceType(ResidenceType.ALONE);
-        req.setGuardianId(999);
 
         when(memberRepository.findById(999)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> elderService.registerElder(req))
+        assertThatThrownBy(() -> elderService.registerElder(999, req))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("보호자를 찾을 수 없습니다: 999");
     }


### PR DESCRIPTION
### Desc
- https://github.com/Medicare-Call/Medicare-Call-Backend/issues/62 에 대한 작업
- 현재는 노인 등록 API를 호출할 경우 보호자 id를 명시적으로 dto에 포함하여 요청하도록 스펙이 구성되어 있다.
- 클라이언트에서 이 경우에는 보호자 id를 메모리나 스토리지에서 관리해야 하고, jwt의 claim에도 있는 정보이기 때문에 불필요한 스펙이다
- 노인 등록 API를 호출할 때, 요청에서 guardianId를 제거하고 jwt의 claim에서 memberId를 추출하여 엔티티를 생성하도록 하자