### PR TITLE
fix: 복약 여부 미응답시 서버에서 데이터 파싱에 실패하는 문제

### DIFF
--- a/src/main/java/com/example/medicare_call/service/data_processor/MedicationService.java
+++ b/src/main/java/com/example/medicare_call/service/data_processor/MedicationService.java
@@ -32,6 +32,11 @@ public class MedicationService {
 
     @Transactional
     public void saveMedicationTakenRecord(CareCallRecord callRecord, HealthDataExtractionResponse.MedicationData medicationData) {
+        if (medicationData.getMedicationType() == null || medicationData.getMedicationType().trim().isEmpty()) {
+            log.warn("약 이름이 누락되어 복약 데이터를 저장하지 않습니다. medicationData={}", medicationData);
+            return;
+        }
+
         // 약 이름으로 Medication 찾기
         Medication medication = medicationRepository.findByName(medicationData.getMedicationType())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEDICATION_NOT_FOUND, "약을 찾을 수 없습니다: " + medicationData.getMedicationType()));

--- a/src/test/java/com/example/medicare_call/service/data_processor/MedicationServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/data_processor/MedicationServiceTest.java
@@ -153,6 +153,42 @@ public class MedicationServiceTest {
     }
 
     @Test
+    @DisplayName("복약 데이터 저장 건너뛰기 - 약 이름이 null일 경우")
+    void saveMedicationTakenRecord_skip_whenMedicationTypeIsNull() {
+        // given
+        HealthDataExtractionResponse.MedicationData medicationData = HealthDataExtractionResponse.MedicationData.builder()
+                .medicationType(null)
+                .taken("복용함")
+                .takenTime("아침")
+                .build();
+
+        // when
+        medicationService.saveMedicationTakenRecord(callRecord, medicationData);
+
+        // then
+        verify(medicationRepository, never()).findByName(any());
+        verify(medicationTakenRecordRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("복약 데이터 저장 건너뛰기 - 약 이름이 비어있을 경우")
+    void saveMedicationTakenRecord_skip_whenMedicationTypeIsEmpty() {
+        // given
+        HealthDataExtractionResponse.MedicationData medicationData = HealthDataExtractionResponse.MedicationData.builder()
+                .medicationType("  ") // 공백 문자열
+                .taken("복용함")
+                .takenTime("아침")
+                .build();
+
+        // when
+        medicationService.saveMedicationTakenRecord(callRecord, medicationData);
+
+        // then
+        verify(medicationRepository, never()).findByName(any());
+        verify(medicationTakenRecordRepository, never()).save(any());
+    }
+
+    @Test
     @DisplayName("복약 데이터 저장 실패 - 약을 찾을 수 없음")
     void saveMedicationTakenRecord_fail_medicationNotFound() {
         // given


### PR DESCRIPTION
### Desc
- 어르신이 복약 여부를 모호하게 응답하는 경우, 복약 여부에 대한 데이터가 하기와 같이 추출된다.
```
  "medicationData": {
    "medicationType": null,
    "taken": "복용하지 않음",
    "takenTime": null
  }
```
- 이 경우, medicationData객체 자체는 null이 아니지만, medicationType의 값이 없어 에러를 던진다.
- 에러를 던지던 것의 의도는 복약 예정인 약이 아니고, 그와 별개의 약을 먹었다고 응답하는 케이스에 대한 처리였음
- medicationType의 값이 비어있으면 에러를 던지지 말고, 복약 기록에 저장하지 않는 형태로 처리하자

### Todo
- 복약 데이터를 복수로 처리할 수 있도록 DTO, Parser 개선
  - 현재는 하나만을 처리해주고 있다