### PR TITLE
fix: 양방향 순환 참조 문제

### DIFF
--- a/src/main/java/com/example/medicare_call/domain/Elder.java
+++ b/src/main/java/com/example/medicare_call/domain/Elder.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ public class Elder {
     @OneToOne(mappedBy = "elder")
     private Subscription subscription;
 
+    @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "guardian_id", nullable = false)
     private Member guardian;

--- a/src/main/java/com/example/medicare_call/domain/Member.java
+++ b/src/main/java/com/example/medicare_call/domain/Member.java
@@ -2,6 +2,7 @@ package com.example.medicare_call.domain;
 
 import com.example.medicare_call.global.enums.Gender;
 import com.example.medicare_call.global.enums.NotificationStatus;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -20,6 +21,7 @@ public class Member {
     @Column(name = "id")
     private Integer id;
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Subscription> subscriptions = new ArrayList<>();
 
@@ -57,6 +59,7 @@ public class Member {
     @Column(name = "push_carecall_missed", nullable = false)
     private NotificationStatus pushCarecallMissed = NotificationStatus.ON;
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "guardian", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Elder> elders = new ArrayList<>();
 

--- a/src/main/java/com/example/medicare_call/domain/Subscription.java
+++ b/src/main/java/com/example/medicare_call/domain/Subscription.java
@@ -2,6 +2,7 @@ package com.example.medicare_call.domain;
 
 import com.example.medicare_call.global.enums.SubscriptionPlan;
 import com.example.medicare_call.global.enums.SubscriptionStatus;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -23,6 +24,7 @@ public class Subscription {
     @Column(name = "id")
     private Long id;
 
+    @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;


### PR DESCRIPTION
### Desc
- 테스트용 API 엔드포인트는 응답 DTO를 만들어두지 않고, 테스트 API호출로 인해 저장된 레코드를 그대로 응답으로 반환 처리하고 있다.
  - e.g. `return ResponseEntity.ok(savedCallRecord);`
- 이 경우에 Jackson에서는 레코드 객체를 JSON형태로 직렬화를 수행하게 된다.
- 이 때, Member, Subscription, Elder 엔티티 간 양방향 연관관계로 인해 JSON 직렬화 과정에서 무한 순환 참조가 발생하여 StackOverflowError가 발생한다.
- `@JsonManagedReference` / `@JsonBackReference` 를 추가하여 직렬화 방향을 지정하자
- `Member`
  - subscriptions, elders 필드에 `@JsonManagedReference` 추가
- `Subscription`
  - member 필드에 `@JsonBackReference` 추가
- `Elder`
  - guardian 필드에 `@JsonBackReference` 추가