### PR TITLE
edit: 심리 상태, 건강 상태 노출 방법 변경

### DIFF
--- a/src/main/java/com/example/medicare_call/service/report/HomeReportService.java
+++ b/src/main/java/com/example/medicare_call/service/report/HomeReportService.java
@@ -298,15 +298,15 @@ public class HomeReportService {
             return null;
         }
 
-        // 가장 최근 기록의 건강 상태 반환
-        CareCallRecord latestRecord = healthRecords.get(healthRecords.size() - 1);
-        Byte healthStatus = latestRecord.getHealthStatus();
-        
-        if (healthStatus == null) {
-            return null;
+        // 오늘 데이터 중 null이 아닌 최신 건강 상태 반환
+        for (int i = healthRecords.size() - 1; i >= 0; i--) {
+            Byte healthStatus = healthRecords.get(i).getHealthStatus();
+            if (healthStatus != null) {
+                return healthStatus == 1 ? "좋음" : "나쁨";
+            }
         }
-        
-        return healthStatus == 1 ? "좋음" : "나쁨";
+
+        return null;
     }
 
     private String getMentalStatus(Integer elderId, LocalDate date) {
@@ -316,15 +316,15 @@ public class HomeReportService {
             return null;
         }
 
-        // 가장 최근 기록의 심리 상태 반환
-        CareCallRecord latestRecord = mentalRecords.get(mentalRecords.size() - 1);
-        Byte psychStatus = latestRecord.getPsychStatus();
-        
-        if (psychStatus == null) {
-            return null;
+        // 오늘 데이터 중 null이 아닌 최신 심리 상태 반환
+        for (int i = mentalRecords.size() - 1; i >= 0; i--) {
+            Byte psychStatus = mentalRecords.get(i).getPsychStatus();
+            if (psychStatus != null) {
+                return psychStatus == 1 ? "좋음" : "나쁨";
+            }
         }
-        
-        return psychStatus == 1 ? "좋음" : "나쁨";
+
+        return null;
     }
 
     private HomeReportResponse.BloodSugar getBloodSugarInfo(Integer elderId, LocalDate date) {


### PR DESCRIPTION
### Desc
- 기존에는 케어콜 데이터 중, 최신의 데이터를 가지고 와서 화면에 노출하고 있었음
- 현재 1차 ~ 3차 케어콜 중에서는 건강, 혹은 심리 상태를 추출하지 않는 경우도 있어 추출된 값 중 최신값을 노출하는 방식으로 처리함
- 만약 오늘치의 데이터 중에서 추출된 값이 없을 경우에는 null으로 응답