### PR TITLE
feat: 데모데이 시연을 위한 즉시 전화 발송 API 구현

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/CareCallController.java
+++ b/src/main/java/com/example/medicare_call/controller/CareCallController.java
@@ -51,6 +51,14 @@ public class CareCallController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    // TODO [DEMO] 데모데이 시연용 임시 코드 → 정식 버전 구현 시 제거 필요
+    @Operation(summary = "즉시 케어콜 발송", description = "memberId를 통해 해당 보호자의 첫 번째 어르신에게 즉시 케어콜을 발송합니다.")
+    @PostMapping("/care-call/immediate")
+    public ResponseEntity<String> sendImmediateCareCall(@Parameter(hidden = true) @AuthUser Long authMemberId) {
+        String result = careCallRequestSenderService.sendImmediateCallToFirstElder(authMemberId.intValue());
+        return ResponseEntity.ok(result);
+    }
+
     //TODO: 개발 완료 후 삭제
     @Operation(summary = "[테스트용] 프롬프트 테스트", description = "케어콜에 전송하는 프롬프트를 직접 작성하여 전화 품질을 테스트합니다.")
     @PostMapping("/test-care-call")

--- a/src/test/java/com/example/medicare_call/controller/TestConfig.java
+++ b/src/test/java/com/example/medicare_call/controller/TestConfig.java
@@ -1,0 +1,36 @@
+package com.example.medicare_call.controller;
+
+import com.example.medicare_call.global.annotation.AuthUser;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@TestConfiguration
+public class TestConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new HandlerMethodArgumentResolver() {
+            @Override
+            public boolean supportsParameter(MethodParameter parameter) {
+                return parameter.hasParameterAnnotation(AuthUser.class) && 
+                       parameter.getParameterType().equals(Long.class);
+            }
+
+            @Override
+            public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+                // 테스트용으로 항상 1L을 반환
+                return 1L;
+            }
+        });
+    }
+}

