### PR TITLE
fix: Elder 내 외래 키 제약 조건 위반 해결

### DIFF
--- a/src/main/java/com/example/medicare_call/domain/Elder.java
+++ b/src/main/java/com/example/medicare_call/domain/Elder.java
@@ -56,10 +56,10 @@ public class Elder {
     @OneToOne(mappedBy = "elder", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     private CareCallSetting careCallSetting;
 
-    @OneToMany(mappedBy = "elder")
+    @OneToMany(mappedBy = "elder", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private final List<MedicationSchedule> medicationSchedules = new ArrayList<>();
 
-    @OneToMany(mappedBy = "elder")
+    @OneToMany(mappedBy = "elder", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private final List<ElderDisease> elderDiseases = new ArrayList<>();
 
     @OneToOne(mappedBy = "elder", cascade = CascadeType.ALL, fetch = FetchType.LAZY)


### PR DESCRIPTION
## Desc
`DELETE /elders/{elderId}` : 어르신 개인정보 삭제 API 테스트 도중 외래 키 제약 조건 위반 발생

- `CascadeType.REMOVE`를 추가함으로써 Elder 엔티티의 변경(삭제)이 연관된 ElderDisease 엔티티에 자동으로 전이되어, Elder가 영속성 컨텍스트에서 제거될 때 자식 엔티티도 함께 삭제
- `orphanRemoval = true` 옵션을 추가하여 elderDiseases 컬렉션에서 자식 엔티티가 제거될 경우 해당 엔티티가 고아 객체로 간주되어 자동으로 데이터베이스에서도 삭제되도록 함