### PR TITLE
feat: 어르신 정보 일괄 등록 API 구현

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/ElderController.java
+++ b/src/main/java/com/example/medicare_call/controller/ElderController.java
@@ -1,12 +1,9 @@
 package com.example.medicare_call.controller;
 
 import com.example.medicare_call.domain.Elder;
-import com.example.medicare_call.dto.ElderResponse;
-import com.example.medicare_call.dto.ElderUpdateRequest;
+import com.example.medicare_call.dto.*;
 import com.example.medicare_call.global.annotation.AuthUser;
 import com.example.medicare_call.service.ElderService;
-import com.example.medicare_call.dto.ElderRegisterRequest;
-import com.example.medicare_call.dto.ElderRegisterResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -86,5 +83,19 @@ public class ElderController {
         log.info("어르신 설정 정보 삭제 요청: memberId={}, elderId={}", memberId, elderId);
         elderService.deleteElder(memberId.intValue(), elderId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(
+            summary = "어르신 정보 일괄 등록",
+            description = "여러 어르신의 기본 정보와 건강 정보를 일괄로 등록합니다."
+    )
+    @PostMapping("/bulk")
+    public ResponseEntity<ElderBulkResponse> bulkRegisterElders(
+            @Parameter(hidden = true) @AuthUser Long memberId,
+            @Valid @RequestBody List<ElderBulkRequest> requests
+    ){
+        log.info("어르신 정보 일괄 등록 요청: memberId={}, 요청 건수={}", memberId, requests.size());
+        ElderBulkResponse response = elderService.bulkRegisterElders(memberId.intValue(), requests);
+        return ResponseEntity.ok(response);
     }
 } 

--- a/src/main/java/com/example/medicare_call/dto/ElderBulkRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/ElderBulkRequest.java
@@ -1,0 +1,26 @@
+package com.example.medicare_call.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "어르신 정보와 건강 정보를 포함한 일괄 등록 요청")
+public class ElderBulkRequest {
+
+    @Schema(description = "어르신 기본 정보")
+    @NotNull(message = "어르신 정보는 필수입니다.")
+    @Valid
+    private ElderRegisterRequest elder;
+
+    @Schema(description = "어르신 건강 정보")
+    @Valid
+    private ElderHealthInfoCreateRequest healthInfo;
+}

--- a/src/main/java/com/example/medicare_call/dto/ElderBulkResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/ElderBulkResponse.java
@@ -1,0 +1,37 @@
+package com.example.medicare_call.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "Bulk 처리 응답")
+public class ElderBulkResponse {
+
+    @Schema(description = "전체 처리된 어르신 수", example = "10")
+    private int totalCount;
+
+    @Schema(description = "성공한 어르신들의 정보")
+    private List<ElderResult> successResults;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "성공한 어르신 정보")
+    public static class ElderResult {
+
+        @Schema(description = "어르신 ID", example = "1")
+        private Integer elderId;
+
+        @Schema(description = "어르신 이름", example = "홍길동")
+        private String elderName;
+    }
+}


### PR DESCRIPTION
### Desc
- POST /elders/bulk 엔드포인트 추가로 여러 어르신을 한 번에 등록
- All-or-Nothing 트랜잭션 방식으로 데이터 일관성 보장
- ElderBulkRequest/Response DTO를 기존 스펙 재사용하여 구현
### Considerations
- IDENTITY 방식의 ID 생성 전략으로 인해 Hibernate Batch 설정이 적용되지 않아 개별 INSERT 쿼리가 실행됩니다. 
- Elder 도메인 특성상 대량 등록이 드물어 별도 Bulk 쿼리(JdbcTemplate 등)로 구현하지 않았습니다.