### PR TITLE
feat: 일일, 주간 데이터 조회 API 에러코드 추가

### DIFF
--- a/src/main/java/com/example/medicare_call/global/ErrorResponse.java
+++ b/src/main/java/com/example/medicare_call/global/ErrorResponse.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Builder
 public class ErrorResponse {
 
@@ -21,27 +21,12 @@ public class ErrorResponse {
     private String code;
 
 
-    private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
-        this.message = code.getMessage();
-        this.status = code.getStatus().value();
-        this.errors = errors;
-        this.code = code.getCode();
-    }
-
-    private ErrorResponse(final ErrorCode code) {
-        this.message = code.getMessage();
-        this.status = code.getStatus().value();
-        this.code = code.getCode();
-        this.errors = new ArrayList<>();
-    }
-
-
     public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
-        return new ErrorResponse(code, FieldError.of(bindingResult));
+        return new ErrorResponse(code.getMessage(), code.getStatus().value(), FieldError.of(bindingResult), code.getCode());
     }
 
     public static ErrorResponse of(final ErrorCode code) {
-        return new ErrorResponse(code);
+        return new ErrorResponse(code.getMessage(), code.getStatus().value(), new ArrayList<>(), code.getCode());
     }
 
 

--- a/src/main/java/com/example/medicare_call/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/medicare_call/global/exception/ErrorCode.java
@@ -45,7 +45,11 @@ public enum ErrorCode {
     ORDER_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "O002", "이미 처리 완료된 주문입니다."),
 
     // NaverPay
