### PR TITLE
feat: 결제 페이지 호스팅 구현

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -46,6 +46,7 @@ jobs:
           script: |
             DOCKER_USERNAME="${{ secrets.DOCKER_USERNAME }}"
             DOCKER_IMAGE="${{ secrets.DOCKER_IMAGE }}"
+            APP_BASE_URL="${{ secrets.APP_BASE_URL }}"
             MYSQL_USER="${{ secrets.MYSQL_USER }}"
             MYSQL_PASSWORD="${{ secrets.MYSQL_PASSWORD }}"
             MYSQL_URL="${{ secrets.MYSQL_URL }}"
@@ -67,6 +68,7 @@ jobs:
             NAVERPAY_CHAIN_ID="${{ secrets.NAVERPAY_CHAIN_ID }}"
             NAVERPAY_PARTNER_ID="${{ secrets.NAVERPAY_PARTNER_ID }}"
             NAVERPAY_API_URL="${{ secrets.NAVERPAY_API_URL }}"
+            NAVERPAY_SDK_MODE="${{ secrets.NAVERPAY_SDK_MODE }}"
 
 
             echo "✋🏻 Stopping existing container"
@@ -84,6 +86,7 @@ jobs:
             echo "🌱 Running new container"
             sudo docker run -d -p 8000:8080 --name medicare-call \
             -e SPRING_PROFILES_ACTIVE=prod \
+            -e APP_BASE_URL="${APP_BASE_URL}" \
             -e MYSQL_USER="${MYSQL_USER}" \
             -e MYSQL_PASSWORD="${MYSQL_PASSWORD}" \
             -e MYSQL_URL="${MYSQL_URL}" \
@@ -105,6 +108,7 @@ jobs:
             -e NAVERPAY_CHAIN_ID="{NAVERPAY_CHAIN_ID}" \
             -e NAVERPAY_PARTNER_ID="{NAVERPAY_PARTNER_ID}" \
             -e NAVERPAY_API_URL="{NAVERPAY_API_URL}" \
+            -e NAVERPAY_SDK_MODE="{NAVERPAY_SDK_MODE}" \
             "${DOCKER_USERNAME}/${DOCKER_IMAGE}"
 
             echo "⏳ Waiting for container to start..."

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 	// Database
 	implementation 'mysql:mysql-connector-java:8.0.33'

--- a/src/main/java/com/example/medicare_call/controller/PaymentPageController.java
+++ b/src/main/java/com/example/medicare_call/controller/PaymentPageController.java
@@ -1,0 +1,58 @@
+package com.example.medicare_call.controller;
+
+import com.example.medicare_call.global.annotation.AuthUser;
+import com.example.medicare_call.service.payment.PaymentPageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+
+@Slf4j
+@Controller
+@RequestMapping("/payments")
+@RequiredArgsConstructor
+@Tag(name = "결제 페이지", description = "결제 페이지 호스팅")
+public class PaymentPageController {
+
+    private final PaymentPageService paymentPageService;
+
+    @GetMapping("/page/{orderCode}")
+    @Operation(
+        summary = "결제 페이지 호출",
+        description = "네이버페이 JavaScript SDK를 사용한 결제 페이지를 반환합니다."
+    )
+    public String paymentPage(
+            @Parameter(hidden = true) @AuthUser Long memberId,
+            @Parameter(description = "주문 코드", required = true)
+            @PathVariable String orderCode,
+            Model model) {
+
+        log.info("결제 페이지 요청 - orderCode: {}, memberId: {}", orderCode, memberId);
+        paymentPageService.preparePaymentPage(memberId, orderCode, model);
+        log.info("결제 페이지 데이터 준비 완료 - orderCode: {}", orderCode);
+        return "payment";
+    }
+
+    @GetMapping("/callback/{orderCode}")
+    @Operation(
+        summary = "결제 완료 콜백",
+        description = "네이버페이 결제 완료 후 호출되는 콜백 페이지입니다."
+    )
+    public String paymentCallback(
+            @PathVariable String orderCode,
+            @RequestParam(required = false) String resultCode,
+            @RequestParam(required = false) String paymentId,
+            @RequestParam(required = false) String resultMessage,
+            Model model) {
+
+        log.info("결제 콜백 수신 - orderCode: {}, resultCode: {}, paymentId: {}",
+            orderCode, resultCode, paymentId);
+        paymentPageService.processPaymentCallback(orderCode, resultCode, paymentId, resultMessage, model);
+        return "payment-result";
+    }
+}

