### PR TITLE
feat: 에러 공통 응답

### DIFF
--- a/src/main/java/com/example/medicare_call/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/medicare_call/global/GlobalExceptionHandler.java
@@ -51,8 +51,7 @@ public class GlobalExceptionHandler {
         String message = String.format("Invalid value '%s' for parameter '%s'.", value, fieldName);
 
         ErrorResponse response = ErrorResponse.builder()
-                .status(ErrorCode.INVALID_TYPE_VALUE.getStatus().value())
-                .code(ErrorCode.INVALID_TYPE_VALUE.getCode())
+                .code(ErrorCode.INVALID_TYPE_VALUE.name())
                 .message(message)
                 .build();
 
@@ -82,8 +81,7 @@ public class GlobalExceptionHandler {
         
         String message = String.format("필수 파라미터 '%s'가 누락되었습니다.", e.getParameterName());
         ErrorResponse response = ErrorResponse.builder()
-                .status(ErrorCode.MISSING_REQUEST_PARAMETER.getStatus().value())
-                .code(ErrorCode.MISSING_REQUEST_PARAMETER.getCode())
+                .code(ErrorCode.MISSING_REQUEST_PARAMETER.name())
                 .message(message)
                 .build();
         

--- a/src/test/java/com/example/medicare_call/controller/HealthAnalysisControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/HealthAnalysisControllerTest.java
@@ -111,7 +111,8 @@ class HealthAnalysisControllerTest {
                         .param("date", "invalid-date")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("INVALID_TYPE_VALUE"))
                 .andExpect(jsonPath("$.message").value("Invalid value 'invalid-date' for parameter 'date'."));
     }
 } 

--- a/src/test/java/com/example/medicare_call/controller/NaverPayControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/NaverPayControllerTest.java
@@ -106,33 +106,32 @@ class NaverPayControllerTest {
                 .andExpect(jsonPath("$.body.code").value("550e8400-e29b-41d4-a716-446655440000"));
     }
 
-    // TODO: 주문 내역 생성 실패에 대한 예외 처리 추가
-//    @Test
-//    @DisplayName("주문 내역 생성 실패")
-//    void createPaymentReserve_failure() throws Exception {
-//        // given
-//        NaverPayReserveRequest request = NaverPayReserveRequest.builder()
-//                .productName("의료 상담 서비스")
-//                .productCount(1)
-//                .totalPayAmount(10000)
-//                .taxScopeAmount(10000)
-//                .taxExScopeAmount(0)
-//                .elderIds(Arrays.asList(1L))
-//                .build();
-//
-//        when(naverPayService.createPaymentReserve(any(NaverPayReserveRequest.class), any(Long.class)))
-//                .thenThrow(new RuntimeException("주문 내역 생성 중 오류가 발생했습니다."));
-//
-//        // when & then
-//        mockMvc.perform(post("/payments/reserve")
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(objectMapper.writeValueAsString(request)))
-//                .andExpect(status().isInternalServerError())
-//                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-//                .andExpect(jsonPath("$.status").value(500))
-//                .andExpect(jsonPath("$.error").value("서버 오류"))
-//                .andExpect(jsonPath("$.message").value("주문 내역 생성 중 오류가 발생했습니다."));
-//    }
+    @Test
+    @DisplayName("주문 내역 생성 실패")
+    void createPaymentReserve_failure() throws Exception {
+        // given
+        NaverPayReserveRequest request = NaverPayReserveRequest.builder()
+                .productName("의료 상담 서비스")
+                .productCount(1)
+                .totalPayAmount(10000)
+                .taxScopeAmount(10000)
+                .taxExScopeAmount(0)
+                .elderIds(Arrays.asList(1L))
+                .build();
+
+        when(naverPayService.createPaymentReserve(any(NaverPayReserveRequest.class), any(Long.class)))
+                .thenThrow(new CustomException(ErrorCode.NAVER_PAY_API_ERROR)); // RuntimeException 대신 CustomException 사용
+
+        // when & then
+        mockMvc.perform(post("/payments/reserve")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("NAVER_PAY_API_ERROR"))
+                .andExpect(jsonPath("$.message").value("결제 처리 중 오류가 발생했습니다. 다시 시도해 주세요."));
+    }
 
     @Test
     @DisplayName("결제 승인 성공")
