### PR TITLE
feat: 홈화면 ai 요약 서비스를 필요한 때만 호출

### DIFF
--- a/src/main/java/com/example/medicare_call/repository/CareCallRecordRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/CareCallRecordRepository.java
@@ -1,12 +1,16 @@
 package com.example.medicare_call.repository;
 
 import com.example.medicare_call.domain.CareCallRecord;
+import com.example.medicare_call.domain.Elder;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -73,4 +77,7 @@ public interface CareCallRecordRepository extends JpaRepository<CareCallRecord, 
            "AND DATE(ccr.startTime) BETWEEN :startDate AND :endDate " +
            "ORDER BY ccr.startTime")
     List<CareCallRecord> findByElderIdAndDateBetween(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
+    @Query("SELECT ccr FROM CareCallRecord ccr WHERE ccr.elder = :elder AND DATE(ccr.calledAt) = :today")
+    List<CareCallRecord> findByElderAndToday(@Param("elder") Elder elder, @Param("today") LocalDate today);
 } 


### PR DESCRIPTION
### Desc
- 홈화면에 필요한 여러 데이터 (`mealStatus`, `medicationStatus`, `sleep`, `healthStatus`, `mentalStatus`, `bloodSugar`) 값이 없어도(`null`) ai를 호출하여 aiSummary를 생성하는 이슈
- 위 데이터들이 존재하지 않거나 해당 날짜의 완료된 CareCallRecord 가 존재하지 않으면 ai 서비스를 호출하지 않고 빈 문자열을 내려주도록 수정 
  - care call 이 진행되지 않으면 당연히 생성되지 않을 정보들이지만 전화 데이터 오류를 고려하여 care call 자체의 상태값도 검증함 
  - callStatus 가 completed 일 때만 정상적인 통화로 간주 

### 수정된 Response 예시
```json
{
  "elderName": "김지현",
  "aiSummary": "",
  "mealStatus": {
    "breakfast": null,
    "lunch": null,
    "dinner": null
  },
  "medicationStatus": {
    "totalTaken": 0,
    "totalGoal": 0,
    "nextMedicationTime": "MORNING",
    "medicationList": []
  },
  "sleep": null,
  "healthStatus": null,
  "mentalStatus": null,
  "bloodSugar": null
}
```