### PR TITLE
feat: MedicationSchedule의 MedicationType 변경

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/HealthDataController.java
+++ b/src/main/java/com/example/medicare_call/controller/HealthDataController.java
@@ -9,6 +9,7 @@ import com.example.medicare_call.dto.data_processor.HealthDataExtractionRequest;
 import com.example.medicare_call.dto.data_processor.HealthDataExtractionResponse;
 import com.example.medicare_call.global.enums.ElderRelation;
 import com.example.medicare_call.global.enums.Gender;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import com.example.medicare_call.global.enums.ResidenceType;
 import com.example.medicare_call.repository.CareCallRecordRepository;
 import com.example.medicare_call.repository.CareCallSettingRepository;
@@ -302,7 +303,7 @@ public class HealthDataController {
                     MedicationSchedule newSchedule = MedicationSchedule.builder()
                             .name("혈압약")
                             .elder(elder)
-                            .scheduleTime("MORNING")
+                            .scheduleTime(MedicationScheduleTime.MORNING)
                             .build();
                     return medicationScheduleRepository.save(newSchedule);
                 });

--- a/src/main/java/com/example/medicare_call/domain/MedicationSchedule.java
+++ b/src/main/java/com/example/medicare_call/domain/MedicationSchedule.java
@@ -1,5 +1,6 @@
 package com.example.medicare_call.domain;
 
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,11 +26,12 @@ public class MedicationSchedule {
     @Column(name = "name", nullable = false)
     private String name;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "schedule_time", nullable = false)
-    private String scheduleTime;
+    private MedicationScheduleTime scheduleTime;
 
     @Builder
