### PR TITLE
feat: cron job 10분단위 설정

### DIFF
--- a/src/main/java/com/example/medicare_call/repository/CareCallSettingRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/CareCallSettingRepository.java
@@ -12,14 +12,17 @@ import java.util.Optional;
 
 public interface CareCallSettingRepository extends JpaRepository<CareCallSetting, Integer> {
 
-    @Query("SELECT c FROM CareCallSetting c JOIN c.elder e WHERE c.firstCallTime = :now AND e.status = 'ACTIVATED'")
-    List<CareCallSetting> findByFirstCallTime(@Param("now") LocalTime now);
+    // 1차 콜 시간 범위 조회
+    @Query("SELECT c FROM CareCallSetting c JOIN c.elder e WHERE c.firstCallTime BETWEEN :startTime AND :endTime AND e.status = 'ACTIVATED'")
+    List<CareCallSetting> findByFirstCallTimeBetween(@Param("startTime") LocalTime startTime, @Param("endTime") LocalTime endTime);
 
-    @Query("SELECT c FROM CareCallSetting c JOIN c.elder e WHERE c.secondCallTime = :now AND e.status = 'ACTIVATED'")
-    List<CareCallSetting> findBySecondCallTime(@Param("now") LocalTime now);
+    // 2차 콜 시간 범위 조회
+    @Query("SELECT c FROM CareCallSetting c JOIN c.elder e WHERE c.secondCallTime BETWEEN :startTime AND :endTime AND e.status = 'ACTIVATED'")
+    List<CareCallSetting> findBySecondCallTimeBetween(@Param("startTime") LocalTime startTime, @Param("endTime") LocalTime endTime);
 
-    @Query("SELECT c FROM CareCallSetting c JOIN c.elder e WHERE c.thirdCallTime = :now AND e.status = 'ACTIVATED'")
-    List<CareCallSetting> findByThirdCallTime(@Param("now") LocalTime now);
+    // 3차 콜 시간 범위 조회
+    @Query("SELECT c FROM CareCallSetting c JOIN c.elder e WHERE c.thirdCallTime BETWEEN :startTime AND :endTime AND e.status = 'ACTIVATED'")
+    List<CareCallSetting> findByThirdCallTimeBetween(@Param("startTime") LocalTime startTime, @Param("endTime") LocalTime endTime);
 
     Optional<CareCallSetting> findByElder(Elder elder);
 }

