### PR TITLE
fix: 구독 데이터가 없는 경우, api에서 404를 반환하는 문제

### DIFF
--- a/src/main/java/com/example/medicare_call/service/SubscriptionService.java
+++ b/src/main/java/com/example/medicare_call/service/SubscriptionService.java
@@ -24,14 +24,8 @@ public class SubscriptionService {
             throw new ResourceNotFoundException("해당 ID의 회원을 찾을 수 없습니다: " + memberId);
         }
 
-        List<SubscriptionResponse> subscriptions = subscriptionRepository.findByMemberId(memberId.intValue()).stream()
+        return subscriptionRepository.findByMemberId(memberId.intValue()).stream()
                 .map(SubscriptionResponse::from)
                 .collect(Collectors.toList());
-
-        if (subscriptions.isEmpty()) {
-            throw new ResourceNotFoundException("해당 회원의 구독 정보를 찾을 수 없습니다.");
-        }
-
-        return subscriptions;
     }
 }

--- a/src/test/java/com/example/medicare_call/controller/SubscriptionControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/SubscriptionControllerTest.java
@@ -77,4 +77,17 @@ class SubscriptionControllerTest {
                 .andExpect(jsonPath("$[0].nextBillingDate").value("2025-07-10"))
                 .andExpect(jsonPath("$[0].startDate").value("2025-05-10"));
     }
+
+    @Test
+    @DisplayName("GET /elders/subscriptions - 회원의 구독 정보 조회 성공 (구독 정보 없음)")
+    void getSubscriptions_Success_Empty() throws Exception {
+        // given
+        given(subscriptionService.getSubscriptionsByMember(anyLong())).willReturn(Collections.emptyList());
+
+        // when & then
+        mockMvc.perform(get("/elders/subscriptions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
 }

--- a/src/test/java/com/example/medicare_call/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/SubscriptionServiceTest.java
@@ -82,16 +82,18 @@ class SubscriptionServiceTest {
     }
 
     @Test
-    @DisplayName("구독 정보 조회 실패 - 구독 정보 없음")
-    void getSubscriptions_Fail_NoSubscriptions() {
+    @DisplayName("구독 정보 조회 성공 - 구독 정보 없음")
+    void getSubscriptions_Success_NoSubscriptions() {
         // given
         Long memberId = 1L;
         given(memberRepository.existsById(memberId.intValue())).willReturn(true);
         given(subscriptionRepository.findByMemberId(memberId.intValue())).willReturn(Collections.emptyList());
 
-        // when & then
-        assertThatThrownBy(() -> subscriptionService.getSubscriptionsByMember(memberId))
-                .isInstanceOf(ResourceNotFoundException.class)
-                .hasMessage("해당 회원의 구독 정보를 찾을 수 없습니다.");
+        // when
+        List<SubscriptionResponse> responses = subscriptionService.getSubscriptionsByMember(memberId);
+
+        // then
+        assertThat(responses).isNotNull();
+        assertThat(responses).isEmpty();
     }
 }


### PR DESCRIPTION
### Desc
- 현재는 회원이 결제를 수행하지 않아 구독 정보를 조회했을 때, 구독 데이터가 없을 경우 404 Not Found를 반환하고 있다.
- 404 Not Found는 데이터가 존재하지 않는 것으로, 데이터가 비어 있는 것과는 다르다.
- 결제를 하지 않아 구독 데이터가 없는 경우에는 일반적으로 기대하는 값인 빈 값을 보내주도록 처리하자.