### PR TITLE
feat: HTTP 요청별 DB I/O 모니터링 메트릭 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ dependencies {
 	// Monitoring
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'net.ttddyy:datasource-proxy:1.7'
+
+	// AOP 설정
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 

--- a/src/main/java/com/example/medicare_call/global/config/CustomQueryExecutionListener.java
+++ b/src/main/java/com/example/medicare_call/global/config/CustomQueryExecutionListener.java
@@ -1,0 +1,34 @@
+package com.example.medicare_call.global.config;
+
+import com.example.medicare_call.global.metrics.RequestMetricsContext;
+import com.example.medicare_call.global.metrics.RequestMetricsHolder;
+import net.ttddyy.dsproxy.ExecutionInfo;
+import net.ttddyy.dsproxy.QueryInfo;
+import net.ttddyy.dsproxy.listener.QueryExecutionListener;
+
+import java.util.List;
+
+public class CustomQueryExecutionListener implements QueryExecutionListener {
+
+    @Override
+    public void beforeQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+        System.out.println("BEFORE");
+        execInfo.addCustomValue("startTime", System.nanoTime());
+    }
+
+    @Override
+    public void afterQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+        System.out.println("AFTER");
+        RequestMetricsContext context = RequestMetricsHolder.get();
+        if (context == null) return;
+
+        Long start = execInfo.getCustomValue("startTime", Long.class);
+        long elapsed;
+        if (start != null) {
+            elapsed = System.nanoTime() - start;
+        } else {
+            elapsed = execInfo.getElapsedTime() * 1_000_000;
+        }
+        context.addDbTime(elapsed);
+    }
+}

--- a/src/main/java/com/example/medicare_call/global/config/CustomQueryExecutionListener.java
+++ b/src/main/java/com/example/medicare_call/global/config/CustomQueryExecutionListener.java
@@ -2,33 +2,39 @@ package com.example.medicare_call.global.config;
 
 import com.example.medicare_call.global.metrics.RequestMetricsContext;
 import com.example.medicare_call.global.metrics.RequestMetricsHolder;
+import lombok.extern.slf4j.Slf4j;
 import net.ttddyy.dsproxy.ExecutionInfo;
 import net.ttddyy.dsproxy.QueryInfo;
 import net.ttddyy.dsproxy.listener.QueryExecutionListener;
 
 import java.util.List;
 
+@Slf4j
 public class CustomQueryExecutionListener implements QueryExecutionListener {
+
+    private static final long SLOW_QUERY_THRESHOLD_MS = 500;
 
     @Override
     public void beforeQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
-        System.out.println("BEFORE");
-        execInfo.addCustomValue("startTime", System.nanoTime());
+
     }
 
     @Override
     public void afterQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
-        System.out.println("AFTER");
         RequestMetricsContext context = RequestMetricsHolder.get();
         if (context == null) return;
 
-        Long start = execInfo.getCustomValue("startTime", Long.class);
-        long elapsed;
-        if (start != null) {
-            elapsed = System.nanoTime() - start;
-        } else {
-            elapsed = execInfo.getElapsedTime() * 1_000_000;
+        int batchSize = execInfo.getBatchSize();
+        int effectiveBatchSize = batchSize > 0 ? batchSize : 1;
+        int executedQueries = queryInfoList.size() * effectiveBatchSize;
+
+        long elapsedMs = execInfo.getElapsedTime();
+        long elapsedNs = elapsedMs * 1_000_000;
+
+        if (executedQueries == 1 && elapsedMs >= SLOW_QUERY_THRESHOLD_MS) {
+            log.warn("[SLOW QUERY] {} ms - {}", elapsedMs, queryInfoList.get(0).getQuery());
         }
-        context.addDbTime(elapsed);
+
+        context.addQueryMetrics(elapsedNs, executedQueries);
     }
 }

--- a/src/main/java/com/example/medicare_call/global/config/DataSourceProxyConfig.java
+++ b/src/main/java/com/example/medicare_call/global/config/DataSourceProxyConfig.java
@@ -1,5 +1,6 @@
 package com.example.medicare_call.global.config;
 
