### PR TITLE
feat: 도커 컨테이너 내부 시간대를 서울시간으로 설정하자

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM amazoncorretto:17
+ENV TZ=Asia/Seoul
 EXPOSE 8080
 COPY ./build/libs/*.jar ./app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
### Desc
- 어플리케이션 로직 상으로 관리되는 cron 스케줄 시간은 한국 시간대를 기준으로 한다
- 스프링 서버에서 now()를 통해 현재 시간대를 조회할 경우, 컨테이너의 시간은 UTC이기 때문에 시간대가 불일치하는 문제가 발생
- 모든 시간대를 서울시로 통합하여 관리하자