### PR TITLE
Feat/update elders health info

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/ElderHealthInfoController.java
+++ b/src/main/java/com/example/medicare_call/controller/ElderHealthInfoController.java
@@ -22,7 +22,7 @@ import java.util.List;
 public class ElderHealthInfoController {
     private final ElderHealthInfoService elderHealthInfoService;
 
-    @Operation(summary = "어르신 건강정보 등록", description = "질환, 복약주기, 특이사항을 등록합니다.")
+    @Operation(summary = "어르신 건강정보 등록 및 수정", description = "질환, 복약주기, 특이사항을 등록 및 수정합니다.")
     @PostMapping("/{elderId}/health-info")
     public ResponseEntity<Void> registerElderHealthInfo(@PathVariable Integer elderId, @Valid @RequestBody ElderHealthInfoCreateRequest request) {
         elderHealthInfoService.registerElderHealthInfo(elderId, request);

--- a/src/main/java/com/example/medicare_call/controller/ElderHealthInfoController.java
+++ b/src/main/java/com/example/medicare_call/controller/ElderHealthInfoController.java
@@ -24,8 +24,8 @@ public class ElderHealthInfoController {
 
     @Operation(summary = "어르신 건강정보 등록 및 수정", description = "질환, 복약주기, 특이사항을 등록 및 수정합니다.")
     @PostMapping("/{elderId}/health-info")
-    public ResponseEntity<Void> registerElderHealthInfo(@PathVariable Integer elderId, @Valid @RequestBody ElderHealthInfoCreateRequest request) {
-        elderHealthInfoService.registerElderHealthInfo(elderId, request);
+    public ResponseEntity<Void> upsertElderHealthInfo(@PathVariable Integer elderId, @Valid @RequestBody ElderHealthInfoCreateRequest request) {
+        elderHealthInfoService.upsertElderHealthInfo(elderId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/com/example/medicare_call/domain/ElderHealthInfo.java
+++ b/src/main/java/com/example/medicare_call/domain/ElderHealthInfo.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 import lombok.Builder;
 
 import jakarta.persistence.*;
+import lombok.Setter;
 
 @Entity
 @Table(name = "ElderHealthInfo")
@@ -20,6 +21,7 @@ public class ElderHealthInfo {
     @JoinColumn(name = "elder_id", nullable = false, unique = true)
     private Elder elder;
 
+    @Setter
     @Column(name = "notes", columnDefinition = "TEXT")
     private String notes;
 

--- a/src/main/java/com/example/medicare_call/repository/ElderDiseaseRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/ElderDiseaseRepository.java
@@ -12,4 +12,6 @@ public interface ElderDiseaseRepository extends JpaRepository<ElderDisease, Obje
 
     @Query("SELECT ed.disease FROM ElderDisease ed WHERE ed.elder = :elder")
     List<Disease> findDiseasesByElder(Elder elder);
+
+    void deleteAllByElder(Elder elder);
 }

--- a/src/main/java/com/example/medicare_call/repository/ElderHealthInfoRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/ElderHealthInfoRepository.java
@@ -1,8 +1,13 @@
 package com.example.medicare_call.repository;
 
+import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.domain.ElderHealthInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ElderHealthInfoRepository extends JpaRepository<ElderHealthInfo, Integer> {
     ElderHealthInfo findByElderId(Integer elderId);
+    void deleteAllByElder(Elder elder);
+    Optional<ElderHealthInfo> findByElder(Elder elder);
 } 

--- a/src/main/java/com/example/medicare_call/repository/MedicationScheduleRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/MedicationScheduleRepository.java
@@ -11,5 +11,6 @@ import java.util.List;
 public interface MedicationScheduleRepository extends JpaRepository<MedicationSchedule, Integer> {
     List<MedicationSchedule> findByElderId(Integer elderId);
     List<MedicationSchedule> findByElder(Elder elder);
+    void deleteAllByElder(Elder elder);
     
 } 

--- a/src/main/java/com/example/medicare_call/service/report/ElderHealthInfoService.java
+++ b/src/main/java/com/example/medicare_call/service/report/ElderHealthInfoService.java
@@ -24,7 +24,7 @@ public class ElderHealthInfoService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void registerElderHealthInfo(Integer elderId, ElderHealthInfoCreateRequest request) {
+    public void upsertElderHealthInfo(Integer elderId, ElderHealthInfoCreateRequest request) {
         // TODO : 이쪽 Exception에 대한 Monitoring 추가 필요. 데이터의 무결성이 깨졌을 확률이 높다
         Elder elder = elderRepository.findById(elderId)
                 .orElseThrow(() -> new ResourceNotFoundException("어르신을 찾을 수 없습니다. elderId: " + elderId));

--- a/src/test/java/com/example/medicare_call/service/ElderHealthInfoServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/ElderHealthInfoServiceTest.java
@@ -55,7 +55,7 @@ class ElderHealthInfoServiceTest {
                 .notes(List.of(ElderHealthNoteType.INSOMNIA))
                 .build();
 
-        elderHealthInfoService.registerElderHealthInfo(1, request);
+        elderHealthInfoService.upsertElderHealthInfo(1, request);
 
         verify(elderDiseaseRepository, times(1)).save(any(ElderDisease.class));
         verify(medicationScheduleRepository, times(1)).save(any(MedicationSchedule.class));
@@ -74,7 +74,7 @@ class ElderHealthInfoServiceTest {
         when(elderRepository.findById(999)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> elderHealthInfoService.registerElderHealthInfo(999, request))
+        assertThatThrownBy(() -> elderHealthInfoService.upsertElderHealthInfo(999, request))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("어르신을 찾을 수 없습니다. elderId: 999");
     }


### PR DESCRIPTION
## Desc
- 프론트 요청에 따라, 어르신 건강정보 수정 로직을 PATCH에서 POST로 변경
   - 기존 건강정보 등록 API가 POST로 구현돼 있었기에, 새로운 엔드포인트를 만드는 것 대신에 `registerElderHealthInfo`를 약간 수정하여 수정도 가능하도록 변경
   - `ElderDisease`, `MedicationSchedule` 는 존재한다면 삭제하고 request의 내용으로 저장
 - `ElderHealthInfo` 는 `Elder`와 `@OneToOne` 관계이므로 notes 업데이트 시 setter로 내용 변경, notes가 없다면 삭제
   - notes만 바꾸기 위해 ElderHealthInfo를 항상 지우는 것은 비효율적이라 판단 

이게 올바른 설계인지 고민중