-    NAVER_PAY_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "N001", "결제 처리 중 오류가 발생했습니다. 다시 시도해 주세요.");
+    NAVER_PAY_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "N001", "결제 처리 중 오류가 발생했습니다. 다시 시도해 주세요."),
+
+    // Data
+    NO_DATA_FOR_TODAY(HttpStatus.NOT_FOUND, "D001", "오늘의 데이터가 없습니다."),
+    NO_DATA_FOR_WEEK(HttpStatus.NOT_FOUND, "D002", "이번주의 데이터가 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/example/medicare_call/service/data_processor/MedicationService.java
+++ b/src/main/java/com/example/medicare_call/service/data_processor/MedicationService.java
@@ -85,12 +85,11 @@ public class MedicationService {
                 .orElseThrow(() -> new CustomException(ErrorCode.ELDER_NOT_FOUND));
 
         List<MedicationTakenRecord> takenRecords = medicationTakenRecordRepository.findByElderIdAndDate(elderId, date);
+        List<MedicationSchedule> schedules = medicationScheduleRepository.findByElder(elder);
 
         if (takenRecords.isEmpty()) {
-            return DailyMedicationResponse.empty(date);
+            throw new CustomException(ErrorCode.NO_DATA_FOR_TODAY);
         }
-
-        List<MedicationSchedule> schedules = medicationScheduleRepository.findByElder(elder);
 
         // 약 종류별 스케줄
         Map<String, List<MedicationSchedule>> schedulesByName = schedules.stream()

--- a/src/main/java/com/example/medicare_call/service/report/HealthAnalysisService.java
+++ b/src/main/java/com/example/medicare_call/service/report/HealthAnalysisService.java
@@ -28,7 +28,7 @@ public class HealthAnalysisService {
         List<CareCallRecord> healthRecords = careCallRecordRepository.findByElderIdAndDateWithHealthData(elderId, date);
 
         if (healthRecords.isEmpty()) {
-            return DailyHealthAnalysisResponse.empty(date);
+            throw new CustomException(ErrorCode.NO_DATA_FOR_TODAY);
         }
 
         CareCallRecord latestRecord = healthRecords.get(healthRecords.size() - 1);

--- a/src/main/java/com/example/medicare_call/service/report/HomeReportService.java
+++ b/src/main/java/com/example/medicare_call/service/report/HomeReportService.java
@@ -76,6 +76,17 @@ public class HomeReportService {
         // 혈당 정보 조회
         HomeReportResponse.BloodSugar bloodSugar = getBloodSugarInfo(elderId, today);
 
+        // 모든 데이터가 비어있는지 확인
+        if (todayMeals.isEmpty() &&
+            todayMedications.isEmpty() &&
+            sleep == null &&
+            healthStatus == null &&
+            mentalStatus == null &&
+            bloodSugar == null
+        ) {
+            throw new CustomException(ErrorCode.NO_DATA_FOR_TODAY);
+        }
+
         // AI 요약 생성
         HomeSummaryDto summaryDto = createHomeSummaryDto(mealStatus, medicationStatus, sleep, healthStatus, mentalStatus, bloodSugar);
         String aiSummary = aiSummaryService.getHomeSummary(summaryDto);

--- a/src/main/java/com/example/medicare_call/service/report/MealRecordService.java
+++ b/src/main/java/com/example/medicare_call/service/report/MealRecordService.java
@@ -31,7 +31,7 @@ public class MealRecordService {
         List<MealRecord> mealRecords = mealRecordRepository.findByElderIdAndDate(elderId, date);
 
         if (mealRecords.isEmpty()) {
-            return DailyMealResponse.empty(date);
+            throw new CustomException(ErrorCode.NO_DATA_FOR_TODAY);
         }
 
         String breakfast = null;

--- a/src/main/java/com/example/medicare_call/service/report/MentalAnalysisService.java
+++ b/src/main/java/com/example/medicare_call/service/report/MentalAnalysisService.java
@@ -35,7 +35,7 @@ public class MentalAnalysisService {
         List<CareCallRecord> mentalRecords = careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(elderId, date);
 
         if (mentalRecords.isEmpty()) {
-            return DailyMentalAnalysisResponse.empty(date);
+            throw new CustomException(ErrorCode.NO_DATA_FOR_TODAY);
         }
 
         List<String> commentList = new ArrayList<>();

--- a/src/main/java/com/example/medicare_call/service/report/SleepRecordService.java
+++ b/src/main/java/com/example/medicare_call/service/report/SleepRecordService.java
@@ -32,7 +32,7 @@ public class SleepRecordService {
         List<CareCallRecord> sleepRecords = careCallRecordRepository.findByElderIdAndDateWithSleepData(elderId, date);
         
         if (sleepRecords.isEmpty()) {
-            return DailySleepResponse.empty(date);
+            throw new CustomException(ErrorCode.NO_DATA_FOR_TODAY);
         }
         
         // 가장 최근 수면 기록 사용

--- a/src/test/java/com/example/medicare_call/service/data_processor/MedicationServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/data_processor/MedicationServiceTest.java
@@ -30,6 +30,7 @@ import com.example.medicare_call.repository.ElderRepository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collections;
 
 @ExtendWith(MockitoExtension.class)
 public class MedicationServiceTest {
@@ -429,20 +430,21 @@ public class MedicationServiceTest {
     }
 
     @Test
-    @DisplayName("복약 데이터 조회 성공 - 데이터 없음")
-    void getDailyMedication_ThrowsResourceNotFoundException() {
+    @DisplayName("날짜별 복약 데이터 조회 실패 - 데이터 없음")
+    void getDailyMedication_NoData_ThrowsException() {
         // given
         Integer elderId = 1;
         LocalDate date = LocalDate.of(2025, 7, 16);
 
         when(elderRepository.findById(elderId)).thenReturn(Optional.of(new Elder()));
+        when(medicationTakenRecordRepository.findByElderIdAndDate(elderId, date)).thenReturn(Collections.emptyList());
+        when(medicationScheduleRepository.findByElder(any(Elder.class))).thenReturn(Collections.emptyList());
 
-        // when
-        DailyMedicationResponse response = medicationService.getDailyMedication(elderId, date);
 
-        // then
-        assertThat(response).isNotNull();
-        assertEquals(date, response.getDate());
-        assertTrue(response.getMedications().isEmpty());
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            medicationService.getDailyMedication(elderId, date);
+        });
+        assertEquals(ErrorCode.NO_DATA_FOR_TODAY, exception.getErrorCode());
     }
 } 

--- a/src/test/java/com/example/medicare_call/service/report/MealRecordServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/report/MealRecordServiceTest.java
@@ -144,7 +144,7 @@ class MealRecordServiceTest {
 
     @Test
     @DisplayName("날짜별 식사 데이터 조회 실패 - 데이터 없음")
-    void getDailyMeals_NoData_ThrowsResourceNotFoundException() {
+    void getDailyMeals_NoData_ThrowsException() {
         // given
         Integer elderId = 1;
         LocalDate date = LocalDate.of(2024, 1, 1);
@@ -153,16 +153,10 @@ class MealRecordServiceTest {
         when(mealRecordRepository.findByElderIdAndDate(elderId, date)).thenReturn(List.of());
 
         // when & then
-        // when
-        DailyMealResponse response = mealRecordService.getDailyMeals(elderId, date);
-
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.getDate()).isEqualTo(date);
-        assertThat(response.getMeals()).isNotNull();
-        assertThat(response.getMeals().getBreakfast()).isNull();
-        assertThat(response.getMeals().getLunch()).isNull();
-        assertThat(response.getMeals().getDinner()).isNull();
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            mealRecordService.getDailyMeals(elderId, date);
+        });
+        assertEquals(ErrorCode.NO_DATA_FOR_TODAY, exception.getErrorCode());
     }
 
     private MealRecord createMealRecord(MealType mealType, String responseSummary) {

--- a/src/test/java/com/example/medicare_call/service/report/MentalAnalysisServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/report/MentalAnalysisServiceTest.java
@@ -22,6 +22,10 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.example.medicare_call.global.exception.CustomException;
+import com.example.medicare_call.global.exception.ErrorCode;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("MentalAnalysisService Test")
@@ -100,7 +104,7 @@ class MentalAnalysisServiceTest {
 
     @Test
     @DisplayName("심리 상태 데이터 조회 실패 - 데이터 없음")
-    void getDailyMentalAnalysis_NoData_ThrowsResourceNotFoundException() {
+    void getDailyMentalAnalysis_NoData_ThrowsException() {
         // given
         Integer elderId = 1;
         LocalDate date = LocalDate.of(2025, 7, 16);
@@ -111,13 +115,11 @@ class MentalAnalysisServiceTest {
         when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(elderId, date))
                 .thenReturn(Collections.emptyList());
 
-        // when
-        DailyMentalAnalysisResponse response = mentalAnalysisService.getDailyMentalAnalysis(elderId, date);
-
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.getDate()).isEqualTo(date);
-        assertThat(response.getCommentList()).isEmpty();
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            mentalAnalysisService.getDailyMentalAnalysis(elderId, date);
+        });
+        assertEquals(ErrorCode.NO_DATA_FOR_TODAY, exception.getErrorCode());
     }
 
     @Test

--- a/src/test/java/com/example/medicare_call/service/report/SleepRecordServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/report/SleepRecordServiceTest.java
@@ -140,7 +140,7 @@ class SleepRecordServiceTest {
 
     @Test
     @DisplayName("수면 데이터 조회 실패 - 데이터 없음")
-    void getDailySleep_NoData_ThrowsResourceNotFoundException() {
+    void getDailySleep_NoData_ThrowsException() {
         // given
         Integer elderId = 1;
         LocalDate date = LocalDate.of(2025, 7, 16);
@@ -151,16 +151,11 @@ class SleepRecordServiceTest {
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(elderId, date))
                 .thenReturn(Collections.emptyList());
 
-        DailySleepResponse response = sleepRecordService.getDailySleep(elderId, date);
-
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.getDate()).isEqualTo(date);
-        assertThat(response.getTotalSleep()).isNotNull();
-        assertThat(response.getTotalSleep().getHours()).isNull();
-        assertThat(response.getTotalSleep().getMinutes()).isNull();
-        assertThat(response.getSleepTime()).isNull();
-        assertThat(response.getWakeTime()).isNull();
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            sleepRecordService.getDailySleep(elderId, date);
+        });
+        assertEquals(ErrorCode.NO_DATA_FOR_TODAY, exception.getErrorCode());
     }
 
     @Test

--- a/src/test/java/com/example/medicare_call/service/report/WeeklyReportServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/report/WeeklyReportServiceTest.java
@@ -5,6 +5,8 @@ import com.example.medicare_call.dto.report.WeeklyReportResponse;
 import com.example.medicare_call.dto.report.WeeklySummaryDto;
 import com.example.medicare_call.global.enums.MealType;
 import com.example.medicare_call.global.enums.MedicationScheduleTime;
+import com.example.medicare_call.global.exception.CustomException;
+import com.example.medicare_call.global.exception.ErrorCode;
 import com.example.medicare_call.repository.*;
 import com.example.medicare_call.service.data_processor.ai.AiSummaryService;
 import org.junit.jupiter.api.BeforeEach;
@@ -93,36 +95,28 @@ class WeeklyReportServiceTest {
                 createMealRecord(1, MealType.BREAKFAST),
                 createMealRecord(2, MealType.LUNCH)
         );
+        List<CareCallRecord> careCallRecordsRecords = Arrays.asList(
+                new CareCallRecord(),
+                new CareCallRecord()
+        );
         when(mealRecordRepository.findByElderIdAndDateBetween(eq(elderId), eq(startDate), eq(endLocalDate)))
                 .thenReturn(mealRecords);
 
-        // 복약 스케줄 모킹
         when(medicationScheduleRepository.findByElderId(elderId))
-                .thenReturn(Arrays.asList(testMedicationSchedule));
-
-        // 복용 기록 모킹
+                .thenReturn(Collections.emptyList());
         when(medicationTakenRecordRepository.findByElderIdAndDateBetween(eq(elderId), eq(startDate), eq(endLocalDate)))
                 .thenReturn(Collections.emptyList());
-
-        // 수면 기록 모킹
         when(careCallRecordRepository.findByElderIdAndDateBetweenWithSleepData(eq(elderId), eq(startDate), eq(endLocalDate)))
                 .thenReturn(Collections.emptyList());
-
-        // 심리 상태 기록 모킹
         when(careCallRecordRepository.findByElderIdAndDateBetweenWithPsychologicalData(eq(elderId), eq(startDate), eq(endLocalDate)))
                 .thenReturn(Collections.emptyList());
-
-        // 혈당 기록 모킹
+        when(careCallRecordRepository.findByElderIdAndDateBetweenWithHealthData(eq(elderId), eq(startDate), eq(endLocalDate)))
+                .thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), eq(startDate), eq(endLocalDate)))
+                .thenReturn(careCallRecordsRecords);
         when(bloodSugarRecordRepository.findByElderIdAndDateBetween(eq(elderId), eq(startDate), eq(endLocalDate)))
                 .thenReturn(Collections.emptyList());
 
-        // 건강 상태 기록 모킹
-        when(careCallRecordRepository.findByElderIdAndDateBetweenWithHealthData(eq(elderId), eq(startDate), eq(endLocalDate)))
-                .thenReturn(Collections.emptyList());
-
-        // 통화 기록 모킹
-        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), eq(startDate), eq(endLocalDate)))
-                .thenReturn(Collections.emptyList());
 
         when(aiSummaryService.getWeeklyStatsSummary(any(WeeklySummaryDto.class))).thenReturn("주간 AI 요약");
 
