### PR TITLE
fix: Soft Deleted된 컬럼을 join 시도하는 문제

### DIFF
--- a/src/main/java/com/example/medicare_call/repository/CareCallRecordRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/CareCallRecordRepository.java
@@ -13,49 +13,63 @@ import org.springframework.stereotype.Repository;
 public interface CareCallRecordRepository extends JpaRepository<CareCallRecord, Integer> {
     
                 @Query("SELECT ccr FROM CareCallRecord ccr " +
+                        "JOIN ccr.elder e " +
                    "WHERE ccr.elder.id = :elderId " +
+                   "AND e.status = 'ACTIVATED' " +
                    "AND DATE(ccr.startTime) = :date " +
                    "AND ccr.sleepStart IS NOT NULL " +
                    "ORDER BY ccr.startTime")
             List<CareCallRecord> findByElderIdAndDateWithSleepData(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
 
             @Query("SELECT ccr FROM CareCallRecord ccr " +
+                    "JOIN ccr.elder e " +
                    "WHERE ccr.elder.id = :elderId " +
+                    "AND e.status = 'ACTIVATED' " +
                    "AND DATE(ccr.startTime) = :date " +
                    "AND ccr.psychologicalDetails IS NOT NULL " +
                    "ORDER BY ccr.startTime")
             List<CareCallRecord> findByElderIdAndDateWithPsychologicalData(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
 
             @Query("SELECT ccr FROM CareCallRecord ccr " +
+                    "JOIN ccr.elder e " +
                    "WHERE ccr.elder.id = :elderId " +
+                    "AND e.status = 'ACTIVATED' " +
                    "AND DATE(ccr.startTime) = :date " +
                    "AND ccr.healthDetails IS NOT NULL " +
                    "ORDER BY ccr.startTime")
             List<CareCallRecord> findByElderIdAndDateWithHealthData(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
 
     @Query("SELECT ccr FROM CareCallRecord ccr " +
+            "JOIN ccr.elder e " +
            "WHERE ccr.elder.id = :elderId " +
+            "AND e.status = 'ACTIVATED' " +
            "AND DATE(ccr.startTime) BETWEEN :startDate AND :endDate " +
            "AND ccr.sleepStart IS NOT NULL " +
            "ORDER BY ccr.startTime")
     List<CareCallRecord> findByElderIdAndDateBetweenWithSleepData(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 
     @Query("SELECT ccr FROM CareCallRecord ccr " +
+            "JOIN ccr.elder e " +
            "WHERE ccr.elder.id = :elderId " +
+            "AND e.status = 'ACTIVATED' " +
            "AND DATE(ccr.startTime) BETWEEN :startDate AND :endDate " +
            "AND ccr.psychologicalDetails IS NOT NULL " +
            "ORDER BY ccr.startTime")
     List<CareCallRecord> findByElderIdAndDateBetweenWithPsychologicalData(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 
     @Query("SELECT ccr FROM CareCallRecord ccr " +
+            "JOIN ccr.elder e " +
            "WHERE ccr.elder.id = :elderId " +
+            "AND e.status = 'ACTIVATED' " +
            "AND DATE(ccr.startTime) BETWEEN :startDate AND :endDate " +
            "AND ccr.healthDetails IS NOT NULL " +
            "ORDER BY ccr.startTime")
     List<CareCallRecord> findByElderIdAndDateBetweenWithHealthData(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 
     @Query("SELECT ccr FROM CareCallRecord ccr " +
+            "JOIN ccr.elder e " +
            "WHERE ccr.elder.id = :elderId " +
+            "AND e.status = 'ACTIVATED' " +
            "AND DATE(ccr.startTime) BETWEEN :startDate AND :endDate " +
            "ORDER BY ccr.startTime")
     List<CareCallRecord> findByElderIdAndDateBetween(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);

--- a/src/main/java/com/example/medicare_call/repository/CareCallSettingRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/CareCallSettingRepository.java
@@ -12,9 +12,11 @@ import java.util.Optional;
 
 public interface CareCallSettingRepository extends JpaRepository<CareCallSetting, Integer> {
 
-    List<CareCallSetting> findByFirstCallTime(LocalTime now);
+    @Query("SELECT c FROM CareCallSetting c JOIN c.elder e WHERE c.firstCallTime = :now AND e.status = 'ACTIVATED'")
+    List<CareCallSetting> findByFirstCallTime(@Param("now") LocalTime now);
 
-    List<CareCallSetting> findBySecondCallTime(LocalTime now);
+    @Query("SELECT c FROM CareCallSetting c JOIN c.elder e WHERE c.secondCallTime = :now AND e.status = 'ACTIVATED'")
+    List<CareCallSetting> findBySecondCallTime(@Param("now") LocalTime now);
 
     Optional<CareCallSetting> findByElder(Elder elder);
 }

--- a/src/main/java/com/example/medicare_call/repository/ElderHealthInfoRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/ElderHealthInfoRepository.java
@@ -3,11 +3,14 @@ package com.example.medicare_call.repository;
 import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.domain.ElderHealthInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ElderHealthInfoRepository extends JpaRepository<ElderHealthInfo, Integer> {
-    ElderHealthInfo findByElderId(Integer elderId);
+    @Query("SELECT ehi FROM ElderHealthInfo ehi JOIN ehi.elder e WHERE e.id = :elderId AND e.status = 'ACTIVATED'")
+    ElderHealthInfo findByElderId(@Param("elderId") Integer elderId);
     void deleteAllByElder(Elder elder);
     Optional<ElderHealthInfo> findByElder(Elder elder);
 } 

--- a/src/main/java/com/example/medicare_call/repository/MedicationScheduleRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/MedicationScheduleRepository.java
@@ -9,7 +9,8 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface MedicationScheduleRepository extends JpaRepository<MedicationSchedule, Integer> {
-    List<MedicationSchedule> findByElderId(Integer elderId);
+    @Query("SELECT ms FROM MedicationSchedule ms JOIN ms.elder e WHERE e.id = :elderId AND e.status = 'ACTIVATED'")
+    List<MedicationSchedule> findByElderId(@Param("elderId") Integer elderId);
     List<MedicationSchedule> findByElder(Elder elder);
     void deleteAllByElder(Elder elder);
     

--- a/src/main/java/com/example/medicare_call/repository/SubscriptionRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/SubscriptionRepository.java
@@ -2,11 +2,14 @@ package com.example.medicare_call.repository;
 
 import com.example.medicare_call.domain.Subscription;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
-    List<Subscription> findByMemberId(Integer memberId);
+    @Query("SELECT s FROM Subscription s JOIN s.elder e WHERE s.member.id = :memberId AND e.status = 'ACTIVATED'")
+    List<Subscription> findByMemberId(@Param("memberId") Integer memberId);
     Optional<Subscription> findByElderId(Integer elderId);
 }


### PR DESCRIPTION
### Desc
- 현재 엔티티들 중에서는 Elder 테이블에만 Soft Delete가 적용되어 있다.
- Soft Delete를 적용함에 따라, Elder 테이블을 참조하는 엔티티들의 Cascading이 제거되어 있는 상태이다.
- 이 경우, elder_id가 외래키인 데이터를 조회하여, 이를 기반으로 Elder 테이블과 테이블 Join을 시도할 경우, Soft Delete 된 Elder을 찾지 못하는 문제가 발생한다.
- JPQL을 통해, 잠재적으로 문제가 발생할 수 있는 부분들에 명시적으로 삭제되지 않은 컬럼만을 조회할 수 있도록 변경하자
- https://github.com/Medicare-Call/Medicare-Call-Backend/issues/113 에 대한 임시처리