### PR TITLE
fix: 잘못된 경로로 요청시 500에러를 뱉는 문제

### DIFF
--- a/src/main/java/com/example/medicare_call/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/medicare_call/global/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.HashMap;
@@ -41,6 +42,14 @@ public class GlobalExceptionHandler {
                 .build();
 
         return new ResponseEntity<>(response, ErrorCode.INVALID_TYPE_VALUE.getStatus());
+    }
+
+    // 지원하지 않는 HTTP Method 처리
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+        return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
     }
 
     // 커스텀 에러

--- a/src/main/java/com/example/medicare_call/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/medicare_call/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C004", "일시적인 서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."),
     INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C005", "입력 형식이 올바르지 않습니다. 올바른 형식으로 입력해 주세요."),
     HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C006", "해당 작업에 대한 권한이 없습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C007", "지원하지 않는 요청 방식입니다. 올바른 방식으로 다시 시도해 주세요."),
 
     // Auth
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A003", "로그인이 만료되었습니다. 다시 로그인해 주세요."),


### PR DESCRIPTION
### Desc
- 현재 API를 잘못된 경로로 요청할 경우, 전역 예외 처리기에서 잡아서 이를 500으로 일괄 뱉어버리는 문제가 있다.
- 존재하지 않는 경로로 API 요청시에는 405를 반환할 수 있도록 전역 예외 처리기에 추가하자