### PR TITLE
edit: 홈 화면 날짜 조회를 통화 시작 시간이 아닌, 통화 발송 시간을 기준으로 변경

### DIFF
--- a/src/main/java/com/example/medicare_call/repository/CareCallRecordRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/CareCallRecordRepository.java
@@ -12,65 +12,65 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CareCallRecordRepository extends JpaRepository<CareCallRecord, Integer> {
     
-                @Query("SELECT ccr FROM CareCallRecord ccr " +
-                        "JOIN ccr.elder e " +
-                   "WHERE ccr.elder.id = :elderId " +
-                   "AND e.status = 'ACTIVATED' " +
-                   "AND DATE(ccr.startTime) = :date " +
-                   "AND ccr.sleepStart IS NOT NULL " +
-                   "ORDER BY ccr.startTime")
-            List<CareCallRecord> findByElderIdAndDateWithSleepData(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
-
-            @Query("SELECT ccr FROM CareCallRecord ccr " +
-                    "JOIN ccr.elder e " +
-                   "WHERE ccr.elder.id = :elderId " +
-                    "AND e.status = 'ACTIVATED' " +
-                   "AND DATE(ccr.startTime) = :date " +
-                   "AND ccr.psychologicalDetails IS NOT NULL " +
-                   "ORDER BY ccr.startTime")
-            List<CareCallRecord> findByElderIdAndDateWithPsychologicalData(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
-
-            @Query("SELECT ccr FROM CareCallRecord ccr " +
-                    "JOIN ccr.elder e " +
-                   "WHERE ccr.elder.id = :elderId " +
-                    "AND e.status = 'ACTIVATED' " +
-                   "AND DATE(ccr.startTime) = :date " +
-                   "AND ccr.healthDetails IS NOT NULL " +
-                   "ORDER BY ccr.startTime")
-            List<CareCallRecord> findByElderIdAndDateWithHealthData(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
+    @Query("SELECT ccr FROM CareCallRecord ccr " +
+            "JOIN ccr.elder e " +
+       "WHERE ccr.elder.id = :elderId " +
+       "AND e.status = 'ACTIVATED' " +
+       "AND DATE(ccr.calledAt) = :date " +
+       "AND ccr.sleepStart IS NOT NULL " +
+       "ORDER BY ccr.calledAt")
+    List<CareCallRecord> findByElderIdAndDateWithSleepData(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
 
     @Query("SELECT ccr FROM CareCallRecord ccr " +
             "JOIN ccr.elder e " +
            "WHERE ccr.elder.id = :elderId " +
             "AND e.status = 'ACTIVATED' " +
-           "AND DATE(ccr.startTime) BETWEEN :startDate AND :endDate " +
+           "AND DATE(ccr.calledAt) = :date " +
+           "AND ccr.psychologicalDetails IS NOT NULL " +
+           "ORDER BY ccr.calledAt")
+    List<CareCallRecord> findByElderIdAndDateWithPsychologicalData(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
+
+    @Query("SELECT ccr FROM CareCallRecord ccr " +
+            "JOIN ccr.elder e " +
+           "WHERE ccr.elder.id = :elderId " +
+            "AND e.status = 'ACTIVATED' " +
+           "AND DATE(ccr.calledAt) = :date " +
+           "AND ccr.healthDetails IS NOT NULL " +
+           "ORDER BY ccr.calledAt")
+    List<CareCallRecord> findByElderIdAndDateWithHealthData(@Param("elderId") Integer elderId, @Param("date") LocalDate date);
+
+    @Query("SELECT ccr FROM CareCallRecord ccr " +
+            "JOIN ccr.elder e " +
+           "WHERE ccr.elder.id = :elderId " +
+            "AND e.status = 'ACTIVATED' " +
+           "AND DATE(ccr.calledAt) BETWEEN :startDate AND :endDate " +
            "AND ccr.sleepStart IS NOT NULL " +
-           "ORDER BY ccr.startTime")
+           "ORDER BY ccr.calledAt")
     List<CareCallRecord> findByElderIdAndDateBetweenWithSleepData(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 
     @Query("SELECT ccr FROM CareCallRecord ccr " +
             "JOIN ccr.elder e " +
            "WHERE ccr.elder.id = :elderId " +
             "AND e.status = 'ACTIVATED' " +
-           "AND DATE(ccr.startTime) BETWEEN :startDate AND :endDate " +
+           "AND DATE(ccr.calledAt) BETWEEN :startDate AND :endDate " +
            "AND ccr.psychologicalDetails IS NOT NULL " +
-           "ORDER BY ccr.startTime")
+           "ORDER BY ccr.calledAt")
     List<CareCallRecord> findByElderIdAndDateBetweenWithPsychologicalData(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 
     @Query("SELECT ccr FROM CareCallRecord ccr " +
             "JOIN ccr.elder e " +
            "WHERE ccr.elder.id = :elderId " +
             "AND e.status = 'ACTIVATED' " +
-           "AND DATE(ccr.startTime) BETWEEN :startDate AND :endDate " +
+           "AND DATE(ccr.calledAt) BETWEEN :startDate AND :endDate " +
            "AND ccr.healthDetails IS NOT NULL " +
-           "ORDER BY ccr.startTime")
+           "ORDER BY ccr.calledAt")
     List<CareCallRecord> findByElderIdAndDateBetweenWithHealthData(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 
     @Query("SELECT ccr FROM CareCallRecord ccr " +
             "JOIN ccr.elder e " +
            "WHERE ccr.elder.id = :elderId " +
             "AND e.status = 'ACTIVATED' " +
-           "AND DATE(ccr.startTime) BETWEEN :startDate AND :endDate " +
-           "ORDER BY ccr.startTime")
+           "AND DATE(ccr.calledAt) BETWEEN :startDate AND :endDate " +
+           "ORDER BY ccr.calledAt")
     List<CareCallRecord> findByElderIdAndDateBetween(@Param("elderId") Integer elderId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 } 

--- a/src/main/java/com/example/medicare_call/service/report/HomeReportService.java
+++ b/src/main/java/com/example/medicare_call/service/report/HomeReportService.java
@@ -292,9 +292,9 @@ public class HomeReportService {
     }
 
     private String getHealthStatus(Integer elderId, LocalDate date) {
-        List<CareCallRecord> healthRecords = careCallRecordRepository.findByElderIdAndDateWithHealthData(elderId, date);
+        List<CareCallRecord> healthRecords = careCallRecordRepository.findByElderIdAndDateBetween(elderId, date, date);
         
-        if (healthRecords.isEmpty()) {
+        if (healthRecords == null || healthRecords.isEmpty()) {
             return null;
         }
 
@@ -310,9 +310,9 @@ public class HomeReportService {
     }
 
     private String getMentalStatus(Integer elderId, LocalDate date) {
-        List<CareCallRecord> mentalRecords = careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(elderId, date);
+        List<CareCallRecord> mentalRecords = careCallRecordRepository.findByElderIdAndDateBetween(elderId, date, date);
         
-        if (mentalRecords.isEmpty()) {
+        if (mentalRecords == null || mentalRecords.isEmpty()) {
             return null;
         }
 

--- a/src/test/java/com/example/medicare_call/service/report/HomeReportServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/report/HomeReportServiceTest.java
@@ -96,9 +96,7 @@ class HomeReportServiceTest {
                 .thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
         when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
@@ -133,8 +131,7 @@ class HomeReportServiceTest {
         when(medicationScheduleRepository.findByElder(testElder)).thenReturn(Collections.emptyList());
         when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
 
         // when & then
@@ -179,9 +176,7 @@ class HomeReportServiceTest {
                 .thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
 
         // when
@@ -216,9 +211,7 @@ class HomeReportServiceTest {
                 .thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
 
         // when & then
@@ -254,10 +247,8 @@ class HomeReportServiceTest {
                 .thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(Collections.singletonList(healthRecord));
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.emptyList());
         when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
         when(aiSummaryService.getHomeSummary(any(HomeSummaryDto.class))).thenReturn("AI 요약");
@@ -286,10 +277,8 @@ class HomeReportServiceTest {
                 .thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(Collections.singletonList(healthRecord));
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.emptyList());
         when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
         when(aiSummaryService.getHomeSummary(any(HomeSummaryDto.class))).thenReturn("AI 요약");
@@ -318,9 +307,7 @@ class HomeReportServiceTest {
                 .thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(Collections.singletonList(mentalRecord));
         when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
@@ -350,9 +337,7 @@ class HomeReportServiceTest {
                 .thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(Collections.singletonList(mentalRecord));
         when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
@@ -383,10 +368,8 @@ class HomeReportServiceTest {
                 .thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.singletonList(healthRecord));
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
-                .thenReturn(Collections.singletonList(mentalRecord));
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(Arrays.asList(healthRecord, mentalRecord));
         when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
         when(aiSummaryService.getHomeSummary(any(HomeSummaryDto.class))).thenReturn("AI 요약");
@@ -434,9 +417,8 @@ class HomeReportServiceTest {
         when(medicationScheduleRepository.findByElder(testElder)).thenReturn(Collections.emptyList());
         when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(Arrays.asList(oldNull, middleGood, latestNull)); // 오름차순 가정
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(aiSummaryService.getHomeSummary(any(HomeSummaryDto.class))).thenReturn("AI 요약");
 
@@ -459,9 +441,8 @@ class HomeReportServiceTest {
         when(medicationScheduleRepository.findByElder(testElder)).thenReturn(Collections.emptyList());
         when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(Arrays.asList(olderBad, latestGood)); // 최신 값이 1
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(aiSummaryService.getHomeSummary(any(HomeSummaryDto.class))).thenReturn("AI 요약");
 
@@ -484,9 +465,8 @@ class HomeReportServiceTest {
         when(medicationScheduleRepository.findByElder(testElder)).thenReturn(Collections.emptyList());
         when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class)))
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(Arrays.asList(r1, r2));
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(aiSummaryService.getHomeSummary(any(HomeSummaryDto.class))).thenReturn("AI 요약");
 
@@ -510,8 +490,7 @@ class HomeReportServiceTest {
         when(medicationScheduleRepository.findByElder(testElder)).thenReturn(Collections.emptyList());
         when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(Arrays.asList(oldNull, middleBad, latestNull));
         when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(aiSummaryService.getHomeSummary(any(HomeSummaryDto.class))).thenReturn("AI 요약");
@@ -535,8 +514,7 @@ class HomeReportServiceTest {
         when(medicationScheduleRepository.findByElder(testElder)).thenReturn(Collections.emptyList());
         when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(Arrays.asList(olderGood, latestBad)); // 최신 값이 0
         when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(aiSummaryService.getHomeSummary(any(HomeSummaryDto.class))).thenReturn("AI 요약");
@@ -560,8 +538,7 @@ class HomeReportServiceTest {
         when(medicationScheduleRepository.findByElder(testElder)).thenReturn(Collections.emptyList());
         when(medicationTakenRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateWithSleepData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithHealthData(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
-        when(careCallRecordRepository.findByElderIdAndDateWithPsychologicalData(eq(elderId), any(LocalDate.class)))
+        when(careCallRecordRepository.findByElderIdAndDateBetween(eq(elderId), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(Arrays.asList(r1, r2));
         when(bloodSugarRecordRepository.findByElderIdAndDate(eq(elderId), any(LocalDate.class))).thenReturn(Collections.emptyList());
         when(aiSummaryService.getHomeSummary(any(HomeSummaryDto.class))).thenReturn("AI 요약");


### PR DESCRIPTION
### Desc
- `startTime`은 외부에서 전달되는 값인데, UTC값을 보내주고 있음
- 한국 시간대에 맞춰 사용하기 위해 우리 서버가 기록하는 값인 `calledAt` 컬럼을 기준으로 조회 및 정렬
- null 데이터가 포함되어야 하는 부분에 사용하는 JPA 메소드 변경