### PR TITLE
fix: 주문에서 상품명을 파싱하지 못하는 문제

### DIFF
--- a/src/main/java/com/example/medicare_call/dto/SubscriptionResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/SubscriptionResponse.java
@@ -41,7 +41,7 @@ public class SubscriptionResponse {
         return SubscriptionResponse.builder()
                 .elderId(subscription.getElder().getId())
                 .name(subscription.getElder().getName())
-                .plan(subscription.getPlan().getPlanName())
+                .plan(subscription.getPlan().getProductName())
                 .price(subscription.getPrice())
                 .nextBillingDate(subscription.getNextBillingDate())
                 .startDate(subscription.getStartDate())

--- a/src/main/java/com/example/medicare_call/global/enums/SubscriptionPlan.java
+++ b/src/main/java/com/example/medicare_call/global/enums/SubscriptionPlan.java
@@ -7,9 +7,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SubscriptionPlan {
 
-    STANDARD("standard", 19000),
-    PREMIUM("premium", 29000);
+    STANDARD("메디케어콜 스탠다드 플랜", 19000),
+    PREMIUM("메디케어콜 프리미엄 플랜", 29000);
 
-    private final String planName;
+    private final String productName;
     private final int price;
+
+    public static SubscriptionPlan findByProductName(String productName) {
+        for (SubscriptionPlan plan : values()) {
+            if (plan.getProductName().equals(productName)) {
+                return plan;
+            }
+        }
+        throw new IllegalArgumentException("Unknown product name: " + productName);
+    }
 }

--- a/src/main/java/com/example/medicare_call/service/payment/NaverPayService.java
+++ b/src/main/java/com/example/medicare_call/service/payment/NaverPayService.java
@@ -225,6 +225,8 @@ public class NaverPayService {
                 throw new CustomException(ErrorCode.NAVER_PAY_API_ERROR, "네이버페이 결제 승인이 실패했습니다. 고객센터로 문의해 주세요.");
             }
 
+        } catch (CustomException e) {
+            throw e; // CustomException은 그대로 다시 던짐
         } catch (RestClientException e) {
             log.error("네이버페이 API 호출 실패 - paymentId: {}, error: {}", paymentId, e.getMessage(), e);
             throw new CustomException(ErrorCode.NAVER_PAY_API_ERROR, "네이버페이 API 연동 중 오류가 발생했습니다.");
@@ -313,10 +315,10 @@ public class NaverPayService {
             List<Long> elderIds = objectMapper.readValue(order.getElderIds(), new TypeReference<List<Long>>() {});
             Member member = order.getMember();
             SubscriptionPlan plan;
-            if ("프리미엄".equals(order.getProductName())) {
-                plan = SubscriptionPlan.PREMIUM;
-            } else {
-                plan = SubscriptionPlan.STANDARD;
+            try {
+                plan = SubscriptionPlan.findByProductName(order.getProductName());
+            } catch (IllegalArgumentException e) {
+                throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "알 수 없는 상품명입니다: " + order.getProductName());
             }
 
             for (Long elderId : elderIds) {

--- a/src/test/java/com/example/medicare_call/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/SubscriptionServiceTest.java
@@ -68,7 +68,7 @@ public class SubscriptionServiceTest {
         assertThat(responses).hasSize(1);
         assertThat(responses.get(0).getElderId()).isEqualTo(elder.getId());
         assertThat(responses.get(0).getName()).isEqualTo(elder.getName());
-        assertThat(responses.get(0).getPlan()).isEqualTo(subscription.getPlan().getPlanName());
+        assertThat(responses.get(0).getPlan()).isEqualTo(subscription.getPlan().getProductName());
     }
 
     @Test


### PR DESCRIPTION
### Desc
- 현재 주문 생성시 입력으로 받은 상품명이 정확하게 일치해야 플랜 가격이 매칭되도록 처리되어 있다.
- 주문 생성시 받기로 정한 입력값과, 서버에서 확인하는 문자열 입력값이 달라, 가격이 다르게 매칭되는 문제가 발생하고 있다.
- 상품명이 일치하지 않으면, 엉뚱한 상품에 매칭되도록 처리되는 분기를 제거하고, 에러를 밖으로 던지도록 처리하자.
- Enum으로 가격과 상품명을 묶어 관리하고, 상품명 매칭에 사용하자.

### Todo
- 현재는 MVP 단계이므로 이렇게 구현하지만,  추후에 다양한 플랜, 상품을 출시하게되는 시점에는 지금처럼 상품을 enum으로 관리하지 말고, Product Table을 추가하여 관리하자.