@@ -151,6 +145,30 @@ class WeeklyReportServiceTest {
         assertThat(response.getBloodSugar().getAfterMeal().getHigh()).isEqualTo(0);
         assertThat(response.getBloodSugar().getAfterMeal().getLow()).isEqualTo(0);
         assertEquals("주간 AI 요약", response.getHealthSummary());
+    }
+
+    @Test
+    @DisplayName("주간 통계 조회 실패 - 데이터 없음")
+    void getWeeklyReport_fail_noData() {
+        // given
+        Integer elderId = 1;
+        LocalDate startDate = LocalDate.of(2025, 7, 15);
+
+        when(elderRepository.findById(elderId)).thenReturn(java.util.Optional.of(testElder));
+        when(mealRecordRepository.findByElderIdAndDateBetween(any(), any(), any())).thenReturn(Collections.emptyList());
+        when(medicationScheduleRepository.findByElderId(any())).thenReturn(Collections.emptyList());
+        when(medicationTakenRecordRepository.findByElderIdAndDateBetween(any(), any(), any())).thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateBetweenWithSleepData(any(), any(), any())).thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateBetweenWithPsychologicalData(any(), any(), any())).thenReturn(Collections.emptyList());
+        when(bloodSugarRecordRepository.findByElderIdAndDateBetween(any(), any(), any())).thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateBetweenWithHealthData(any(), any(), any())).thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateBetween(any(), any(), any())).thenReturn(Collections.emptyList());
+
+        // when & then
+        CustomException exception = org.junit.jupiter.api.Assertions.assertThrows(CustomException.class, () -> {
+            weeklyReportService.getWeeklyReport(elderId, startDate);
+        });
+        assertEquals(ErrorCode.NO_DATA_FOR_WEEK, exception.getErrorCode());
     }
 
     private MealRecord createMealRecord(Integer id, MealType mealType) {


### PR DESCRIPTION
### Desc
- 클라이언트 측 요청으로, 데이터가 없을 경우에는 empty DTO 대신 에러코드로 응답하기로 하였다.
- 조회 날짜에 유효한 데이터가 없을 경우에는 하기와 같이 응답하도록 처리
```
{
  "message": "이번주의 데이터가 없습니다.",
  "status": 404,
  "errors": [],
  "code": "D002"
}
```
```
{
  "message": "오늘의 데이터가 없습니다.",
  "status": 404,
  "errors": [],
  "code": "D001"
}
```