### PR TITLE
fix: 양방향 순환 참조 문제

### DIFF
--- a/src/main/java/com/example/medicare_call/domain/CareCallRecord.java
+++ b/src/main/java/com/example/medicare_call/domain/CareCallRecord.java
@@ -1,6 +1,8 @@
 package com.example.medicare_call.domain;
 
 import com.example.medicare_call.dto.data_processor.CareCallDataProcessRequest;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Data;
@@ -21,10 +23,12 @@ public class CareCallRecord {
     @Column(name = "id")
     private Integer id;
 
+    @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "elder_id", nullable = false)
     private Elder elder;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "setting_id", nullable = false)
     private CareCallSetting setting;

--- a/src/main/java/com/example/medicare_call/domain/CareCallSetting.java
+++ b/src/main/java/com/example/medicare_call/domain/CareCallSetting.java
@@ -1,5 +1,6 @@
 package com.example.medicare_call.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
@@ -17,6 +18,7 @@ public class CareCallSetting {
     @Column(name = "id")
     private Integer id;
 
+    @JsonBackReference
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "elder_id", nullable = false, unique = true)
     private Elder elder;

--- a/src/main/java/com/example/medicare_call/domain/Elder.java
+++ b/src/main/java/com/example/medicare_call/domain/Elder.java
@@ -1,5 +1,6 @@
 package com.example.medicare_call.domain;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
@@ -29,6 +30,7 @@ public class Elder {
     @Column(name = "id")
     private Integer id;
 
+    @JsonManagedReference
     @OneToOne(mappedBy = "elder")
     private Subscription subscription;
 
@@ -61,18 +63,23 @@ public class Elder {
     @Column(name = "status", nullable = false, length = 20)
     private ElderStatus status;
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "elder")
     private final List<CareCallRecord> careCallRecords = new ArrayList<>();
 
+    @JsonManagedReference
     @OneToOne(mappedBy = "elder", fetch = FetchType.LAZY)
     private CareCallSetting careCallSetting;
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "elder")
     private final List<MedicationSchedule> medicationSchedules = new ArrayList<>();
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "elder")
     private final List<ElderDisease> elderDiseases = new ArrayList<>();
 
+    @JsonManagedReference
     @OneToOne(mappedBy = "elder", fetch = FetchType.LAZY)
     private ElderHealthInfo elderHealthInfo;
 

--- a/src/main/java/com/example/medicare_call/domain/ElderDisease.java
+++ b/src/main/java/com/example/medicare_call/domain/ElderDisease.java
@@ -1,5 +1,6 @@
 package com.example.medicare_call.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
@@ -12,6 +13,7 @@ import jakarta.persistence.*;
 @NoArgsConstructor
 public class ElderDisease {
     @Id
+    @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "elder_id", nullable = false)
     private Elder elder;

--- a/src/main/java/com/example/medicare_call/domain/ElderHealthInfo.java
+++ b/src/main/java/com/example/medicare_call/domain/ElderHealthInfo.java
@@ -1,5 +1,6 @@
 package com.example.medicare_call.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
@@ -17,6 +18,7 @@ public class ElderHealthInfo {
     @Column(name = "id")
     private Integer id;
 
+    @JsonBackReference
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "elder_id", nullable = false, unique = true)
     private Elder elder;

--- a/src/main/java/com/example/medicare_call/domain/MedicationSchedule.java
+++ b/src/main/java/com/example/medicare_call/domain/MedicationSchedule.java
@@ -1,5 +1,6 @@
 package com.example.medicare_call.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
@@ -16,6 +17,7 @@ public class MedicationSchedule {
     @Column(name = "id")
     private Integer id;
 
+    @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "elder_id", nullable = false)
     private Elder elder;

--- a/src/main/java/com/example/medicare_call/domain/Subscription.java
+++ b/src/main/java/com/example/medicare_call/domain/Subscription.java
@@ -29,6 +29,7 @@ public class Subscription {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @JsonBackReference
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "elder_id", nullable = false, unique = true)
     private Elder elder;


### PR DESCRIPTION
### Desc
- 테스트용 API 엔드포인트는 응답 DTO를 만들어두지 않고, 테스트 API호출로 인해 저장된 레코드를 그대로 응답으로 반환 처리하고 있다.
  - e.g. `return ResponseEntity.ok(savedCallRecord);`
- 이 경우에 Jackson에서는 레코드 객체를 JSON형태로 직렬화를 수행하게 된다.
- 이 때, Member, Subscription, Elder 엔티티 간 양방향 연관관계로 인해 JSON 직렬화 과정에서 무한 순환 참조가 발생하여 StackOverflowError가 발생한다.
- `@JsonManagedReference` / `@JsonBackReference` 를 추가하여 직렬화 방향을 지정하자
- https://github.com/Medicare-Call/Medicare-Call-Backend/pull/119 에 대한 후속 보완