### PR TITLE
fix: 건강 상태, 심리 상태 필드에 건강 정보, 심리 정보를 반환하는 문제

### DIFF
--- a/src/main/java/com/example/medicare_call/service/report/HomeReportService.java
+++ b/src/main/java/com/example/medicare_call/service/report/HomeReportService.java
@@ -286,7 +286,13 @@ public class HomeReportService {
 
         // 가장 최근 기록의 건강 상태 반환
         CareCallRecord latestRecord = healthRecords.get(healthRecords.size() - 1);
-        return latestRecord.getHealthDetails();
+        Byte healthStatus = latestRecord.getHealthStatus();
+        
+        if (healthStatus == null) {
+            return null;
+        }
+        
+        return healthStatus == 1 ? "좋음" : "나쁨";
     }
 
     private String getMentalStatus(Integer elderId, LocalDate date) {
@@ -298,7 +304,13 @@ public class HomeReportService {
 
         // 가장 최근 기록의 심리 상태 반환
         CareCallRecord latestRecord = mentalRecords.get(mentalRecords.size() - 1);
-        return latestRecord.getPsychologicalDetails();
+        Byte psychStatus = latestRecord.getPsychStatus();
+        
+        if (psychStatus == null) {
+            return null;
+        }
+        
+        return psychStatus == 1 ? "좋음" : "나쁨";
     }
 
     private HomeReportResponse.BloodSugar getBloodSugarInfo(Integer elderId, LocalDate date) {

--- a/src/test/java/com/example/medicare_call/controller/HomeControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/HomeControllerTest.java
@@ -97,4 +97,54 @@ class HomeControllerTest {
                 .andExpect(jsonPath("$.mentalStatus").value("좋음"))
                 .andExpect(jsonPath("$.bloodSugar.meanValue").value(120));
     }
+
+    @Test
+    @DisplayName("홈 화면 데이터 조회 성공 - 건강 상태 나쁨, 심리 상태 나쁨")
+    void getHomeData_성공_상태나쁨() throws Exception {
+        // given
+        Integer elderId = 1;
+
+        HomeReportResponse.MealStatus mealStatus = HomeReportResponse.MealStatus.builder()
+                .breakfast(false)
+                .lunch(false)
+                .dinner(false)
+                .build();
+
+        HomeReportResponse.MedicationStatus medicationStatus = HomeReportResponse.MedicationStatus.builder()
+                .totalTaken(0)
+                .totalGoal(3)
+                .nextMedicationTime(MedicationScheduleTime.MORNING)
+                .medicationList(Collections.emptyList())
+                .build();
+
+        HomeReportResponse expectedResponse = HomeReportResponse.builder()
+                .elderName("김옥자")
+                .aiSummary("건강 상태가 좋지 않습니다.")
+                .mealStatus(mealStatus)
+                .medicationStatus(medicationStatus)
+                .sleep(null)
+                .healthStatus("나쁨")
+                .mentalStatus("나쁨")
+                .bloodSugar(null)
+                .build();
+
+        when(homeReportService.getHomeReport(eq(elderId)))
+                .thenReturn(expectedResponse);
+
+        // when & then
+        mockMvc.perform(get("/elders/{elderId}/home", elderId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.elderName").value("김옥자"))
+                .andExpect(jsonPath("$.aiSummary").value("건강 상태가 좋지 않습니다."))
+                .andExpect(jsonPath("$.mealStatus.breakfast").value(false))
+                .andExpect(jsonPath("$.mealStatus.lunch").value(false))
+                .andExpect(jsonPath("$.mealStatus.dinner").value(false))
+                .andExpect(jsonPath("$.medicationStatus.totalTaken").value(0))
+                .andExpect(jsonPath("$.medicationStatus.totalGoal").value(3))
+                .andExpect(jsonPath("$.medicationStatus.nextMedicationTime").value("MORNING"))
+                .andExpect(jsonPath("$.healthStatus").value("나쁨"))
+                .andExpect(jsonPath("$.mentalStatus").value("나쁨"))
+                .andExpect(jsonPath("$.sleep").doesNotExist())
+                .andExpect(jsonPath("$.bloodSugar").doesNotExist());
+    }
 } 

--- a/src/test/java/com/example/medicare_call/service/report/HomeReportServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/report/HomeReportServiceTest.java
@@ -261,6 +261,168 @@ class HomeReportServiceTest {
                 .build();
     }
 
+    @Test
+    @DisplayName("홈 화면 데이터 조회 성공 - 건강 상태 좋음")
+    void getHomeReport_성공_건강상태좋음() {
+        // given
+        Integer elderId = 1;
+
+        CareCallRecord healthRecord = createCareCallRecord(1, (byte) 1, null); // healthStatus = 1 (좋음)
+
+        when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
+        when(mealRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(medicationScheduleRepository.findByElder(testElder))
+                .thenReturn(Collections.emptyList());
+        when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.singletonList(healthRecord));
+        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(aiSummaryService.getHomeSummary(any(HomeSummaryDto.class))).thenReturn("AI 요약");
+
+        // when
+        HomeReportResponse response = homeReportService.getHomeReport(elderId);
+
+        // then
+        assertThat(response.getHealthStatus()).isEqualTo("좋음");
+    }
+
+    @Test
+    @DisplayName("홈 화면 데이터 조회 성공 - 건강 상태 나쁨")
+    void getHomeReport_성공_건강상태나쁨() {
+        // given
+        Integer elderId = 1;
+
+        CareCallRecord healthRecord = createCareCallRecord(1, (byte) 0, null); // healthStatus = 0 (나쁨)
+
+        when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
+        when(mealRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(medicationScheduleRepository.findByElder(testElder))
+                .thenReturn(Collections.emptyList());
+        when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.singletonList(healthRecord));
+        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(aiSummaryService.getHomeSummary(any(HomeSummaryDto.class))).thenReturn("AI 요약");
+
+        // when
+        HomeReportResponse response = homeReportService.getHomeReport(elderId);
+
+        // then
+        assertThat(response.getHealthStatus()).isEqualTo("나쁨");
+    }
+
+    @Test
+    @DisplayName("홈 화면 데이터 조회 성공 - 심리 상태 좋음")
+    void getHomeReport_성공_심리상태좋음() {
+        // given
+        Integer elderId = 1;
+
+        CareCallRecord mentalRecord = createCareCallRecord(1, null, (byte) 1); // psychStatus = 1 (좋음)
+
+        when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
+        when(mealRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(medicationScheduleRepository.findByElder(testElder))
+                .thenReturn(Collections.emptyList());
+        when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.singletonList(mentalRecord));
+        when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(aiSummaryService.getHomeSummary(any(HomeSummaryDto.class))).thenReturn("AI 요약");
+
+        // when
+        HomeReportResponse response = homeReportService.getHomeReport(elderId);
+
+        // then
+        assertThat(response.getMentalStatus()).isEqualTo("좋음");
+    }
+
+    @Test
+    @DisplayName("홈 화면 데이터 조회 성공 - 심리 상태 나쁨")
+    void getHomeReport_성공_심리상태나쁨() {
+        // given
+        Integer elderId = 1;
+
+        CareCallRecord mentalRecord = createCareCallRecord(1, null, (byte) 0); // psychStatus = 0 (나쁨)
+
+        when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
+        when(mealRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(medicationScheduleRepository.findByElder(testElder))
+                .thenReturn(Collections.emptyList());
+        when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.singletonList(mentalRecord));
+        when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(aiSummaryService.getHomeSummary(any(HomeSummaryDto.class))).thenReturn("AI 요약");
+
+        // when
+        HomeReportResponse response = homeReportService.getHomeReport(elderId);
+
+        // then
+        assertThat(response.getMentalStatus()).isEqualTo("나쁨");
+    }
+
+    @Test
+    @DisplayName("홈 화면 데이터 조회 성공 - 건강 및 심리 상태 모두 있음")
+    void getHomeReport_성공_건강심리상태모두있음() {
+        // given
+        Integer elderId = 1;
+
+        CareCallRecord healthRecord = createCareCallRecord(1, (byte) 1, null); // healthStatus = 1 (좋음)
+        CareCallRecord mentalRecord = createCareCallRecord(2, null, (byte) 0); // psychStatus = 0 (나쁨)
+
+        when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
+        when(mealRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(medicationScheduleRepository.findByElder(testElder))
+                .thenReturn(Collections.emptyList());
+        when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.singletonList(healthRecord));
+        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.singletonList(mentalRecord));
+        when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(aiSummaryService.getHomeSummary(any(HomeSummaryDto.class))).thenReturn("AI 요약");
+
+        // when
+        HomeReportResponse response = homeReportService.getHomeReport(elderId);
+
+        // then
+        assertThat(response.getHealthStatus()).isEqualTo("좋음");
+        assertThat(response.getMentalStatus()).isEqualTo("나쁨");
+    }
+
     private MedicationSchedule createMedicationSchedule(Integer id, String medicationName, String scheduleTime) {
         Medication medication = Medication.builder()
                 .id(id)
@@ -271,6 +433,17 @@ class HomeReportServiceTest {
                 .id(id)
                 .medication(medication)
                 .scheduleTime(scheduleTime)
+                .build();
+    }
+
+    private CareCallRecord createCareCallRecord(Integer id, Byte healthStatus, Byte psychStatus) {
+        return CareCallRecord.builder()
+                .id(id)
+                .elder(testElder)
+                .calledAt(LocalDateTime.now())
+                .responded((byte) 1)
+                .healthStatus(healthStatus)
+                .psychStatus(psychStatus)
                 .build();
     }
 }


### PR DESCRIPTION
### Desc
- `HomeResponse`으로 내려주는 healthStatus, mentalStatus는 CareCallRecord 엔티티의 healthStatus, psychStatus 이어야 한다.
- 현재는 healthDetails와 psychologicalDetails 필드를 반환하고 있어 기대하는 응답을 받지 못하는 상황
-  올바른 필드를 사용하여 "좋음", "나쁨" 의 형태로 응답을 반환하자

### Todo
- 추후 Enum으로 마이그레이션해서 관리하면 좋을 것 같다