### PR TITLE
feat: WeeklyReportResponse에  구독 시작 데이터 추가

### DIFF
--- a/src/main/java/com/example/medicare_call/dto/report/WeeklyReportResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/report/WeeklyReportResponse.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.util.Map;
 
 @Getter
@@ -34,6 +35,9 @@ public class WeeklyReportResponse {
 
     @Schema(description = "혈당 상태 통계")
     private BloodSugar bloodSugar;
+
+    @Schema(description = "회원의 구독 시작 날짜")
+    private LocalDate subscriptionStartDate;
 
     @Getter
     @Builder

--- a/src/main/java/com/example/medicare_call/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/medicare_call/global/exception/ErrorCode.java
@@ -49,7 +49,10 @@ public enum ErrorCode {
 
     // Data
     NO_DATA_FOR_TODAY(HttpStatus.NOT_FOUND, "D001", "오늘의 데이터가 없습니다."),
-    NO_DATA_FOR_WEEK(HttpStatus.NOT_FOUND, "D002", "이번주의 데이터가 없습니다.");
+    NO_DATA_FOR_WEEK(HttpStatus.NOT_FOUND, "D002", "이번주의 데이터가 없습니다."),
+
+    // Subscription
+    SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "구독 정보를 찾을 수 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/example/medicare_call/service/report/WeeklyReportService.java
+++ b/src/main/java/com/example/medicare_call/service/report/WeeklyReportService.java
@@ -11,6 +11,7 @@ import com.example.medicare_call.global.exception.CustomException;
 import com.example.medicare_call.global.exception.ErrorCode;
 import com.example.medicare_call.repository.*;
 import com.example.medicare_call.service.data_processor.ai.AiSummaryService;
+import jdk.dynalink.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -34,8 +36,13 @@ public class WeeklyReportService {
     private final CareCallRecordRepository careCallRecordRepository;
     private final BloodSugarRecordRepository bloodSugarRecordRepository;
     private final AiSummaryService aiSummaryService;
+    private final SubscriptionRepository subscriptionRepository;
 
     public WeeklyReportResponse getWeeklyReport(Integer elderId, LocalDate startDate) {
+        LocalDate subscriptionStartDate = subscriptionRepository.findByElderId(elderId)
+                .map(Subscription::getStartDate)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
+
         LocalDate endDate = startDate.plusDays(6); // 7일간 조회
 
         // 어르신 정보 조회
@@ -93,6 +100,7 @@ public class WeeklyReportService {
                 .averageSleep(averageSleep)
                 .psychSummary(psychSummary)
                 .bloodSugar(bloodSugar)
+                .subscriptionStartDate(subscriptionStartDate)
                 .build();
     }
     

--- a/src/test/java/com/example/medicare_call/service/report/WeeklyReportServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/report/WeeklyReportServiceTest.java
@@ -53,12 +53,16 @@ class WeeklyReportServiceTest {
     @Mock
     private AiSummaryService aiSummaryService;
 
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
     @InjectMocks
     private WeeklyReportService weeklyReportService;
 
     private Elder testElder;
     private CareCallRecord testCallRecord;
     private MedicationSchedule testMedicationSchedule;
+    private Subscription testSubscription;
 
     @BeforeEach
     void setUp() {
@@ -77,6 +81,12 @@ class WeeklyReportServiceTest {
                 .id(1)
                 .name("혈압약")
                 .scheduleTime(MedicationScheduleTime.MORNING)
+                .build();
+
+        testSubscription = Subscription.builder()
+                .id(1L)
+                .elder(testElder)
+                .startDate(LocalDate.of(2025, 7, 1))
                 .build();
     }
 
@@ -120,6 +130,7 @@ class WeeklyReportServiceTest {
                 .thenReturn(careCallRecordsRecords);
         when(bloodSugarRecordRepository.findByElderIdAndDateBetween(eq(elderId), eq(startDate), eq(endLocalDate)))
                 .thenReturn(Collections.emptyList());
+        when(subscriptionRepository.findByElderId(elderId)).thenReturn(java.util.Optional.of(testSubscription));
 
 
         when(aiSummaryService.getWeeklyStatsSummary(any(WeeklySummaryDto.class))).thenReturn("주간 AI 요약");
@@ -167,6 +178,7 @@ class WeeklyReportServiceTest {
         when(bloodSugarRecordRepository.findByElderIdAndDateBetween(any(), any(), any())).thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateBetweenWithHealthData(any(), any(), any())).thenReturn(Collections.emptyList());
         when(careCallRecordRepository.findByElderIdAndDateBetween(any(), any(), any())).thenReturn(Collections.emptyList());
+        when(subscriptionRepository.findByElderId(elderId)).thenReturn(java.util.Optional.of(testSubscription));
 
         // when & then
         CustomException exception = org.junit.jupiter.api.Assertions.assertThrows(CustomException.class, () -> {
@@ -174,6 +186,7 @@ class WeeklyReportServiceTest {
         });
         assertEquals(ErrorCode.NO_DATA_FOR_WEEK, exception.getErrorCode());
     }
+
 
     private MealRecord createMealRecord(Integer id, MealType mealType, byte eatenStatus) {
         return MealRecord.builder()


### PR DESCRIPTION
- 주간 통계 데이터 화면에서 무한으로 이전 데이터를 불러오는 문제
- 회원의 구독 시작 날짜를 추가로 응답하여 안드로이드에서 처리합니다.