### PR TITLE
Feat/get memberinfo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	testImplementation 'org.springframework.security:spring-security-test'
+
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,8 +63,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	testImplementation 'org.springframework.security:spring-security-test'
-
 }
 
 

--- a/src/main/java/com/example/medicare_call/controller/MemberController.java
+++ b/src/main/java/com/example/medicare_call/controller/MemberController.java
@@ -1,31 +1,40 @@
 package com.example.medicare_call.controller;
 
+import com.example.medicare_call.dto.MemberInfoResponse;
 import com.example.medicare_call.dto.auth.MemberRegisterRequest;
 import com.example.medicare_call.dto.auth.TokenResponse;
 import com.example.medicare_call.global.annotation.AuthPhone;
+import com.example.medicare_call.global.annotation.AuthUser;
+import com.example.medicare_call.service.MemberService;
 import com.example.medicare_call.service.auth.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Member Auth", description = "회원가입/회원등록/로그인 API")
+@Tag(name = "Member", description = "회원가입/로그인/회원정보 API")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/members")
 public class MemberController {
 
     private final AuthService authService;
+    private final MemberService memberService;
 
-    @PostMapping("")
+    @PostMapping("/members")
+    @Operation(summary = "회원가입", description = "새로운 회원을 등록합니다")
     public ResponseEntity<TokenResponse> register(@Parameter(hidden = true) @AuthPhone String phone,
                                            @Valid @RequestBody MemberRegisterRequest signUpDto) {
         TokenResponse tokenResponse = authService.register(phone,signUpDto);
         return ResponseEntity.ok(tokenResponse);
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다")
+    public ResponseEntity<MemberInfoResponse> getMemberInfo(@Parameter(hidden = true) @AuthUser Long memberId){
+        MemberInfoResponse memberInfoResponse = memberService.getMemberInfo(memberId.intValue());
+        return ResponseEntity.ok(memberInfoResponse);
     }
 }

--- a/src/main/java/com/example/medicare_call/controller/MemberController.java
+++ b/src/main/java/com/example/medicare_call/controller/MemberController.java
@@ -31,7 +31,7 @@ public class MemberController {
         return ResponseEntity.ok(tokenResponse);
     }
 
-    @GetMapping("/me")
+    @GetMapping("/member")
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다")
     public ResponseEntity<MemberInfoResponse> getMemberInfo(@Parameter(hidden = true) @AuthUser Long memberId){
         MemberInfoResponse memberInfoResponse = memberService.getMemberInfo(memberId.intValue());

--- a/src/main/java/com/example/medicare_call/domain/Member.java
+++ b/src/main/java/com/example/medicare_call/domain/Member.java
@@ -1,5 +1,7 @@
 package com.example.medicare_call.domain;
 
+import com.example.medicare_call.global.enums.Gender;
+import com.example.medicare_call.global.enums.NotificationStatus;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -39,8 +41,28 @@ public class Member {
     @Column(name = "plan") //처음 회원가입 시 plan이 없으므로  nullable=false 조건 삭제
     private Byte plan;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "push_all", nullable = false)
+    private NotificationStatus pushAll = NotificationStatus.ON;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "push_carecall_completed", nullable = false)
+    private NotificationStatus pushCarecallCompleted = NotificationStatus.ON;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "push_health_alert", nullable = false)
+    private NotificationStatus pushHealthAlert = NotificationStatus.ON;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "push_carecall_missed", nullable = false)
+    private NotificationStatus pushCarecallMissed = NotificationStatus.ON;
+
     @OneToMany(mappedBy = "guardian", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Elder> elders = new ArrayList<>();
+
+    public Gender getGenderEnum() {
+        return Gender.fromCode(gender); // byte값 → Enum 변환
+    }
 
     @Builder
     public Member(Integer id, String name, String phone, LocalDate birthDate, Byte gender, LocalDateTime termsAgreedAt, Byte plan) {

--- a/src/main/java/com/example/medicare_call/dto/MemberInfoResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/MemberInfoResponse.java
@@ -1,0 +1,55 @@
+package com.example.medicare_call.dto;
+
+import com.example.medicare_call.domain.Member;
+import com.example.medicare_call.global.enums.Gender;
+import com.example.medicare_call.global.enums.NotificationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public record MemberInfoResponse(
+        @Schema(description = "보호자 이름", example = "김미연")
+        String name,
+
+        @Schema(description = "생년월일", example = "2000-01-01")
+        LocalDate birthDate,
+
+        @Schema(description = "성별", example = "FEMALE")
+        Gender gender,
+
+        @Schema(description = "휴대폰 번호", example = "01012345678")
+        String phone,
+
+        @Schema(description = "푸시 알림 설정 객체")
+        PushNotificationResponse pushNotification
+) {
+    public record PushNotificationResponse(
+            @Schema(description = "전체 푸시 알림 설정", example = "ON", allowableValues = {"ON", "OFF"})
+            NotificationStatus all,
+
+            @Schema(description = "케어콜 완료 시 알림 설정", example = "OFF", allowableValues = {"ON", "OFF"})
+            NotificationStatus carecallCompleted,
+
+            @Schema(description = "건강 이상 징후 알림 설정", example = "OFF", allowableValues = {"ON", "OFF"})
+            NotificationStatus healthAlert,
+
+            @Schema(description = "케어콜 부재중 알림 설정", example = "ON", allowableValues = {"ON", "OFF"})
+            NotificationStatus carecallMissed
+    ) {
+    }
+
+    public static MemberInfoResponse from(Member member) {
+        return new MemberInfoResponse(
+                member.getName(),
+                member.getBirthDate(),
+                member.getGenderEnum(),
+                member.getPhone(),
+                new PushNotificationResponse(
+                        member.getPushAll(),
+                        member.getPushCarecallCompleted(),
+                        member.getPushHealthAlert(),
+                        member.getPushCarecallMissed()
+                )
+        );
+    }
+}

--- a/src/main/java/com/example/medicare_call/dto/MemberInfoResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/MemberInfoResponse.java
@@ -1,26 +1,36 @@
 package com.example.medicare_call.dto;
 
 import com.example.medicare_call.domain.Member;
+import com.example.medicare_call.global.annotation.ValidBirthDate;
+import com.example.medicare_call.global.annotation.ValidPhoneNumber;
 import com.example.medicare_call.global.enums.Gender;
 import com.example.medicare_call.global.enums.NotificationStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 
 import java.time.LocalDate;
 
 public record MemberInfoResponse(
         @Schema(description = "보호자 이름", example = "김미연")
+        @NotBlank(message = "이름은 필수입니다")
         String name,
 
         @Schema(description = "생년월일", example = "2000-01-01")
+        @NotBlank(message = "생년월일은 필수입니다")
+        @ValidBirthDate
         LocalDate birthDate,
 
         @Schema(description = "성별", example = "FEMALE")
+        @NotBlank(message = "성별은 필수입니다")
         Gender gender,
 
         @Schema(description = "휴대폰 번호", example = "01012345678")
+        @ValidPhoneNumber
+        @NotBlank(message = "휴대폰 번호는 필수입니다")
         String phone,
 
         @Schema(description = "푸시 알림 설정 객체")
+        @NotBlank(message = "푸시알림 정보는 필수입니다")
         PushNotificationResponse pushNotification
 ) {
     public record PushNotificationResponse(

--- a/src/main/java/com/example/medicare_call/global/enums/NotificationStatus.java
+++ b/src/main/java/com/example/medicare_call/global/enums/NotificationStatus.java
@@ -1,0 +1,5 @@
+package com.example.medicare_call.global.enums;
+
+public enum NotificationStatus {
+    ON, OFF
+}

--- a/src/main/java/com/example/medicare_call/service/MemberService.java
+++ b/src/main/java/com/example/medicare_call/service/MemberService.java
@@ -1,4 +1,23 @@
 package com.example.medicare_call.service;
 
+import com.example.medicare_call.domain.Member;
+import com.example.medicare_call.dto.MemberInfoResponse;
+import com.example.medicare_call.global.exception.CustomException;
+import com.example.medicare_call.global.exception.ErrorCode;
+import com.example.medicare_call.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
 public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public MemberInfoResponse getMemberInfo(Integer memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        return MemberInfoResponse.from(member);
+    }
 }

--- a/src/main/resources/db/migration/V17__add_push_notification_columns_to_member.sql
+++ b/src/main/resources/db/migration/V17__add_push_notification_columns_to_member.sql
@@ -1,0 +1,11 @@
+-- 푸시 알림 설정 컬럼 추가
+ALTER TABLE Member
+    -- 전체 푸시 알림 설정
+    ADD COLUMN push_all ENUM('ON','OFF') NOT NULL DEFAULT 'ON',
+    -- 케어콜 완료 시 알림 설정
+    ADD COLUMN push_carecall_completed ENUM('ON','OFF') NOT NULL DEFAULT 'ON',
+    -- 건강 이상 징후 알림 설정
+    ADD COLUMN push_health_alert ENUM('ON','OFF') NOT NULL DEFAULT 'ON',
+    -- 케어콜 부재중 알림 설정
+    ADD COLUMN push_carecall_missed ENUM('ON','OFF') NOT NULL DEFAULT 'ON';
+

--- a/src/test/java/com/example/medicare_call/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/MemberControllerTest.java
@@ -1,0 +1,111 @@
+package com.example.medicare_call.controller;
+
+import com.example.medicare_call.dto.MemberInfoResponse;
+import com.example.medicare_call.global.annotation.AuthUser;
+import com.example.medicare_call.global.enums.Gender;
+import com.example.medicare_call.global.enums.NotificationStatus;
+import com.example.medicare_call.global.jwt.JwtProvider;
+import com.example.medicare_call.service.MemberService;
+import com.example.medicare_call.service.auth.AuthService;
+import com.example.medicare_call.global.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+@AutoConfigureMockMvc(addFilters = false) // security필터 비활성화
+@ActiveProfiles("test")
+class MemberControllerTest {
+
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    private static class TestAuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+        @Override
+        public boolean supportsParameter(MethodParameter parameter) {
+            return parameter.hasParameterAnnotation(AuthUser.class);
+        }
+
+        @Override
+        public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                      NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+            return 1L; // 테스트용 고정 memberId
+        }
+    }
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new MemberController(authService, memberService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new TestAuthUserArgumentResolver())
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .alwaysDo(print())
+                .build();
+    }
+
+    @Test
+    @DisplayName("내 정보 조회 성공")
+    void getMemberInfo_Success() throws Exception {
+        // given
+        MemberInfoResponse.PushNotificationResponse pushNotificationResponse =
+                new MemberInfoResponse.PushNotificationResponse(
+                        NotificationStatus.ON, NotificationStatus.OFF,
+                        NotificationStatus.ON, NotificationStatus.OFF
+                );
+
+        MemberInfoResponse expectedResponse = new MemberInfoResponse(
+                "테스트유저", java.time.LocalDate.of(1995, 5, 10),
+                Gender.FEMALE, "010-1234-5678", pushNotificationResponse
+        );
+
+        when(memberService.getMemberInfo(anyInt())).thenReturn(expectedResponse);
+
+        // when
+        ResultActions actions = mockMvc.perform(get("/me")
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("테스트유저"))
+                .andExpect(jsonPath("$.birthDate").value(hasItems(1995, 5, 10)))
+                .andExpect(jsonPath("$.gender").value("FEMALE"))
+                .andExpect(jsonPath("$.phone").value("010-1234-5678"))
+                .andExpect(jsonPath("$.pushNotification.all").value("ON"))
+                .andExpect(jsonPath("$.pushNotification.carecallCompleted").value("OFF"));
+    }
+
+}

--- a/src/test/java/com/example/medicare_call/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/MemberControllerTest.java
@@ -93,7 +93,7 @@ class MemberControllerTest {
         when(memberService.getMemberInfo(anyInt())).thenReturn(expectedResponse);
 
         // when
-        ResultActions actions = mockMvc.perform(get("/me")
+        ResultActions actions = mockMvc.perform(get("/member")
                 .contentType(MediaType.APPLICATION_JSON)
         );
 


### PR DESCRIPTION
## Desc
- 회원 정보를 가져오는 API 개발 
- Member 테이블에 푸쉬 알림 관련 컬럼 추가 
   - `push_all`, `push_carecall_completed`, `push_health_alert`, `push_carecall_missed`
   - 기본 값 ON
 
## API Spec
`GET /me`
response 예시
```json
{
  "name": "김미연",
  "birthDate": "2000-01-01",
  "gender": "FEMALE",
  "phone": "01012345678",
  "pushNotification": {
    "all": "ON",
    "carecallCompleted": "OFF",
    "healthAlert": "OFF",
    "carecallMissed": "ON"
  }
}
```