--- a/src/main/java/com/example/medicare_call/scheduler/CareCallScheduler.java
+++ b/src/main/java/com/example/medicare_call/scheduler/CareCallScheduler.java
@@ -16,7 +16,7 @@ public class CareCallScheduler {
 
     private final CareCallSchedulerService schedulerService;
 
-    @Scheduled(cron = "0 * * * * *") // 매 분 0초마다 실행
+    @Scheduled(cron = "0 */10 * * * *") // 매 10분마다 0초에 실행
     public void runCallScheduler() {
         schedulerService.checkAndSendCalls();
     }

--- a/src/main/java/com/example/medicare_call/service/carecall/CareCallSchedulerService.java
+++ b/src/main/java/com/example/medicare_call/service/carecall/CareCallSchedulerService.java
@@ -18,25 +18,27 @@ public class CareCallSchedulerService {
     private final CareCallRequestSenderService careCallRequestSenderService;
 
     public void checkAndSendCalls() {
-        LocalTime now = LocalTime.now().withSecond(0).withNano(0); // UTC 기준 현재 시간
-        checkAndSendCalls(now);
+        LocalTime endTime = LocalTime.now().withSecond(0).withNano(0);
+        // 현재부터 10분 전까지의 기간 설정 (cron job 이 10분 단위로 실행)
+        LocalTime startTime = endTime.minusMinutes(10);
+        checkAndSendCallsInRange(startTime, endTime);
     }
 
-    public void checkAndSendCalls(LocalTime now) {
+    public void checkAndSendCallsInRange(LocalTime startTime, LocalTime endTime) {
         //1차 케어콜
-        List<CareCallSetting> firstTargets = settingRepository.findByFirstCallTime(now);
+        List<CareCallSetting> firstTargets = settingRepository.findByFirstCallTimeBetween(startTime, endTime);
         for (CareCallSetting setting : firstTargets) {
             careCallRequestSenderService.sendCall(setting.getId(), setting.getElder().getId(), CallType.FIRST);
         }
 
         //2차 케어콜
-        List<CareCallSetting> secondTargets = settingRepository.findBySecondCallTime(now);
+        List<CareCallSetting> secondTargets = settingRepository.findBySecondCallTimeBetween(startTime, endTime);
         for (CareCallSetting setting : secondTargets) {
             careCallRequestSenderService.sendCall(setting.getId(), setting.getElder().getId(), CallType.SECOND);
         }
 
         //3차 케어콜
-        List<CareCallSetting> thirdTargets = settingRepository.findByThirdCallTime(now);
+        List<CareCallSetting> thirdTargets = settingRepository.findByThirdCallTimeBetween(startTime, endTime);
         for (CareCallSetting setting : thirdTargets) {
             careCallRequestSenderService.sendCall(setting.getId(), setting.getElder().getId(), CallType.THIRD);
         }

--- a/src/test/java/com/example/medicare_call/service/carecall/CareCallSchedulerServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/carecall/CareCallSchedulerServiceTest.java
@@ -30,26 +30,28 @@ public class CareCallSchedulerServiceTest {
     @Test
     void testCheckAndSendCalls_shouldCallEldersWithMatchingTimes() {
         // given
-        LocalTime fixedTime = LocalTime.of(10, 0);
+        LocalTime startTime = LocalTime.of(10, 0);
+        LocalTime endTime = LocalTime.of(10, 10);
+
 
         Elder dummyElder1 = Elder.builder().id(1).build();
         Elder dummyElder2 = Elder.builder().id(2).build();
 
         CareCallSetting firstSetting = CareCallSetting.builder()
                 .elder(dummyElder1)
-                .firstCallTime(fixedTime)
+                .firstCallTime(LocalTime.of(10, 5))
                 .build();
 
         CareCallSetting secondSetting = CareCallSetting.builder()
                 .elder(dummyElder2)
-                .secondCallTime(fixedTime)
+                .secondCallTime(LocalTime.of(10, 8))
                 .build();
 
-        when(careCallSettingRepository.findByFirstCallTime(fixedTime)).thenReturn(List.of(firstSetting));
-        when(careCallSettingRepository.findBySecondCallTime(fixedTime)).thenReturn(List.of(secondSetting));
+        when(careCallSettingRepository.findByFirstCallTimeBetween(startTime, endTime)).thenReturn(List.of(firstSetting));
+        when(careCallSettingRepository.findBySecondCallTimeBetween(startTime, endTime)).thenReturn(List.of(secondSetting));
 
         // when
-        schedulerService.checkAndSendCalls(fixedTime);
+        schedulerService.checkAndSendCallsInRange(startTime, endTime);
 
         // then
         verify(callService).sendCall(firstSetting.getId(), dummyElder1.getId(), CallType.FIRST);


### PR DESCRIPTION
### Desc
- 기존 케어콜 스케줄러는 현재 시간(`LocalTime.now()`)과 정확히 일치하는 시간에 설정된 콜만 조회하여 실행
  - 서버 부하, DB 지연 등으로 스케줄러 실행이 조금이라도 늦어질 경우, 해당 분의 케어콜이 누락될 수 있는 위험
- 안드에서 케어콜 설정이 10분 단위이므로 cron job 도 그에 맞춰 실행
  - 실행 주기와 동일하게 케어콜을 **현재 시간부터 10분 전까지**의 시간 범위를 설정하여 조회하도록 수정