+import com.example.medicare_call.global.metrics.CustomQueryExecutionListener;
 import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/example/medicare_call/global/config/DataSourceProxyConfig.java
+++ b/src/main/java/com/example/medicare_call/global/config/DataSourceProxyConfig.java
@@ -1,0 +1,25 @@
+package com.example.medicare_call.global.config;
+
+import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class DataSourceProxyConfig {
+
+    @Bean
+    @Primary
+    public DataSource proxyDataSource(DataSourceProperties properties) {
+        DataSource realDataSource = properties.initializeDataSourceBuilder().build();
+
+        return ProxyDataSourceBuilder
+                .create(realDataSource)
+                .name("DS-Proxy")
+                .listener(new CustomQueryExecutionListener())
+                .build();
+    }
+}

--- a/src/main/java/com/example/medicare_call/global/config/DataSourceProxyConfig.java
+++ b/src/main/java/com/example/medicare_call/global/config/DataSourceProxyConfig.java
@@ -1,26 +1,59 @@
 package com.example.medicare_call.global.config;
 
 import com.example.medicare_call.global.metrics.CustomQueryExecutionListener;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.ttddyy.dsproxy.support.ProxyDataSource;
 import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 
 import javax.sql.DataSource;
+import java.util.List;
 
 @Configuration
 public class DataSourceProxyConfig {
 
     @Bean
-    @Primary
-    public DataSource proxyDataSource(DataSourceProperties properties) {
-        DataSource realDataSource = properties.initializeDataSourceBuilder().build();
+    public static BeanPostProcessor dataSourceProxyBeanPostProcessor(
+            CustomQueryExecutionListener listener,
+            DataSourceProxyProperties properties
+    ) {
+        return new DataSourceProxyBeanPostProcessor(listener, properties.getExclude());
+    }
 
-        return ProxyDataSourceBuilder
-                .create(realDataSource)
-                .name("DS-Proxy")
-                .listener(new CustomQueryExecutionListener())
-                .build();
+    @Slf4j
+    @RequiredArgsConstructor
+    static class DataSourceProxyBeanPostProcessor implements BeanPostProcessor {
+        private final CustomQueryExecutionListener listener;
+        private final List<String> excludedBeanNames;
+
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+            if (bean instanceof DataSource) {
+                // 이미 ProxyDataSource인 경우 재프록시 방지
+                if (bean instanceof ProxyDataSource) {
+                    log.info("Skip proxy: DataSource [{}] is already a ProxyDataSource", beanName);
+                    return bean;
+                }
+
+                // application.yml 설정에서 제외된 DataSource인 경우 스킵
+                if (excludedBeanNames.contains(beanName)) {
+                    log.info("Skip proxy: DataSource [{}] is excluded by configuration", beanName);
+                    return bean;
+                }
+
+                // Proxy 적용
+                log.info("Apply proxy: Wrapping DataSource [{}] with ProxyDataSource", beanName);
+                return ProxyDataSourceBuilder
+                        .create((DataSource) bean)
+                        .name("DS-Proxy")
+                        .listener(listener)
+                        .build();
+            }
+            return bean;
+        }
     }
 }

--- a/src/main/java/com/example/medicare_call/global/config/DataSourceProxyProperties.java
+++ b/src/main/java/com/example/medicare_call/global/config/DataSourceProxyProperties.java
@@ -1,0 +1,19 @@
+package com.example.medicare_call.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.datasource-proxy")
+public class DataSourceProxyProperties {
+
+    // 프록시 적용에서 제외할 DataSource Bean 이름 목록
+    private List<String> exclude = new ArrayList<>();
+}

--- a/src/main/java/com/example/medicare_call/global/metrics/CustomQueryExecutionListener.java
+++ b/src/main/java/com/example/medicare_call/global/metrics/CustomQueryExecutionListener.java
@@ -1,7 +1,5 @@
-package com.example.medicare_call.global.config;
+package com.example.medicare_call.global.metrics;
 