--- a/src/main/java/com/example/medicare_call/service/payment/PaymentPageService.java
+++ b/src/main/java/com/example/medicare_call/service/payment/PaymentPageService.java
@@ -1,0 +1,84 @@
+package com.example.medicare_call.service.payment;
+
+import com.example.medicare_call.domain.Order;
+import com.example.medicare_call.global.exception.CustomException;
+import com.example.medicare_call.global.exception.ErrorCode;
+import com.example.medicare_call.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.ui.Model;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentPageService {
+
+    private final OrderRepository orderRepository;
+    private final NaverPayService naverPayService;
+
+    @Value("${naverpay.client.id}")
+    private String naverPayClientId;
+
+    @Value("${naverpay.chain.id}")
+    private String naverPayChainId;
+
+    @Value("${naverpay.sdk.mode}")
+    private String naverPaySdkMode;
+
+    @Value("${base-url}")
+    private String baseUrl;
+
+    /**
+     * 결제 페이지에 필요한 데이터를 Model에 담아 반환합니다.
+     * @param orderCode 주문 코드
+     * @param model Thymeleaf 모델
+     */
+    public void preparePaymentPage(Long memberId, String orderCode, Model model) {
+        Order order = orderRepository.findByCode(orderCode)
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.getMember().getId().equals(memberId.intValue())) {
+            throw new CustomException(ErrorCode.HANDLE_ACCESS_DENIED);
+        }
+
+        model.addAttribute("orderCode", orderCode);
+        model.addAttribute("productName", order.getProductName());
+        model.addAttribute("totalPayAmount", order.getTotalPayAmount());
+        model.addAttribute("taxScopeAmount", order.getTaxScopeAmount());
+        model.addAttribute("taxExScopeAmount", order.getTaxExScopeAmount());
+        model.addAttribute("naverPayClientId", naverPayClientId);
+        model.addAttribute("naverPayChainId", naverPayChainId);
+        model.addAttribute("naverPaySdkMode", naverPaySdkMode);
+
+        model.addAttribute("returnUrl", baseUrl + "/payments/callback/" + orderCode);
+    }
+
+    /**
+     * 결제 콜백을 처리하고 결과 데이터를 Model에 담아 반환합니다.
+     * @param orderCode 주문 코드
+     * @param resultCode 네이버페이 결과 코드
+     * @param paymentId 네이버페이 결제 ID
+     * @param resultMessage 네이버페이 결과 메시지
+     * @param model Thymeleaf 모델
+     */
+    public void processPaymentCallback(String orderCode, String resultCode, String paymentId, String resultMessage, Model model) {
+        model.addAttribute("orderCode", orderCode);
+        model.addAttribute("resultCode", resultCode);
+        model.addAttribute("paymentId", paymentId);
+        model.addAttribute("resultMessage", resultMessage);
+
+        if ("Success".equals(resultCode) && paymentId != null) {
+            try {
+                naverPayService.approvePayment(paymentId);
+                model.addAttribute("success", true);
+                model.addAttribute("message", "결제가 성공적으로 완료되었습니다.");
+            } catch (Exception e) {
+                model.addAttribute("success", false);
+                model.addAttribute("message", "결제 승인 중 오류가 발생했습니다: " + e.getMessage());
+            }
+        } else {
+            model.addAttribute("success", false);
+            model.addAttribute("message", resultMessage != null ? resultMessage : "결제가 취소되었거나 실패했습니다.");
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,6 +73,10 @@ naverpay:
     id: ${NAVERPAY_PARTNER_ID}
   api:
     url: ${NAVERPAY_API_URL}
+  sdk:
+    mode: ${NAVERPAY_SDK_MODE}
+
+base-url: ${LOCAL_BASE_URL}
 
 ---
 spring:
@@ -139,3 +143,7 @@ naverpay:
     id: ${NAVERPAY_PARTNER_ID}
   api:
     url: ${NAVERPAY_API_URL}
+  sdk:
+    mode: ${NAVERPAY_SDK_MODE:production}
+
+base-url: ${APP_BASE_URL}

--- a/src/main/resources/templates/payment-result.html
+++ b/src/main/resources/templates/payment-result.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>결제 완료</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f8f9fa;
+        }
+        .container {
+            max-width: 400px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 12px;
+            padding: 24px;
+            box-shadow: 0 2px 12px rgba(0,0,0,0.1);
+            text-align: center;
+        }
+        .logo {
+            font-size: 24px;
+            font-weight: 700;
+            color: #1a73e8;
+            margin-bottom: 16px;
+        }
+        .success-icon {
+            font-size: 48px;
+            color: #03c75a;
+            margin-bottom: 16px;
+        }
+        .error-icon {
+            font-size: 48px;
+            color: #ff4444;
+            margin-bottom: 16px;
+        }
+        .title {
+            font-size: 20px;
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+        .message {
+            color: #666;
+            margin-bottom: 24px;
+            line-height: 1.5;
+        }
+        .order-info {
+            background: #f8f9fa;
+            padding: 16px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            text-align: left;
+        }
+        .info-row {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 8px;
+        }
+        .info-row:last-child {
+            margin-bottom: 0;
+        }
+        .label {
+            color: #666;
+            font-size: 14px;
+        }
+        .value {
+            font-weight: 600;
+            font-size: 14px;
+        }
+        .close-button {
+            width: 100%;
+            height: 48px;
+            background: #1a73e8;
+            color: white;
+            border: none;
+            border-radius: 8px;
+            font-size: 16px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background-color 0.2s;
+        }
+        .close-button:hover {
+            background: #1557b0;
+        }
+        .countdown {
+            font-size: 12px;
+            color: #666;
+            margin-top: 8px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="logo">메디케어콜</div>
+        
+        <div th:if="${success}">
+            <div class="success-icon">✓</div>
+            <div class="title">결제 완료</div>
+        </div>
+        
+        <div th:unless="${success}">
+            <div class="error-icon">✕</div>
+            <div class="title">결제 실패</div>
+        </div>
+        
+        <div class="message" th:text="${message}">
+            결제가 완료되었습니다.
+        </div>
+        
+        <div class="order-info">
+            <div class="info-row">
+                <span class="label">주문번호</span>
+                <span class="value" th:text="${orderCode}">ORDER123</span>
+            </div>
+            <div class="info-row" th:if="${paymentId}">
+                <span class="label">결제번호</span>
+                <span class="value" th:text="${paymentId}">PAY123</span>
+            </div>
+            <div class="info-row">
+                <span class="label">결과코드</span>
+                <span class="value" th:text="${resultCode}">Success</span>
+            </div>
+        </div>
+        
+        <button id="closeBtn" class="close-button">
+            앱으로 돌아가기
+        </button>
+        
+        <div class="countdown">
+            <span id="countdown">3</span>초 후 자동으로 돌아갑니다.
+        </div>
+    </div>
+
+    <script th:inline="javascript">
+        // 안드로이드 연동을 위한 인터페이스 정의
+        const AndroidBridge = window.Android;
+
+        // 최종 결제 결과를 담는 객체
+        const paymentResult = {
+            success: /*[[${success}]]*/ true,
+            orderCode: /*[[${orderCode}]]*/ "test_order_code",
+            paymentId: /*[[${paymentId}]]*/ null,
+            resultCode: /*[[${resultCode}]]*/ "Success",
+            message: /*[[${message}]]*/ "결제가 완료되었습니다."
+        };
+
+        // 페이지가 로드되면 즉시 안드로이드에 결과 전송
+        window.onload = function() {
+            if (AndroidBridge && AndroidBridge.onPaymentComplete) {
+                AndroidBridge.onPaymentComplete(JSON.stringify(paymentResult));
+            }
+            
+            // 3초 후 자동으로 페이지 닫기 시도
+            setTimeout(closePage, 3000);
+        };
+
+        // "앱으로 돌아가기" 버튼 이벤트
+        document.getElementById("closeBtn").addEventListener("click", function() {
+            closePage();
+        });
+
+        // 페이지 닫기 함수
+        function closePage() {
+            if (AndroidBridge && AndroidBridge.closePage) {
+                AndroidBridge.closePage();
+            } else {
+                // 안드로이드 인터페이스가 없을 경우를 대비한 대체 동작
+                window.close(); 
+            }
+        }
+
+        // 카운트다운 UI 업데이트
+        let countdown = 3;
+        const countdownElement = document.getElementById("countdown");
+        const timer = setInterval(function() {
+            countdown--;
+            if (countdown > 0) {
+                countdownElement.textContent = countdown;
+            } else {
+                clearInterval(timer);
+                countdownElement.parentElement.textContent = "앱으로 돌아갑니다...";
+            }
+        }, 1000);
+    </script>
+</body>
+</html>

--- a/src/main/resources/templates/payment.html
+++ b/src/main/resources/templates/payment.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>메디케어콜 결제</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f8f9fa;
+        }
+        .container {
+            max-width: 400px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 12px;
+            padding: 24px;
+            box-shadow: 0 2px 12px rgba(0,0,0,0.1);
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 24px;
+        }
+        .logo {
+            font-size: 24px;
+            font-weight: 700;
+            color: #1a73e8;
+            margin-bottom: 8px;
+        }
+        .product-info {
+            background: #f8f9fa;
+            padding: 16px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+        }
+        .product-name {
+            font-size: 18px;
+            font-weight: 600;
+            color: #333;
+            margin-bottom: 8px;
+        }
+        .product-amount {
+            font-size: 24px;
+            font-weight: 700;
+            color: #1a73e8;
+        }
+        .order-info {
+            font-size: 12px;
+            color: #666;
+            margin-bottom: 20px;
+        }
+        .payment-button {
+            width: 100%;
+            height: 52px;
+            background: #03c75a;
+            color: white;
+            border: none;
+            border-radius: 8px;
+            font-size: 16px;
+            font-weight: 600;
+            cursor: pointer;
+            margin-bottom: 16px;
+            transition: background-color 0.2s;
+        }
+        .payment-button:hover {
+            background: #02b351;
+        }
+        .payment-button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+        .loading {
+            display: none;
+            text-align: center;
+            color: #666;
+            margin-top: 16px;
+        }
+        .error {
+            background: #fee;
+            color: #c33;
+            padding: 12px;
+            border-radius: 6px;
+            margin-top: 16px;
+            display: none;
+        }
+        .spinner {
+            display: inline-block;
+            width: 20px;
+            height: 20px;
+            border: 3px solid #f3f3f3;
+            border-top: 3px solid #1a73e8;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <div class="logo">메디케어콜</div>
+            <h2>결제하기</h2>
+        </div>
+        
+        <div class="product-info">
+            <div class="product-name" th:text="${productName}">상품명</div>
+            <div class="product-amount" th:text="${#numbers.formatInteger(totalPayAmount, 0, 'COMMA')} + '원'">금액</div>
+        </div>
+        
+        <div class="order-info">
+            주문번호: <span th:text="${orderCode}">ORDER123</span>
+        </div>
+        
+        <button id="naverPayBtn" class="payment-button">
+            네이버페이로 결제하기
+        </button>
+        
+        <div id="loading" class="loading">
+            <div class="spinner"></div>
+            결제 처리 중입니다...
+        </div>
+        
+        <div id="error" class="error">
+            결제 중 오류가 발생했습니다.
+        </div>
+    </div>
+
+    <!-- 네이버페이 JavaScript SDK -->
+    <script src="https://nsp.pay.naver.com/sdk/js/naverpay.min.js"></script>
+    
+    <script th:inline="javascript">
+        // 안드로이드 연동을 위한 인터페이스 정의
+        const AndroidBridge = window.Android;
+
+        // 네이버페이 SDK 초기화
+        var oPay = Naver.Pay.create({
+            "mode": /*[[${naverPaySdkMode}]]*/ "development",
+            "clientId": /*[[${naverPayClientId}]]*/ "test_client_id",
+            "chainId": /*[[${naverPayChainId}]]*/ "test_chain_id"
+        });
+
+        // 결제 버튼 클릭 이벤트
+        document.getElementById("naverPayBtn").addEventListener("click", function() {
+            const button = this;
+            button.disabled = true;
+            document.getElementById("loading").style.display = "block";
+            document.getElementById("error").style.display = "none";
+
+            // 네이버페이 결제창 호출
+            oPay.open({
+                "merchantUserKey": "user_" + Date.now(),
+                "merchantPayKey": /*[[${orderCode}]]*/ "test_order_code",
+                "productName": /*[[${productName}]]*/ "테스트 상품",
+                "totalPayAmount": /*[[${totalPayAmount}]]*/ 10000,
+                "taxScopeAmount": /*[[${taxScopeAmount}]]*/ 10000,
+                "taxExScopeAmount": /*[[${taxExScopeAmount}]]*/ 0,
+                "returnUrl": /*[[${returnUrl}]]*/ "http://localhost:8080/api/payments/callback/test",
+                "productCount": 1,
+                "productItems": [{
+                    "categoryType": "ETC",
+                    "categoryId": "ETC",
+                    "uid": /*[[${orderCode}]]*/ "test_order_code",
+                    "name": /*[[${productName}]]*/ "테스트 상품",
+                    "count": 1
+                }]
+            });
+        });
+
+        // 페이지 로드 완료 시 안드로이드에 알림
+        window.onload = function() {
+            if (AndroidBridge && AndroidBridge.onPageLoaded) {
+                AndroidBridge.onPageLoaded();
+            }
+        };
+
+        // 전역 에러 핸들러
+        window.onerror = function(msg, url, lineNo, columnNo, error) {
+            console.error('결제 페이지 에러:', msg);
+            document.getElementById("error").innerText = '결제 과정에서 오류가 발생했습니다. 다시 시도해주세요.';
+            document.getElementById("error").style.display = "block";
+            document.getElementById("loading").style.display = "none";
+            document.getElementById("naverPayBtn").disabled = false;
+        };
+    </script>
+</body>
+</html>

--- a/src/test/java/com/example/medicare_call/controller/PaymentPageControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/PaymentPageControllerTest.java
@@ -1,0 +1,92 @@
+package com.example.medicare_call.controller;
+
+import com.example.medicare_call.global.GlobalExceptionHandler;
+import com.example.medicare_call.global.annotation.AuthUser;
+import com.example.medicare_call.service.payment.PaymentPageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentPageControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private PaymentPageService paymentPageService;
+
+    @InjectMocks
+    private PaymentPageController controller;
+
+    @BeforeEach
+    void setup() {
+        HandlerMethodArgumentResolver authUserArgumentResolver = new HandlerMethodArgumentResolver() {
+            @Override
+            public boolean supportsParameter(MethodParameter parameter) {
+                return parameter.hasParameterAnnotation(AuthUser.class) &&
+                        parameter.getParameterType().equals(Long.class);
+            }
+
+            @Override
+            public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+                return 1L; // 테스트용 ID
+            }
+        };
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(authUserArgumentResolver)
+                .build();
+    }
+
+    @Test
+    @DisplayName("결제 페이지 렌더링")
+    void payment_page_success() throws Exception {
+        // given
+        String orderCode = "ORDER-TEST-001";
+        Long memberId = 1L;
+
+        // when & then
+        mockMvc.perform(get("/payments/page/" + orderCode)
+                        .accept(MediaType.TEXT_HTML))
+                .andExpect(status().isOk())
+                .andExpect(view().name("payment"));
+
+        verify(paymentPageService, times(1)).preparePaymentPage(eq(memberId), eq(orderCode), any());
+    }
+
+    @Test
+    @DisplayName("결제 콜백 처리")
+    void payment_callback_success() throws Exception {
+        // given
+        String orderCode = "ORDER-TEST-002";
+        String paymentId = "PAY-12345";
+
+        // when & then
+        mockMvc.perform(get("/payments/callback/" + orderCode)
+                        .param("resultCode", "Success")
+                        .param("paymentId", paymentId)
+                        .accept(MediaType.TEXT_HTML))
+                .andExpect(status().isOk())
+                .andExpect(view().name("payment-result"));
+
+        verify(paymentPageService, times(1)).processPaymentCallback(eq(orderCode), eq("Success"), eq(paymentId), any(), any());
+    }
+}

--- a/src/test/java/com/example/medicare_call/service/payment/PaymentPageServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/payment/PaymentPageServiceTest.java
@@ -1,0 +1,99 @@
+package com.example.medicare_call.service.payment;
+
+import com.example.medicare_call.domain.Member;
+import com.example.medicare_call.domain.Order;
+import com.example.medicare_call.global.exception.CustomException;
+import com.example.medicare_call.global.exception.ErrorCode;
+import com.example.medicare_call.repository.OrderRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ui.Model;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentPageServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private Model model;
+
+    @InjectMocks
+    private PaymentPageService paymentPageService;
+
+    private Member testMember;
+    private Order testOrder;
+
+    @BeforeEach
+    void setUp() {
+        testMember = Member.builder()
+                .id(1)
+                .name("testUser")
+                .build();
+
+        testOrder = Order.builder()
+                .code("ORDER-TEST-001")
+                .productName("Test Product")
+                .totalPayAmount(10000)
+                .member(testMember)
+                .build();
+    }
+
+    @Test
+    @DisplayName("결제 페이지 데이터 준비 성공")
+    void preparePaymentPage_success() {
+        // given
+        when(orderRepository.findByCode("ORDER-TEST-001")).thenReturn(Optional.of(testOrder));
+
+        // when
+        paymentPageService.preparePaymentPage(1L, "ORDER-TEST-001", model);
+
+        // then
+        verify(orderRepository).findByCode("ORDER-TEST-001");
+        verify(model).addAttribute("orderCode", "ORDER-TEST-001");
+        verify(model).addAttribute("productName", "Test Product");
+        verify(model).addAttribute("totalPayAmount", 10000);
+    }
+
+    @Test
+    @DisplayName("결제 페이지 데이터 준비 실패 - 주문자 불일치")
+    void preparePaymentPage_fail_invalid_member() {
+        // given
+        when(orderRepository.findByCode("ORDER-TEST-001")).thenReturn(Optional.of(testOrder));
+        Long wrongMemberId = 2L;
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            paymentPageService.preparePaymentPage(wrongMemberId, "ORDER-TEST-001", model);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.HANDLE_ACCESS_DENIED);
+        verify(orderRepository).findByCode("ORDER-TEST-001");
+        verify(model, never()).addAttribute(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("결제 페이지 데이터 준비 실패 - 주문 없음")
+    void preparePaymentPage_fail_order_not_found() {
+        // given
+        when(orderRepository.findByCode("NON-EXISTENT-ORDER")).thenReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            paymentPageService.preparePaymentPage(1L, "NON-EXISTENT-ORDER", model);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ORDER_NOT_FOUND);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -45,3 +45,7 @@ naverpay:
     id: test-partner-id
   api:
     url: https://example.com
+  sdk:
+    mode: test
+
+base-url: https://example.com


### PR DESCRIPTION
### Desc
- 네이버페이에서는 JavaScript 기반의 결제 연동 SDK를 지원하고 있다.
- 서버 측에서 네이버페이 JavaScript SDK를 이용한 결제 페이지를 호스팅하고, 결제 페이지를 안드로이드에서 WebView로 렌더링하여 JavaScript Interface를 활용하여 결제 처리를 수행하자

### 결제 Flow
1. 클라이언트에서 결제 요청 생성 `POST /payments/reserve`
2. 서버에서는 클라이언트의 결제 요청 파라미터를 기반으로 메디케어 DB에 주문을 생성하고, 생성된 주문의 주문 코드를 반환한다.
```
{
  "code": "Success",
  "message": "주문이 성공적으로 생성되었습니다.",
  "body": {
    "code": "주문코드"
  }
}
```
3. 클라이언트에서는 `https://medicare-call.shop/api/payments/page/{주문코드}` 형식으로, 주문 코드를 이용하여 결제 페이지(payment.html)을 WebView로 띄운다.
  3-1. 이 때, `Authorization`헤더에 `Bearer {AccessTokenValue}` 형식으로 Access Token값을 포함해주어야 결제 페이지에 정상적으로 접근이 가능하다.
4. WebView 페이지에서 사용자가 결제를 마치고 나면, 네이버페이측에서 returnUrl을 통해, 우리의 결제 완료 페이지(payment-result.html)쪽으로 리다이렉션 처리를 해준다.
5. 우리 서버는 결제 완료 페이지에 접근 요청이 들어왔을 경우, 리다이렉션 과정에서 전달된 주문 정보를 바탕으로 네이버페이 서버로 api 요청을 해, 실제로 결제된 금액과 항목을 메디케어 DB의 주문 데이터와 대조하고, 데이터 변조 여부를 검토한다.
  5-1. 데이터 변조가 있어, 우리쪽 DB의 주문 데이터와 네이버페이를 통해 결제된 내용이 상이할 경우, 결제가 실패 처리된다. (`approvePayment`, `validateAndUpdateOrder` 참조)
  5-2. 데이터가 일치할 경우, 결제 성공 처리를 하고 결제 대상인 어르신들의 구독 만료 기간을 1개월 뒤로 설정한다.
6. 위의 검증 결과를 바탕으로, 서버는 결제 완료 페이지를 렌더링하고, 결제 완료 페이지는 결제 성공 여부 등을 하기 구조의 json 객체로 담아 안드로이드 쪽으로 전달한다.
```
{
  "success": true,
  "orderCode": "실제-주문-코드",
  "paymentId": "네이버페이-결제-ID",
  "resultCode": "Success",
  "message": "결제가 성공적으로 완료되었습니다."
}
```
payment-result.html의 하기 스크립트에 의해, 안드로이드 앱으로 데이터를 전달합니다.
```
window.onload = function() {
    if (AndroidBridge && AndroidBridge.onPaymentComplete) {
        AndroidBridge.onPaymentComplete(JSON.stringify(paymentResult));
    }

    // 3초 후 자동으로 페이지 닫기 시도
    setTimeout(closePage, 3000);
};
```