### PR TITLE
fix: 시스템 기본 타임존 변경

### DIFF
--- a/src/main/java/com/example/medicare_call/MedicareCallApplication.java
+++ b/src/main/java/com/example/medicare_call/MedicareCallApplication.java
@@ -11,11 +11,6 @@ import java.util.TimeZone;
 @EnableScheduling
 public class MedicareCallApplication {
 
-	@PostConstruct
-	public void started() {
-		TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-	}
-
 	public static void main(String[] args) {
 		SpringApplication.run(MedicareCallApplication.class, args);
 	}


### PR DESCRIPTION
### Desc
- 등록된 Cron Job이 실행되지 않는 문제 
  - https://github.com/Medicare-Call/Medicare-Call-Backend/pull/128 해당 pr에서 도커 내부 시간대를 서울 시간대로 변경
  - `TimeZone.setDefault(TimeZone.getTimeZone("UTC"));` 를 통해 JVM이 실행되는 시스템의 기본 타임존이 UTC임을 확인
  - 해당 부분을 지우고 케어콜 Cron Job이 설정된 시간에 요청을 보내는지 확인 필요 