-import com.example.medicare_call.global.metrics.RequestMetricsContext;
-import com.example.medicare_call.global.metrics.RequestMetricsHolder;
 import lombok.extern.slf4j.Slf4j;
 import net.ttddyy.dsproxy.ExecutionInfo;
 import net.ttddyy.dsproxy.QueryInfo;

--- a/src/main/java/com/example/medicare_call/global/metrics/CustomQueryExecutionListener.java
+++ b/src/main/java/com/example/medicare_call/global/metrics/CustomQueryExecutionListener.java
@@ -4,10 +4,12 @@ import lombok.extern.slf4j.Slf4j;
 import net.ttddyy.dsproxy.ExecutionInfo;
 import net.ttddyy.dsproxy.QueryInfo;
 import net.ttddyy.dsproxy.listener.QueryExecutionListener;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Slf4j
+@Component
 public class CustomQueryExecutionListener implements QueryExecutionListener {
 
     private static final long SLOW_QUERY_THRESHOLD_MS = 500;

--- a/src/main/java/com/example/medicare_call/global/metrics/RequestMetricsAspect.java
+++ b/src/main/java/com/example/medicare_call/global/metrics/RequestMetricsAspect.java
@@ -1,0 +1,78 @@
+package com.example.medicare_call.global.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.concurrent.TimeUnit;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RequestMetricsAspect {
+
+    private final MeterRegistry meterRegistry;
+
+    @Around("@within(org.springframework.web.bind.annotation.RestController)")
+    public Object aroundController(ProceedingJoinPoint pjp) throws Throwable {
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes == null) return pjp.proceed();
+
+        HttpServletRequest request = attributes.getRequest();
+        String endpoint = extractEndpoint(request);
+        String method = request.getMethod();
+
+        RequestMetricsHolder.set(new RequestMetricsContext(endpoint, method));
+
+        try {
+            return pjp.proceed();
+        } finally {
+            recordMetrics();
+            RequestMetricsHolder.clear();
+        }
+    }
+
+    private String extractEndpoint(HttpServletRequest request) {
+        Object bestPattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        return bestPattern != null ? bestPattern.toString() : request.getRequestURI();
+    }
+
+    private void recordMetrics() {
+        RequestMetricsContext context = RequestMetricsHolder.get();
+        if (context == null) return;
+
+        long nanos = context.getDbElapsedTimeNanos();
+        int totalQueries = context.getQueryCount();
+
+        Timer.builder("http.db.io.time")
+                .tag("uri", context.getEndpoint())
+                .tag("method", context.getHttpMethod())
+                .description("Database I/O time per HTTP request")
+                .register(meterRegistry)
+                .record(nanos, TimeUnit.NANOSECONDS);
+
+        Counter.builder("http.db.query.count")
+                .tag("uri", context.getEndpoint())
+                .tag("method", context.getHttpMethod())
+                .description("Number of database queries per HTTP request")
+                .register(meterRegistry)
+                .increment(totalQueries);
+
+        log.debug("Recorded metrics - {} {} - {}ms, {} queries",
+                context.getHttpMethod(),
+                context.getEndpoint(),
+                nanos / 1_000_000.0,
+                totalQueries);
+    }
+}

--- a/src/main/java/com/example/medicare_call/global/metrics/RequestMetricsContext.java
+++ b/src/main/java/com/example/medicare_call/global/metrics/RequestMetricsContext.java
@@ -11,9 +11,9 @@ public class RequestMetricsContext {
         this.httpMethod = httpMethod;
     }
 