@@ -179,7 +178,8 @@ class NaverPayControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isInternalServerError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("NAVER_PAY_API_ERROR"))
                 .andExpect(jsonPath("$.message").value("결제 처리 중 오류가 발생했습니다. 다시 시도해 주세요."));
     }
 }

--- a/src/test/java/com/example/medicare_call/global/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/medicare_call/global/GlobalExceptionHandlerTest.java
@@ -57,8 +57,8 @@ class GlobalExceptionHandlerTest {
 //        // given & when & then
 //        mockMvc.perform(get("/non-existent-endpoint"))
 //                .andExpect(status().isNotFound())
-//                .andExpect(jsonPath("$.code").value("C003"))
-//                .andExpect(jsonPath("$.status").value(404))
+//                .andExpect(jsonPath("$.success").value(false))
+//                .andExpect(jsonPath("$.code").value("NOT_FOUND"))
 //                .andExpect(jsonPath("$.message").value("요청하신 페이지나 기능을 찾을 수 없습니다."));
 //    }
 
@@ -68,8 +68,8 @@ class GlobalExceptionHandlerTest {
         // given & when & then
         mockMvc.perform(get("/test/missing-param"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("C008"))
-                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("MISSING_REQUEST_PARAMETER"))
                 .andExpect(jsonPath("$.message").value("필수 파라미터 'requiredParam'가 누락되었습니다."));
     }
 
@@ -81,8 +81,8 @@ class GlobalExceptionHandlerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{invalid json}"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("C009"))
-                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("INVALID_JSON_FORMAT"))
                 .andExpect(jsonPath("$.message").value("JSON 형식이 올바르지 않습니다. 요청 데이터를 확인해 주세요."));
     }
 
@@ -92,8 +92,8 @@ class GlobalExceptionHandlerTest {
         // given & when & then
         mockMvc.perform(delete("/test/get-only"))
                 .andExpect(status().isMethodNotAllowed())
-                .andExpect(jsonPath("$.code").value("C007"))
-                .andExpect(jsonPath("$.status").value(405))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("METHOD_NOT_ALLOWED"))
                 .andExpect(jsonPath("$.message").value("지원하지 않는 요청 방식입니다. 올바른 방식으로 다시 시도해 주세요."));
     }
 
@@ -105,8 +105,8 @@ class GlobalExceptionHandlerTest {
                         .contentType(MediaType.TEXT_PLAIN)
                         .content("plain text"))
                 .andExpect(status().isUnsupportedMediaType())
-                .andExpect(jsonPath("$.code").value("C010"))
-                .andExpect(jsonPath("$.status").value(415))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("UNSUPPORTED_MEDIA_TYPE"))
                 .andExpect(jsonPath("$.message").value("지원하지 않는 미디어 타입입니다."));
     }
 
@@ -116,8 +116,8 @@ class GlobalExceptionHandlerTest {
         // given & when & then
         mockMvc.perform(get("/test/type-mismatch?id=invalid"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("C005"))
-                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("INVALID_TYPE_VALUE"))
                 .andExpect(jsonPath("$.message").value("Invalid value 'invalid' for parameter 'id'."));
     }
 
@@ -127,8 +127,8 @@ class GlobalExceptionHandlerTest {
         // given & when & then
         mockMvc.perform(get("/test/custom-exception"))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("M001"))
-                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("MEMBER_NOT_FOUND"))
                 .andExpect(jsonPath("$.message").value("존재하지 않는 회원입니다."));
     }
 
@@ -138,8 +138,8 @@ class GlobalExceptionHandlerTest {
         // given & when & then
         mockMvc.perform(get("/test/general-exception"))
                 .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.code").value("C004"))
-                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
                 .andExpect(jsonPath("$.message").value("일시적인 서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."));
     }
 


### PR DESCRIPTION
### Desc
- 에러 타입을 클라이언트 입장에서 구체적으로 알 수 있도록 변경하자
- code필드
  - 서버 내부적으로 사용하는 코드가 아닌, Exception name을 던져서 확인이 쉽도록 변경
- message
  - 에러 상황에 대한 명세
```
{
    "success": false,
    "code": "",
    "message": "",
}
```