--- a/src/test/java/com/example/medicare_call/service/carecall/CareCallRequestSenderServiceImmediateTest.java
+++ b/src/test/java/com/example/medicare_call/service/carecall/CareCallRequestSenderServiceImmediateTest.java
@@ -1,0 +1,226 @@
+package com.example.medicare_call.service.carecall;
+
+import com.example.medicare_call.domain.*;
+import com.example.medicare_call.global.enums.CallType;
+import com.example.medicare_call.global.enums.ElderRelation;
+import com.example.medicare_call.global.enums.ResidenceType;
+import com.example.medicare_call.global.exception.CustomException;
+import com.example.medicare_call.global.exception.ErrorCode;
+import com.example.medicare_call.repository.*;
+import com.example.medicare_call.service.carecall.prompt.CallPromptGeneratorFactory;
+import com.example.medicare_call.service.carecall.prompt.FirstCallPromptGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("첫 번째 어르신 즉시 케어콜 요청 서비스 테스트")
+class CareCallRequestSenderServiceImmediateTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ElderRepository elderRepository;
+
+    @Mock
+    private ElderHealthInfoRepository healthInfoRepository;
+
+    @Mock
+    private ElderDiseaseRepository elderDiseaseRepository;
+
+    @Mock
+    private MedicationScheduleRepository medicationScheduleRepository;
+
+    @Mock
+    private CareCallSettingRepository careCallSettingRepository;
+
+    @Mock
+    private CallPromptGeneratorFactory callPromptGeneratorFactory;
+
+    @Mock
+    private FirstCallPromptGenerator firstCallPromptGenerator;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private CareCallRequestSenderService careCallRequestSenderService;
+
+    private Member testMember;
+    private Elder testElder1;
+    private Elder testElder2;
+    private ElderHealthInfo testHealthInfo;
+    private CareCallSetting testCareCallSetting;
+    private List<Disease> testDiseases;
+    private List<MedicationSchedule> testMedicationSchedules;
+
+    @BeforeEach
+    void setUp() {
+        testMember = Member.builder()
+                .id(1)
+                .name("김보호자")
+                .phone("01012345678")
+                .gender((byte) 1)
+                .termsAgreedAt(LocalDateTime.now())
+                .plan((byte) 1)
+                .build();
+
+        testElder1 = Elder.builder()
+                .id(1)
+                .guardian(testMember)
+                .name("김할머니")
+                .birthDate(LocalDate.of(1940, 1, 1))
+                .gender((byte) 0)
+                .phone("01087654321")
+                .relationship(ElderRelation.GRANDCHILD)
+                .residenceType(ResidenceType.ALONE)
+                .build();
+
+        testElder2 = Elder.builder()
+                .id(2)
+                .guardian(testMember)
+                .name("박할아버지")
+                .birthDate(LocalDate.of(1938, 5, 15))
+                .gender((byte) 1)
+                .phone("01098765432")
+                .relationship(ElderRelation.CHILD)
+                .residenceType(ResidenceType.ALONE)
+                .build();
+
+        testHealthInfo = ElderHealthInfo.builder()
+                .id(1)
+                .elder(testElder1)
+                .build();
+
+        testCareCallSetting = CareCallSetting.builder()
+                .id(1)
+                .elder(testElder1)
+                .firstCallTime(LocalTime.now())
+                .recurrence((byte) 0)
+                .build();
+
+        testDiseases = Collections.emptyList();
+        testMedicationSchedules = Collections.emptyList();
+
+        // Member의 elders 리스트 설정 (testElder1이 첫 번째)
+        testMember.getElders().addAll(Arrays.asList(testElder1, testElder2));
+    }
+
+    @Test
+    @DisplayName("memberId로 첫 번째 어르신에게 즉시 케어콜 발송 - 성공")
+    void sendImmediateCallToFirstElder_Success() {
+        // given
+        Integer memberId = 1;
+        String expectedPrompt = "테스트 프롬프트";
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+        when(careCallSettingRepository.findByElder(testElder1)).thenReturn(Optional.of(testCareCallSetting));
+        when(careCallSettingRepository.save(any(CareCallSetting.class))).thenReturn(testCareCallSetting);
+        when(elderRepository.findById(testElder1.getId())).thenReturn(Optional.of(testElder1));
+        when(healthInfoRepository.findByElderId(testElder1.getId())).thenReturn(testHealthInfo);
+        when(elderDiseaseRepository.findDiseasesByElder(testElder1)).thenReturn(testDiseases);
+        when(medicationScheduleRepository.findByElderId(testElder1.getId())).thenReturn(testMedicationSchedules);
+        when(callPromptGeneratorFactory.getGenerator(CallType.FIRST)).thenReturn(firstCallPromptGenerator);
+        when(firstCallPromptGenerator.generate(any(), any(), any(), any())).thenReturn(expectedPrompt);
+
+        // when
+        String result = careCallRequestSenderService.sendImmediateCallToFirstElder(memberId);
+
+        // then
+        assertThat(result).isEqualTo("김할머니 어르신께 즉시 케어콜 발송이 완료되었습니다.");
+
+        verify(memberRepository).findById(memberId);
+        verify(careCallSettingRepository).findByElder(testElder1);
+        verify(careCallSettingRepository).save(any(CareCallSetting.class));
+        verify(callPromptGeneratorFactory).getGenerator(CallType.FIRST);
+        // 첫 번째 어르신에게만 전화하므로 testElder1에만 호출
+        verify(elderRepository).findById(testElder1.getId());
+        verify(elderRepository, never()).findById(testElder2.getId());
+    }
+
+    @Test
+    @DisplayName("memberId로 첫 번째 어르신 케어콜 발송 - 회원 없음")
+    void sendImmediateCallToFirstElder_MemberNotFound() {
+        // given
+        Integer memberId = 999;
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> careCallRequestSenderService.sendImmediateCallToFirstElder(memberId))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("memberId로 첫 번째 어르신 케어콜 발송 - 등록된 어르신 없음")
+    void sendImmediateCallToFirstElder_NoElders() {
+        // given
+        Integer memberId = 1;
+        Member memberWithNoElders = Member.builder()
+                .id(memberId)
+                .name("김보호자")
+                .phone("01012345678")
+                .gender((byte) 1)
+                .termsAgreedAt(LocalDateTime.now())
+                .plan((byte) 1)
+                .build();
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(memberWithNoElders));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            careCallRequestSenderService.sendImmediateCallToFirstElder(memberId);
+        });
+        assertEquals(ErrorCode.ELDER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("memberId로 첫 번째 어르신 케어콜 발송 - 새로운 CareCallSetting 생성")
+    void sendImmediateCallToFirstElder_CreateNewSetting() {
+        // given
+        Integer memberId = 1;
+        String expectedPrompt = "테스트 프롬프트";
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+        when(careCallSettingRepository.findByElder(testElder1)).thenReturn(Optional.empty()); // 기존 설정 없음
+        when(careCallSettingRepository.save(any(CareCallSetting.class))).thenReturn(testCareCallSetting);
+        when(elderRepository.findById(testElder1.getId())).thenReturn(Optional.of(testElder1));
+        when(healthInfoRepository.findByElderId(testElder1.getId())).thenReturn(testHealthInfo);
+        when(elderDiseaseRepository.findDiseasesByElder(testElder1)).thenReturn(testDiseases);
+        when(medicationScheduleRepository.findByElderId(testElder1.getId())).thenReturn(testMedicationSchedules);
+        when(callPromptGeneratorFactory.getGenerator(CallType.FIRST)).thenReturn(firstCallPromptGenerator);
+        when(firstCallPromptGenerator.generate(any(), any(), any(), any())).thenReturn(expectedPrompt);
+
+        // when
+        String result = careCallRequestSenderService.sendImmediateCallToFirstElder(memberId);
+
+        // then
+        assertThat(result).isEqualTo("김할머니 어르신께 즉시 케어콜 발송이 완료되었습니다.");
+
+        verify(memberRepository).findById(memberId);
+        verify(careCallSettingRepository).findByElder(testElder1);
+        verify(careCallSettingRepository).save(any(CareCallSetting.class)); // 새로운 설정 저장
+        verify(callPromptGeneratorFactory).getGenerator(CallType.FIRST);
+    }
+}