-    public void addDbTime(long nanos) {
+    public void addQueryMetrics(long nanos, int queries) {
         dbElapsedTimeNanos += nanos;
-        queryCount++;
+        queryCount += queries;
     }
 
     public long getDbElapsedTimeNanos() { return dbElapsedTimeNanos; }

--- a/src/main/java/com/example/medicare_call/global/metrics/RequestMetricsContext.java
+++ b/src/main/java/com/example/medicare_call/global/metrics/RequestMetricsContext.java
@@ -1,0 +1,23 @@
+package com.example.medicare_call.global.metrics;
+
+public class RequestMetricsContext {
+    private final String endpoint;
+    private final String httpMethod;
+    private long dbElapsedTimeNanos = 0;
+    private int queryCount = 0;
+
+    public RequestMetricsContext(String endpoint, String httpMethod) {
+        this.endpoint = endpoint;
+        this.httpMethod = httpMethod;
+    }
+
+    public void addDbTime(long nanos) {
+        dbElapsedTimeNanos += nanos;
+        queryCount++;
+    }
+
+    public long getDbElapsedTimeNanos() { return dbElapsedTimeNanos; }
+    public int getQueryCount() { return queryCount; }
+    public String getEndpoint() { return endpoint; }
+    public String getHttpMethod() { return httpMethod; }
+}

--- a/src/main/java/com/example/medicare_call/global/metrics/RequestMetricsHolder.java
+++ b/src/main/java/com/example/medicare_call/global/metrics/RequestMetricsHolder.java
@@ -1,0 +1,9 @@
+package com.example.medicare_call.global.metrics;
+
+public class RequestMetricsHolder {
+    private static final ThreadLocal<RequestMetricsContext> contextHolder = new ThreadLocal<>();
+
+    public static void set(RequestMetricsContext context) { contextHolder.set(context); }
+    public static RequestMetricsContext get() { return contextHolder.get(); }
+    public static void clear() { contextHolder.remove(); }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,6 +88,12 @@ management:
       enabled: true
   server:
     prometheus-allowed-ips: 0.0.0.0/0 # 로컬이니 열어두긴 했는데 compose 네트워크 대역만 허용해도 상관없습니다
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.db.io.time: true
+      percentiles:
+        http.db.io.time: 0.5,0.95,0.99
 
 ---
 spring:
@@ -169,3 +175,9 @@ management:
       enabled: true
   server:
     prometheus-allowed-ips: ${MONITORING_SERVER_HOST}
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.db.io.time: true
+      percentiles:
+        http.db.io.time: 0.5,0.95,0.99

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,8 +10,7 @@ jwt:
 
 app:
   datasource-proxy:
-    exclude:
-      - exampleDataSourceName   # 제외할 DataSource 이름
+    exclude: [] # 제외할 DataSource 이름
 
 ---
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,11 @@ jwt:
   phoneTokenExpiration: ${JWT_PHONE_EXPIRATION}
   refreshTokenExpirationDays: ${JWT_REFRESH_EXPIRATION_DAYS}
 
+app:
+  datasource-proxy:
+    exclude:
+      - exampleDataSourceName   # 제외할 DataSource 이름
+
 ---
 spring:
   config:


### PR DESCRIPTION
### Desc
  - HTTP 요청별 DB I/O 시간과 쿼리 개수를 측정하는 메트릭 시스템 구현
  - AOP 기반 컨트롤러 메트릭 수집 및 ThreadLocal 기반 메트릭 컨텍스트 관리
  - Micrometer와 연동하여 Prometheus 메트릭으로 DB 성능 지표 수집
  - 히스토그램 분포 및 백분위수(P50, P95, P99) 메트릭 설정 추가
  - DataSource Proxy를 활용한 쿼리 실행 감지 및 성능 모니터링
  - 500ms 이상 소요되는 slow query 로깅 (단일 쿼리 대상)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 각 요청별 엔드포인트·HTTP 메서드 기준으로 DB I/O 시간과 쿼리 수를 수집해 메트릭으로 기록합니다.
  - Prometheus용 히스토그램과 퍼센타일(50/95/99) 지표를 추가해 지연 분포를 관찰할 수 있습니다.
  - 느린 쿼리 감지 시 경고 로그를 생성합니다.

- 작업(Chores)
  - 모니터링/AOP 및 데이터소스 프록시 관련 런타임 의존성을 추가했습니다.
  - 데이터소스 프록시 설정 및 제외 리스트와 로컬 Hikari 커넥션 풀 설정을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->