### PR TITLE
edit: Elder 삭제 API Soft Delete 적용

### DIFF
--- a/src/main/java/com/example/medicare_call/domain/Elder.java
+++ b/src/main/java/com/example/medicare_call/domain/Elder.java
@@ -10,20 +10,25 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.example.medicare_call.global.enums.ElderRelation;
+import com.example.medicare_call.global.enums.ElderStatus;
 import com.example.medicare_call.global.enums.ResidenceType;
 import lombok.Setter;
+import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLDelete;
 
 @Entity
 @Table(name = "Elder")
 @Getter
 @NoArgsConstructor
+@Where(clause = "status = 'ACTIVATED'")
+@SQLDelete(sql = "UPDATE Elder SET status = 'DELETED' WHERE id = ?")
 public class Elder {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Integer id;
 
-    @OneToOne(mappedBy = "elder", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "elder")
     private Subscription subscription;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -50,23 +55,27 @@ public class Elder {
     @Column(name = "residence_type", nullable = false, length = 20)
     private ResidenceType residenceType;
 
-    @OneToMany(mappedBy = "elder", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ElderStatus status;
+
+    @OneToMany(mappedBy = "elder")
     private final List<CareCallRecord> careCallRecords = new ArrayList<>();
 
-    @OneToOne(mappedBy = "elder", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "elder", fetch = FetchType.LAZY)
     private CareCallSetting careCallSetting;
 
-    @OneToMany(mappedBy = "elder", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "elder")
     private final List<MedicationSchedule> medicationSchedules = new ArrayList<>();
 
-    @OneToMany(mappedBy = "elder", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "elder")
     private final List<ElderDisease> elderDiseases = new ArrayList<>();
 
-    @OneToOne(mappedBy = "elder", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "elder", fetch = FetchType.LAZY)
     private ElderHealthInfo elderHealthInfo;
 
     @Builder
-    public Elder(Integer id, Member guardian, String name, LocalDate birthDate, Byte gender, String phone, ElderRelation relationship, ResidenceType residenceType) {
+    public Elder(Integer id, Member guardian, String name, LocalDate birthDate, Byte gender, String phone, ElderRelation relationship, ResidenceType residenceType, ElderStatus status) {
         this.id = id;
         this.guardian = guardian;
         this.name = name;
@@ -75,6 +84,7 @@ public class Elder {
         this.phone = phone;
         this.relationship = relationship;
         this.residenceType = residenceType;
+        this.status = status != null ? status : ElderStatus.ACTIVATED;
     }
 
     // setting update를 post로 구현

--- a/src/main/java/com/example/medicare_call/global/enums/ElderStatus.java
+++ b/src/main/java/com/example/medicare_call/global/enums/ElderStatus.java
@@ -1,0 +1,6 @@
+package com.example.medicare_call.global.enums;
+
+public enum ElderStatus {
+    ACTIVATED,  // 활성화된 상태
+    DELETED     // 삭제된 상태
+}

--- a/src/main/java/com/example/medicare_call/repository/ElderRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/ElderRepository.java
@@ -2,11 +2,25 @@ package com.example.medicare_call.repository;
 
 import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.domain.Member;
+import com.example.medicare_call.global.enums.ElderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ElderRepository extends JpaRepository<Elder, Integer> {
     List<Elder> findByGuardian(Member member);
+
+    @Query("SELECT e FROM Elder e WHERE e.id = :id AND e.status = :status")
+    Optional<Elder> findByIdAndStatus(@Param("id") Integer id, @Param("status") ElderStatus status);
+
+    @Query("SELECT e FROM Elder e WHERE e.guardian = :guardian AND e.status = :status")
+    List<Elder> findByGuardianAndStatus(@Param("guardian") Member guardian, @Param("status") ElderStatus status);
+
+    // 모든 상태의 어르신을 조회 (관리자용)
+    @Query("SELECT e FROM Elder e WHERE e.id = :id")
+    Optional<Elder> findByIdIgnoreStatus(@Param("id") Integer id);
 
 } 

--- a/src/main/resources/db/migration/V16__add_status_to_elder.sql
+++ b/src/main/resources/db/migration/V16__add_status_to_elder.sql
@@ -1,0 +1,8 @@
+-- Elder 테이블에 status 컬럼 추가 (soft delete 지원)
+ALTER TABLE Elder ADD COLUMN status ENUM('ACTIVATED', 'DELETED') NOT NULL DEFAULT 'ACTIVATED';
+
+-- 기존 데이터의 status를 모두 ACTIVATED로 설정
+UPDATE Elder SET status = 'ACTIVATED' WHERE status IS NULL OR status = '';
+
+-- status 컬럼에 인덱스 추가
+CREATE INDEX idx_elder_status ON Elder(status);

--- a/src/test/java/com/example/medicare_call/service/ElderServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/ElderServiceTest.java
@@ -3,6 +3,7 @@ package com.example.medicare_call.service;
 import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.dto.ElderRegisterRequest;
 import com.example.medicare_call.global.enums.ElderRelation;
+import com.example.medicare_call.global.enums.ElderStatus;
 import com.example.medicare_call.global.enums.ResidenceType;
 import com.example.medicare_call.global.enums.Gender;
 import com.example.medicare_call.repository.ElderRepository;
@@ -25,6 +26,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -157,5 +160,27 @@ class ElderServiceTest {
             elderService.deleteElder(memberId, elderId);
         });
         assertEquals(ErrorCode.HANDLE_ACCESS_DENIED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("어르신 정보 삭제 성공 (soft delete)")
+    void deleteElder_success_softDelete() {
+        // given
+        Integer memberId = 1;
+        Integer elderId = 1;
+
+        Member guardian = Member.builder().id(memberId).build();
+        Elder elder = Elder.builder()
+                .id(elderId)
+                .guardian(guardian)
+                .status(ElderStatus.ACTIVATED)
+                .build();
+        when(elderRepository.findById(elderId)).thenReturn(Optional.of(elder));
+
+        // when
+        elderService.deleteElder(memberId, elderId);
+
+        // then
+        verify(elderRepository, times(1)).delete(elder);
     }
 } 


### PR DESCRIPTION
### Desc
- Elder Table에 status 컬럼을 추가하는 마이그레이션 생성
- status컬럼은 ACTIVATED, DELETED의 두 가지 상태값을 가진다.
- JPA의 표준 delete가 soft delete를 수행하도록 매핑, 표준 조회는 status가 ACTIVATED인 회원에 대해서만 수행하도록 wrapping
- 어플리케이션 레벨의 cascading은 제거하자
  - 어플리케이션에는 실데이터의 삭제가 일어나지 않음
- https://github.com/Medicare-Call/Medicare-Call-Backend/issues/91