### PR DESCRIPTION
### Desc
- 데모데이 시연시, 원활환 케어콜 체험을 위한 임시 엔드포인트를 추가
  - 어플리케이션 로직의 사이드 이펙트를 방지하기 위해, 별도의 설정들을 엔드포인트에만 요청하기만 하면 자동으로 생성한다. (e.g. CareCallSetting)
  - 데모데이 시연시에는 CronJob을 통해 케어콜을 보내는 Scheduler은 비활성 처리 예정
- Controller들의 `AuthenticationArgumentResolver`에 대한 의존성을 제거하기 위한 테스트 설정 모듈 추가
  - Spring MVC가 시작될 때 WebMvcConfigurer의 addArgumentResolvers 메서드를 호출하여 우리의 resolver를 등록
  - 테스트 환경에서 `@AuthUser`에 대해 resolver가 1L을 반환하도록 처리
  - 컨트롤러는 엔드포인트에 대한 요청이 기대하는 반환을 가지는지에 대한 테스트에 집중해야 한다. Spring Security에 대한 검증은 별도로 마련하는게 바람직한 테스트 구조

### API Spec
`POST /care-call/immediate`
- 요청시, 클라이언트에서 함께 전송된 jwt Access Token의 memberId값을 파싱하여, 회원의 첫 번째 Elder으로 전화를 발송

### 참고
- 노드 서버 버그로 로컬에서 전화 테스트는 해보지 못함