-    public MedicationSchedule(Integer id, Elder elder, String name, String scheduleTime) {
+    public MedicationSchedule(Integer id, Elder elder, String name, MedicationScheduleTime scheduleTime) {
         this.id = id;
         this.elder = elder;
         this.name = name;

--- a/src/main/java/com/example/medicare_call/dto/ElderHealthInfoCreateRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/ElderHealthInfoCreateRequest.java
@@ -38,14 +38,14 @@ public class ElderHealthInfoCreateRequest {
     @NoArgsConstructor
     public static class MedicationScheduleRequest {
         private String medicationName;
-        private List<MedicationScheduleTime> scheduleTimes;
+        private List<String> scheduleTimes;
 
         @Builder
-        public MedicationScheduleRequest(String medicationName, List<MedicationScheduleTime> scheduleTimes) {
+        public MedicationScheduleRequest(String medicationName, List<String> scheduleTimes) {
             this.medicationName = medicationName;
             this.scheduleTimes = scheduleTimes;
         }
 
-        public List<MedicationScheduleTime> getScheduleTimes() { return scheduleTimes; }
+        public List<String> getScheduleTimes() { return scheduleTimes; }
     }
 } 

--- a/src/main/java/com/example/medicare_call/service/carecall/prompt/FirstCallPromptGenerator.java
+++ b/src/main/java/com/example/medicare_call/service/carecall/prompt/FirstCallPromptGenerator.java
@@ -4,6 +4,7 @@ import com.example.medicare_call.domain.Disease;
 import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.domain.ElderHealthInfo;
 import com.example.medicare_call.domain.MedicationSchedule;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -22,7 +23,7 @@ public class FirstCallPromptGenerator implements CallPromptGenerator{
 
         // 아침 복약명 추출 (scheduleTime: "morning")
         List<String> morningMedications = medicationSchedules.stream()
-                .filter(ms -> ms.getScheduleTime() != null && ms.getScheduleTime().toUpperCase().contains("MORNING"))
+                .filter(ms -> ms.getScheduleTime() == MedicationScheduleTime.MORNING)
                 .map(MedicationSchedule::getName)
                 .toList();
 

--- a/src/main/java/com/example/medicare_call/service/carecall/prompt/ImmediateCallPromptGenerator.java
+++ b/src/main/java/com/example/medicare_call/service/carecall/prompt/ImmediateCallPromptGenerator.java
@@ -4,6 +4,7 @@ import com.example.medicare_call.domain.Disease;
 import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.domain.ElderHealthInfo;
 import com.example.medicare_call.domain.MedicationSchedule;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -22,7 +23,7 @@ public class ImmediateCallPromptGenerator implements CallPromptGenerator {
 
         // 아침 복약명 추출 (scheduleTime: "MORNING")
         List<String> morningMedications = medicationSchedules.stream()
-                .filter(ms -> ms.getScheduleTime() != null && ms.getScheduleTime().toUpperCase().contains("MORNING"))
+                .filter(ms -> ms.getScheduleTime() == MedicationScheduleTime.MORNING)
                 .map(MedicationSchedule::getName)
                 .toList();
 

--- a/src/main/java/com/example/medicare_call/service/carecall/prompt/SecondCallPromptGenerator.java
+++ b/src/main/java/com/example/medicare_call/service/carecall/prompt/SecondCallPromptGenerator.java
@@ -4,6 +4,7 @@ import com.example.medicare_call.domain.Disease;
 import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.domain.ElderHealthInfo;
 import com.example.medicare_call.domain.MedicationSchedule;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -18,7 +19,7 @@ public class SecondCallPromptGenerator implements CallPromptGenerator {
 
         // 2. 점심 복약명 추출 (scheduleTime: "lunch")
         List<String> lunchMedications = medicationSchedules.stream()
-                .filter(ms -> ms.getScheduleTime() != null && ms.getScheduleTime().toUpperCase().contains("LUNCH"))
+                .filter(ms -> ms.getScheduleTime() == MedicationScheduleTime.LUNCH)
                 .map(MedicationSchedule::getName)
                 .toList();
 

--- a/src/main/java/com/example/medicare_call/service/carecall/prompt/ThirdCallPromptGenerator.java
+++ b/src/main/java/com/example/medicare_call/service/carecall/prompt/ThirdCallPromptGenerator.java
@@ -4,6 +4,7 @@ import com.example.medicare_call.domain.Disease;
 import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.domain.ElderHealthInfo;
 import com.example.medicare_call.domain.MedicationSchedule;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,7 +18,7 @@ public class ThirdCallPromptGenerator implements CallPromptGenerator {
 
 // 2. 저녁 복약명 추출 (scheduleTime: "evening")
         List<String> eveningMedications = medicationSchedules.stream()
-                .filter(ms -> ms.getScheduleTime() != null && ms.getScheduleTime().toUpperCase().contains("DINNER"))
+                .filter(ms -> ms.getScheduleTime() == MedicationScheduleTime.DINNER)
                 .map(MedicationSchedule::getName)
                 .toList();
 

--- a/src/main/java/com/example/medicare_call/service/report/HomeReportService.java
+++ b/src/main/java/com/example/medicare_call/service/report/HomeReportService.java
@@ -175,9 +175,7 @@ public class HomeReportService {
                     List<MedicationSchedule> medicationScheduleList = entry.getValue();
                     
                     // 해당 약의 하루 목표 복용 횟수
-                    int goal = medicationScheduleList.stream()
-                            .mapToInt(schedule -> schedule.getScheduleTime().split(",").length)
-                            .sum();
+                    int goal = medicationScheduleList.size();
                     int taken = medicationTakenCounts.getOrDefault(medicationName, 0L).intValue();
 
                     // 다음 복약 시간 계산 (해당 약의 스케줄 중 가장 가까운 시간)
@@ -193,9 +191,7 @@ public class HomeReportService {
                 .collect(Collectors.toList());
 
         // 전체 목표 복용 횟수 계산
-        int totalGoal = schedules.stream()
-                .mapToInt(schedule -> schedule.getScheduleTime().split(",").length)
-                .sum();
+        int totalGoal = schedules.size();
 
         // 전체 다음 복약 시간 계산 (모든 약 중 가장 가까운 시간)
         MedicationScheduleTime nextTime = calculateNextMedicationTime(schedules);
@@ -216,16 +212,12 @@ public class HomeReportService {
         LocalTime now = LocalTime.now();
 
         Optional<MedicationScheduleTime> nextTimeToday = schedules.stream()
-                .flatMap(schedule -> Arrays.stream(schedule.getScheduleTime().split(",")))
-                .map(String::trim)
-                .map(MedicationScheduleTime::valueOf)
+                .map(MedicationSchedule::getScheduleTime)
                 .filter(scheduleTime -> getLocalTimeFromScheduleTime(scheduleTime).isAfter(now))
                 .min(Comparator.comparing(this::getLocalTimeFromScheduleTime));
 
         return nextTimeToday.orElseGet(() -> schedules.stream()
-                .flatMap(schedule -> Arrays.stream(schedule.getScheduleTime().split(",")))
-                .map(String::trim)
-                .map(MedicationScheduleTime::valueOf)
+                .map(MedicationSchedule::getScheduleTime)
                 .min(Comparator.comparing(this::getLocalTimeFromScheduleTime))
                 .orElse(MedicationScheduleTime.MORNING));
     }

--- a/src/main/resources/db/migration/V20__refactor_medication_schedule_time.sql
+++ b/src/main/resources/db/migration/V20__refactor_medication_schedule_time.sql
@@ -1,0 +1,42 @@
+-- 외래 키 제약 조건 비활성화
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- 임시 테이블 생성하여 기존 데이터를 복제
+CREATE TABLE TempMedicationSchedule AS SELECT * FROM MedicationSchedule;
+
+-- 기존 MedicationSchedule 테이블 비우기
+TRUNCATE TABLE MedicationSchedule;
+
+-- schedule_time 컬럼 타입을 ENUM으로 변경
+ALTER TABLE MedicationSchedule MODIFY COLUMN schedule_time ENUM('MORNING', 'LUNCH', 'DINNER');
+
+-- 임시 테이블에서 데이터를 읽어와 새로운 형식으로 삽입
+INSERT INTO MedicationSchedule (elder_id, name, schedule_time)
+SELECT
+    elder_id,
+    name,
+    'MORNING'
+FROM TempMedicationSchedule
+WHERE schedule_time LIKE '%MORNING%';
+
+INSERT INTO MedicationSchedule (elder_id, name, schedule_time)
+SELECT
+    elder_id,
+    name,
+    'LUNCH'
+FROM TempMedicationSchedule
+WHERE schedule_time LIKE '%LUNCH%';
+
+INSERT INTO MedicationSchedule (elder_id, name, schedule_time)
+SELECT
+    elder_id,
+    name,
+    'DINNER'
+FROM TempMedicationSchedule
+WHERE schedule_time LIKE '%DINNER%';
+
+-- 임시 테이블 삭제
+DROP TABLE TempMedicationSchedule;
+
+-- 외래 키 제약 조건 다시 활성화
+SET FOREIGN_KEY_CHECKS = 1;

--- a/src/test/java/com/example/medicare_call/controller/ElderHealthInfoControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/ElderHealthInfoControllerTest.java
@@ -34,7 +34,7 @@ class ElderHealthInfoControllerTest {
     void registerElderHealthInfo_success() throws Exception {
         ElderHealthInfoCreateRequest.MedicationScheduleRequest msReq = ElderHealthInfoCreateRequest.MedicationScheduleRequest.builder()
                 .medicationName("당뇨약")
-                .scheduleTimes(List.of(MedicationScheduleTime.MORNING, MedicationScheduleTime.DINNER))
+                .scheduleTimes(List.of(MedicationScheduleTime.MORNING.name(), MedicationScheduleTime.DINNER.name()))
                 .build();
         ElderHealthInfoCreateRequest request = ElderHealthInfoCreateRequest.builder()
                 .diseaseNames(List.of("당뇨"))

--- a/src/test/java/com/example/medicare_call/service/data_processor/MedicationServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/data_processor/MedicationServiceTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.example.medicare_call.dto.report.DailyMedicationResponse;
 import com.example.medicare_call.global.enums.MedicationTakenStatus;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import com.example.medicare_call.repository.ElderRepository;
 
 import java.time.LocalDate;
@@ -65,7 +66,7 @@ public class MedicationServiceTest {
                 .id(1)
                 .elder(elder)
                 .name("혈압약")
-                .scheduleTime("MORNING")
+                .scheduleTime(MedicationScheduleTime.MORNING)
                 .build();
     }
 
@@ -207,7 +208,7 @@ public class MedicationServiceTest {
                 .id(1)
                 .elder(elder)
                 .name("혈압약")
-                .scheduleTime("MORNING,LUNCH")
+                .scheduleTime(MedicationScheduleTime.MORNING)
                 .build();
 
         when(medicationScheduleRepository.findByElder(elder)).thenReturn(Arrays.asList(morningSchedule));
@@ -237,7 +238,7 @@ public class MedicationServiceTest {
                 .id(1)
                 .elder(elder)
                 .name("혈압약")
-                .scheduleTime("MORNING,LUNCH")
+                .scheduleTime(MedicationScheduleTime.LUNCH)
                 .build();
 
         when(medicationScheduleRepository.findByElder(elder)).thenReturn(Arrays.asList(lunchSchedule));
@@ -267,7 +268,7 @@ public class MedicationServiceTest {
                 .id(1)
                 .elder(elder)
                 .name("혈압약")
-                .scheduleTime("MORNING,LUNCH")
+                .scheduleTime(MedicationScheduleTime.MORNING)
                 .build();
 
         when(medicationScheduleRepository.findByElder(elder)).thenReturn(Arrays.asList(morningSchedule));
@@ -298,35 +299,35 @@ public class MedicationServiceTest {
                 .id(1)
                 .elder(elder)
                 .name("당뇨약")
-                .scheduleTime("MORNING")
+                .scheduleTime(MedicationScheduleTime.MORNING)
                 .build();
 
         MedicationSchedule schedule2 = MedicationSchedule.builder()
                 .id(2)
                 .elder(elder)
                 .name("당뇨약")
-                .scheduleTime("LUNCH")
+                .scheduleTime(MedicationScheduleTime.LUNCH)
                 .build();
 
         MedicationSchedule schedule3 = MedicationSchedule.builder()
                 .id(3)
                 .elder(elder)
                 .name("당뇨약")
-                .scheduleTime("DINNER")
+                .scheduleTime(MedicationScheduleTime.DINNER)
                 .build();
 
         MedicationSchedule schedule4 = MedicationSchedule.builder()
                 .id(4)
                 .elder(elder)
                 .name("혈압약")
-                .scheduleTime("MORNING")
+                .scheduleTime(MedicationScheduleTime.MORNING)
                 .build();
 
         MedicationSchedule schedule5 = MedicationSchedule.builder()
                 .id(5)
                 .elder(elder)
                 .name("혈압약")
-                .scheduleTime("DINNER")
+                .scheduleTime(MedicationScheduleTime.DINNER)
                 .build();
 
         CareCallRecord morningCall = CareCallRecord.builder()

--- a/src/test/java/com/example/medicare_call/service/report/HomeReportServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/report/HomeReportServiceTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.example.medicare_call.global.exception.CustomException;
 import com.example.medicare_call.global.exception.ErrorCode;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("HomeReportService 테스트")
@@ -176,9 +177,9 @@ class HomeReportServiceTest {
         Integer elderId = 1;
 
         // 복약 스케줄 생성 (하루 3회 복용)
-        MedicationSchedule morningSchedule = createMedicationSchedule(1, "혈압약", "MORNING");
-        MedicationSchedule lunchSchedule = createMedicationSchedule(2, "혈압약", "LUNCH");
-        MedicationSchedule dinnerSchedule = createMedicationSchedule(3, "혈압약", "DINNER");
+        MedicationSchedule morningSchedule = createMedicationSchedule(1, "혈압약", MedicationScheduleTime.MORNING);
+        MedicationSchedule lunchSchedule = createMedicationSchedule(2, "혈압약", MedicationScheduleTime.LUNCH);
+        MedicationSchedule dinnerSchedule = createMedicationSchedule(3, "혈압약", MedicationScheduleTime.DINNER);
 
         when(elderRepository.findById(elderId)).thenReturn(java.util.Optional.of(testElder));
         when(mealRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
@@ -207,45 +208,6 @@ class HomeReportServiceTest {
         HomeReportResponse.MedicationInfo medicationInfo = response.getMedicationStatus().getMedicationList().get(0);
         assertThat(medicationInfo.getType()).isEqualTo("혈압약");
         assertThat(medicationInfo.getGoal()).isEqualTo(3); // 하루 3회 복용 목표
-        assertThat(medicationInfo.getTaken()).isEqualTo(0);
-    }
-
-    @Test
-    @DisplayName("홈 화면 데이터 조회 성공 - 복약 스케줄이 쉼표로 구분된 문자열일 경우")
-    void getHomeReport_성공_복약스케줄_쉼표구분() {
-        // given
-        Integer elderId = 1;
-
-        // 복약 스케줄 생성 (하루 3회 복용, 쉼표로 구분된 문자열)
-        MedicationSchedule commaSeparatedSchedule = createMedicationSchedule(1, "혈압약", "MORNING,LUNCH,DINNER");
-
-        when(elderRepository.findById(elderId)).thenReturn(java.util.Optional.of(testElder));
-        when(mealRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.emptyList());
-        when(medicationScheduleRepository.findByElder(testElder))
-                .thenReturn(Collections.singletonList(commaSeparatedSchedule));
-        when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.emptyList());
-        when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.emptyList());
-
-        // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId);
-
-        // then
-        assertThat(response.getMedicationStatus().getTotalGoal()).isEqualTo(3);
-        assertThat(response.getMedicationStatus().getTotalTaken()).isEqualTo(0);
-        assertThat(response.getMedicationStatus().getMedicationList()).hasSize(1);
-
-        HomeReportResponse.MedicationInfo medicationInfo = response.getMedicationStatus().getMedicationList().get(0);
-        assertThat(medicationInfo.getType()).isEqualTo("혈압약");
-        assertThat(medicationInfo.getGoal()).isEqualTo(3);
         assertThat(medicationInfo.getTaken()).isEqualTo(0);
     }
 
@@ -419,7 +381,7 @@ class HomeReportServiceTest {
         assertThat(response.getMentalStatus()).isEqualTo("나쁨");
     }
 
-    private MedicationSchedule createMedicationSchedule(Integer id, String medicationName, String scheduleTime) {
+    private MedicationSchedule createMedicationSchedule(Integer id, String medicationName, MedicationScheduleTime scheduleTime) {
         return MedicationSchedule.builder()
                 .id(id)
                 .name(medicationName)

--- a/src/test/java/com/example/medicare_call/service/report/WeeklyReportServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/report/WeeklyReportServiceTest.java
@@ -4,6 +4,7 @@ import com.example.medicare_call.domain.*;
 import com.example.medicare_call.dto.report.WeeklyReportResponse;
 import com.example.medicare_call.dto.report.WeeklySummaryDto;
 import com.example.medicare_call.global.enums.MealType;
+import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import com.example.medicare_call.repository.*;
 import com.example.medicare_call.service.data_processor.ai.AiSummaryService;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,7 +74,7 @@ class WeeklyReportServiceTest {
         testMedicationSchedule = MedicationSchedule.builder()
                 .id(1)
                 .name("혈압약")
-                .scheduleTime("MORNING")
+                .scheduleTime(MedicationScheduleTime.MORNING)
                 .build();
     }
 


### PR DESCRIPTION
### Desc
- 하루 내에서 MedicationSchedule과 MedicationTakenRecord를 OneToOne으로 매칭하기 위한 사전 작업
- MedicationSchedule테이블에 복약 시간을 저장하는 컬럼을 변경하기 위한 마이그레이션 적용
  - 문자열 기반의 컬럼을 Enum타입으로 마이그레이션하여 관리를 용이하게 하자
  - `,` 를 이용해 컬럼에 데이터를 몰아넣으면, 엔티티간의 매핑이 어려워지고, 사용할 때마다 데이터를 꺼내 언패킹해야 하는 문제점이 존재한다.
    - 데이터를 쪼개는 마이그레이션을 적용
- 컬럼 타입이 변경됨에 따라, 함께 변경이 필요한 서비스 대응 처리