### PR TITLE
feat: 어르신 정보 일괄 등록 API 구현 v2

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/ElderController.java
+++ b/src/main/java/com/example/medicare_call/controller/ElderController.java
@@ -7,6 +7,7 @@ import com.example.medicare_call.global.annotation.AuthUser;
 import com.example.medicare_call.service.ElderService;
 import com.example.medicare_call.dto.ElderRegisterRequest;
 import com.example.medicare_call.dto.ElderRegisterResponse;
+import com.example.medicare_call.dto.BulkElderRegisterRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -86,5 +87,19 @@ public class ElderController {
         log.info("어르신 설정 정보 삭제 요청: memberId={}, elderId={}", memberId, elderId);
         elderService.deleteElder(memberId.intValue(), elderId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(
+            summary = "어르신 정보 일괄 등록",
+            description = "여러 어르신의 기본 정보를 일괄로 등록합니다."
+    )
+    @PostMapping("/bulk")
+    public ResponseEntity<List<ElderRegisterResponse>> bulkRegisterElders(
+            @Parameter(hidden = true) @AuthUser Long memberId,
+            @Valid @RequestBody BulkElderRegisterRequest requestList
+    ){
+        log.info("어르신 정보 일괄 등록 요청: memberId={}, 요청 건수={}", memberId, requestList.getElders().size());
+        List<ElderRegisterResponse> responses = elderService.bulkRegisterElders(memberId.intValue(), requestList.getElders());
+        return ResponseEntity.ok(responses);
     }
 } 

--- a/src/main/java/com/example/medicare_call/controller/ElderHealthInfoController.java
+++ b/src/main/java/com/example/medicare_call/controller/ElderHealthInfoController.java
@@ -1,14 +1,16 @@
 package com.example.medicare_call.controller;
 
+import com.example.medicare_call.dto.BulkElderHealthInfoCreateRequest;
+import com.example.medicare_call.dto.ElderHealthInfoCreateRequest;
 import com.example.medicare_call.dto.ElderHealthInfoResponse;
 import com.example.medicare_call.global.annotation.AuthUser;
-import com.example.medicare_call.dto.ElderHealthInfoCreateRequest;
 import com.example.medicare_call.service.report.ElderHealthInfoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @Tag(name = "ElderHealthInfo", description = "어르신 건강정보(질환, 복약주기, 특이사항) 등록 API")
+@Slf4j
 @RestController
 @RequestMapping("/elders")
 @RequiredArgsConstructor
@@ -33,5 +36,19 @@ public class ElderHealthInfoController {
     @GetMapping("/health-info")
     public ResponseEntity<List<ElderHealthInfoResponse>> getElderHealthInfo(@Parameter(hidden = true) @AuthUser Long memberId) {
         return ResponseEntity.ok(elderHealthInfoService.getElderHealth(memberId.intValue()));
+    }
+
+    @Operation(
+            summary = "어르신 건강정보 일괄 등록",
+            description = "여러 어르신의 건강정보(질환, 복약주기, 특이사항)를 일괄로 등록 및 수정합니다."
+    )
+    @PostMapping("/health-info/bulk")
+    public ResponseEntity<Void> bulkUpsertElderHealthInfo(
+            @Parameter(hidden = true) @AuthUser Long memberId,
+            @Valid @RequestBody BulkElderHealthInfoCreateRequest requestList
+    ){
+        log.info("어르신 건강정보 일괄 등록 요청: memberId={}, 요청 건수={}", memberId, requestList.getHealthInfos().size());
+        elderHealthInfoService.bulkUpsertElderHealthInfo(memberId.intValue(), requestList.getHealthInfos());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/com/example/medicare_call/dto/BulkElderHealthInfoCreateRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/BulkElderHealthInfoCreateRequest.java
@@ -1,0 +1,24 @@
+package com.example.medicare_call.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "어르신 건강정보 일괄 생성 요청")
+public class BulkElderHealthInfoCreateRequest {
+
+    @NotEmpty(message = "어르신 건강정보 목록은 비어있을 수 없습니다")
+    @Schema(description = "어르신 건강정보 일괄 생성 목록", required = true)
+    private List<@Valid @NotNull ElderHealthInfoCreateRequestWithElderId> healthInfos;
+}

--- a/src/main/java/com/example/medicare_call/dto/BulkElderRegisterRequest.java
+++ b/src/main/java/com/example/medicare_call/dto/BulkElderRegisterRequest.java
@@ -1,0 +1,24 @@
+package com.example.medicare_call.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "어르신 일괄 등록 요청")
+public class BulkElderRegisterRequest {
+
+    @NotEmpty(message = "어르신 목록은 비어있을 수 없습니다")
+    @Schema(description = "어르신 일괄 등록 목록", required = true)
+    private List<@Valid @NotNull ElderRegisterRequest> elders;
+}

--- a/src/main/java/com/example/medicare_call/dto/ElderHealthInfoCreateRequestWithElderId.java
+++ b/src/main/java/com/example/medicare_call/dto/ElderHealthInfoCreateRequestWithElderId.java
@@ -1,0 +1,46 @@
+package com.example.medicare_call.dto;
+
+import com.example.medicare_call.global.enums.ElderHealthNoteType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "어르신 건강 정보 생성 요청 (elderId 포함)")
+public class ElderHealthInfoCreateRequestWithElderId {
+
+    @NotNull(message = "어르신 ID는 필수입니다")
+    @Schema(description = "어르신 ID", example = "1")
+    private Integer elderId;
+
+    @Schema(description = "질병명 목록", example = "[\"당뇨병\", \"고혈압\"]")
+    private List<String> diseaseNames;
+
+    @Schema(description = "복약 스케줄 목록")
+    private List<ElderHealthInfoCreateRequest.MedicationScheduleRequest> medicationSchedules;
+
+    @Schema(
+        description = "특이사항(여러 개 선택 가능)\n" +
+            "INSOMNIA: 불면증 / 수면장애\n" +
+            "FORGET_MEDICATION: 약 자주 잊음\n" +
+            "WALKING_DIFFICULTY: 보행 불편\n" +
+            "HEARING_LOSS: 청력 저하\n" +
+            "COGNITIVE_DECLINE: 인지저하 의심\n" +
+            "MOOD_SWINGS: 감정기복\n" +
+            "RECENT_SPOUSE_DEATH: 최근 배우자 사망\n" +
+            "SMOKING: 흡연\n" +
+            "DRINKING: 음주\n" +
+            "ALCOHOL_ADDICTION: 알콜중독\n" +
+            "VISUAL_IMPAIRMENT: 시각장애",
+        example = "[\"INSOMNIA\", \"FORGET_MEDICATION\"]"
+    )
+    private List<ElderHealthNoteType> notes;
+}

--- a/src/main/java/com/example/medicare_call/service/report/ElderHealthInfoService.java
+++ b/src/main/java/com/example/medicare_call/service/report/ElderHealthInfoService.java
@@ -2,6 +2,7 @@ package com.example.medicare_call.service.report;
 
 import com.example.medicare_call.domain.*;
 import com.example.medicare_call.dto.ElderHealthInfoCreateRequest;
+import com.example.medicare_call.dto.ElderHealthInfoCreateRequestWithElderId;
 import com.example.medicare_call.dto.ElderHealthInfoResponse;
 import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import com.example.medicare_call.global.exception.CustomException;
@@ -98,6 +99,31 @@ public class ElderHealthInfoService {
             elderHealthInfoRepository.deleteAllByElder(elder);
         }
     }
+
+    @Transactional
+    public void bulkUpsertElderHealthInfo(Integer memberId, List<ElderHealthInfoCreateRequestWithElderId> requests) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        for (ElderHealthInfoCreateRequestWithElderId request : requests) {
+            // elderId 유효성 검증 및 해당 어르신이 요청자의 어르신인지 확인
+            Elder elder = elderRepository.findById(request.getElderId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.ELDER_NOT_FOUND));
+
+            if (!elder.getGuardian().getId().equals(memberId)) {
+                throw new CustomException(ErrorCode.HANDLE_ACCESS_DENIED);
+            }
+
+            ElderHealthInfoCreateRequest elderHealthInfoRequest = ElderHealthInfoCreateRequest.builder()
+                    .diseaseNames(request.getDiseaseNames())
+                    .medicationSchedules(request.getMedicationSchedules())
+                    .notes(request.getNotes())
+                    .build();
+
+            upsertElderHealthInfo(request.getElderId(), elderHealthInfoRequest);
+        }
+    }
+
     public List<ElderHealthInfoResponse> getElderHealth(Integer memberId){
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/test/java/com/example/medicare_call/controller/ElderControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/ElderControllerTest.java
@@ -2,6 +2,8 @@ package com.example.medicare_call.controller;
 
 import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.dto.ElderRegisterRequest;
+import com.example.medicare_call.dto.ElderRegisterResponse;
+import com.example.medicare_call.dto.BulkElderRegisterRequest;
 import com.example.medicare_call.global.enums.ElderRelation;
 import com.example.medicare_call.global.enums.ResidenceType;
 import com.example.medicare_call.global.enums.Gender;
@@ -28,6 +30,7 @@ import com.example.medicare_call.global.GlobalExceptionHandler;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -53,6 +56,10 @@ class ElderControllerTest {
     @MockBean
     private JwtProvider jwtProvider;
 
+    private Member testMember;
+    private ElderRegisterRequest testElderRequest1;
+    private ElderRegisterRequest testElderRequest2;
+
     private static class TestAuthUserArgumentResolver implements HandlerMethodArgumentResolver {
         @Override
         public boolean supportsParameter(org.springframework.core.MethodParameter parameter) {
@@ -75,50 +82,58 @@ class ElderControllerTest {
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .setCustomArgumentResolvers(new TestAuthUserArgumentResolver())
                 .build();
-        Member member = Member.builder()
-            .name("테스트보호자")
-            .phone("01000000000")
-            .gender((byte)1)
-            .termsAgreedAt(LocalDateTime.now())
-            .plan((byte)1)
-            .build();
-        when(memberRepository.findById(1)).thenReturn(Optional.of(member));
+
+        testMember = Member.builder()
+                .id(1)
+                .name("테스트보호자")
+                .phone("01000000000")
+                .gender((byte)1)
+                .termsAgreedAt(LocalDateTime.now())
+                .plan((byte)1)
+                .build();
+
+        testElderRequest1 = new ElderRegisterRequest();
+        testElderRequest1.setName("홍길동");
+        testElderRequest1.setBirthDate(java.time.LocalDate.of(1940, 5, 1));
+        testElderRequest1.setGender(Gender.MALE);
+        testElderRequest1.setPhone("01012345678");
+        testElderRequest1.setRelationship(ElderRelation.GRANDCHILD);
+        testElderRequest1.setResidenceType(ResidenceType.ALONE);
+
+        testElderRequest2 = new ElderRegisterRequest();
+        testElderRequest2.setName("김영희");
+        testElderRequest2.setBirthDate(java.time.LocalDate.of(1945, 3, 15));
+        testElderRequest2.setGender(Gender.FEMALE);
+        testElderRequest2.setPhone("01098765432");
+        testElderRequest2.setRelationship(ElderRelation.CHILD);
+        testElderRequest2.setResidenceType(ResidenceType.WITH_FAMILY);
+
+        when(memberRepository.findById(1)).thenReturn(Optional.of(testMember));
+    }
+
+    private byte convertGenderToByte(Gender gender) {
+        return (byte) (gender == Gender.MALE ? 0 : 1);
     }
 
     @Test
     @DisplayName("어르신 등록 성공")
     void registerElder_success() throws Exception {
-        ElderRegisterRequest req = new ElderRegisterRequest();
-        req.setName("홍길동");
-        req.setBirthDate(java.time.LocalDate.of(1940, 5, 1));
-        req.setGender(Gender.MALE);
-        req.setPhone("01012345678");
-        req.setRelationship(ElderRelation.GRANDCHILD);
-        req.setResidenceType(ResidenceType.ALONE);
-
         when(elderService.registerElder(any(Integer.class), any(ElderRegisterRequest.class))).thenReturn(
             Elder.builder()
                     .id(1)
-                    .name("홍길동")
-                    .birthDate(java.time.LocalDate.of(1940, 5, 1))
-                    .gender((byte)0)
-                    .phone("01012345678")
-                    .relationship(ElderRelation.GRANDCHILD)
-                    .residenceType(ResidenceType.ALONE)
-                    .guardian(Member.builder()
-                        .id(1)
-                        .name("테스트보호자")
-                        .phone("01000000000")
-                        .gender((byte)1)
-                        .termsAgreedAt(LocalDateTime.now())
-                        .plan((byte)1)
-                        .build())
+                    .name(testElderRequest1.getName())
+                    .birthDate(testElderRequest1.getBirthDate())
+                    .gender(convertGenderToByte(testElderRequest1.getGender()))
+                    .phone(testElderRequest1.getPhone())
+                    .relationship(testElderRequest1.getRelationship())
+                    .residenceType(testElderRequest1.getResidenceType())
+                    .guardian(testMember)
                     .build()
         );
 
         mockMvc.perform(post("/elders")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(req)))
+                .content(objectMapper.writeValueAsString(testElderRequest1)))
                 .andExpect(status().isOk());
     }
 
@@ -136,6 +151,91 @@ class ElderControllerTest {
         mockMvc.perform(post("/elders")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("어르신 정보 일괄 등록 성공")
+    void bulkRegisterElders_success() throws Exception {
+        // given
+        BulkElderRegisterRequest bulkRequest = BulkElderRegisterRequest.builder()
+                .elders(List.of(testElderRequest1, testElderRequest2))
+                .build();
+
+        List<ElderRegisterResponse> expectedResponses = List.of(
+                ElderRegisterResponse.builder()
+                        .id(1)
+                        .name(testElderRequest1.getName())
+                        .birthDate(testElderRequest1.getBirthDate())
+                        .phone(testElderRequest1.getPhone())
+                        .gender("MALE")
+                        .relationship(testElderRequest1.getRelationship().name())
+                        .residenceType(testElderRequest1.getResidenceType().name())
+                        .guardianId(testMember.getId())
+                        .guardianName(testMember.getName())
+                        .build(),
+                ElderRegisterResponse.builder()
+                        .id(2)
+                        .name(testElderRequest2.getName())
+                        .birthDate(testElderRequest2.getBirthDate())
+                        .phone(testElderRequest2.getPhone())
+                        .gender("FEMALE")
+                        .relationship(testElderRequest2.getRelationship().name())
+                        .residenceType(testElderRequest2.getResidenceType().name())
+                        .guardianId(testMember.getId())
+                        .guardianName(testMember.getName())
+                        .build()
+        );
+
+        when(elderService.bulkRegisterElders(any(Integer.class), any(List.class)))
+                .thenReturn(expectedResponses);
+
+        // when & then
+        mockMvc.perform(post("/elders/bulk")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(bulkRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].name").value("홍길동"))
+                .andExpect(jsonPath("$[1].name").value("김영희"));
+    }
+
+    @Test
+    @DisplayName("어르신 정보 일괄 등록 실패 - 빈 리스트")
+    void bulkRegisterElders_fail_emptyList() throws Exception {
+        // given
+        BulkElderRegisterRequest emptyRequest = BulkElderRegisterRequest.builder()
+                .elders(List.of())
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/elders/bulk")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(emptyRequest)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("어르신 정보 일괄 등록 실패 - 필수값 누락")
+    void bulkRegisterElders_fail_validation() throws Exception {
+        // given
+        ElderRegisterRequest invalidRequest = new ElderRegisterRequest();
+        invalidRequest.setName(""); // name 누락
+        invalidRequest.setBirthDate(java.time.LocalDate.of(1940, 5, 1));
+        invalidRequest.setGender(Gender.MALE);
+        invalidRequest.setPhone("01012345678");
+        invalidRequest.setRelationship(ElderRelation.GRANDCHILD);
+        invalidRequest.setResidenceType(ResidenceType.ALONE);
+
+        BulkElderRegisterRequest bulkRequest = BulkElderRegisterRequest.builder()
+                .elders(List.of(invalidRequest))
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/elders/bulk")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(bulkRequest)))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/example/medicare_call/controller/ElderHealthInfoControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/ElderHealthInfoControllerTest.java
@@ -1,12 +1,16 @@
 package com.example.medicare_call.controller;
 
 import com.example.medicare_call.dto.ElderHealthInfoCreateRequest;
+import com.example.medicare_call.dto.ElderHealthInfoCreateRequestWithElderId;
+import com.example.medicare_call.dto.BulkElderHealthInfoCreateRequest;
 import com.example.medicare_call.global.enums.ElderHealthNoteType;
 import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import com.example.medicare_call.global.jwt.JwtProvider;
 import com.example.medicare_call.service.carecall.CareCallSettingService;
 import com.example.medicare_call.service.report.ElderHealthInfoService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -14,6 +18,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import com.example.medicare_call.global.annotation.AuthUser;
+import com.example.medicare_call.global.GlobalExceptionHandler;
 
 import java.util.List;
 
@@ -23,12 +32,36 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(ElderHealthInfoController.class)
 @AutoConfigureMockMvc(addFilters = false)
 class ElderHealthInfoControllerTest {
-    @Autowired MockMvc mockMvc;
+    private MockMvc mockMvc;
     @MockBean ElderHealthInfoService elderHealthInfoService;
     @Autowired ObjectMapper objectMapper;
     @MockBean private JwtProvider jwtProvider;
     @MockBean
     private CareCallSettingService careCallSettingService;
+
+    private static class TestAuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+        @Override
+        public boolean supportsParameter(org.springframework.core.MethodParameter parameter) {
+            return parameter.hasParameterAnnotation(AuthUser.class);
+        }
+
+        @Override
+        public Object resolveArgument(org.springframework.core.MethodParameter parameter,
+                                      org.springframework.web.method.support.ModelAndViewContainer mavContainer,
+                                      org.springframework.web.context.request.NativeWebRequest webRequest,
+                                      org.springframework.web.bind.support.WebDataBinderFactory binderFactory) {
+            return 1L; // 테스트용 고정 memberId
+        }
+    }
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new ElderHealthInfoController(elderHealthInfoService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new TestAuthUserArgumentResolver())
+                .build();
+    }
 
     @Test
     void registerElderHealthInfo_success() throws Exception {
@@ -46,5 +79,79 @@ class ElderHealthInfoControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("어르신 건강정보 일괄 등록 성공")
+    void bulkUpsertElderHealthInfo_success() throws Exception {
+        // given
+        ElderHealthInfoCreateRequest.MedicationScheduleRequest msReq1 = ElderHealthInfoCreateRequest.MedicationScheduleRequest.builder()
+                .medicationName("고혈압약")
+                .scheduleTimes(List.of("MORNING", "DINNER"))
+                .build();
+
+        ElderHealthInfoCreateRequest.MedicationScheduleRequest msReq2 = ElderHealthInfoCreateRequest.MedicationScheduleRequest.builder()
+                .medicationName("당뇨약")
+                .scheduleTimes(List.of("MORNING"))
+                .build();
+
+        ElderHealthInfoCreateRequestWithElderId request1 = ElderHealthInfoCreateRequestWithElderId.builder()
+                .elderId(1)
+                .diseaseNames(List.of("고혈압"))
+                .medicationSchedules(List.of(msReq1))
+                .notes(List.of(ElderHealthNoteType.FORGET_MEDICATION))
+                .build();
+
+        ElderHealthInfoCreateRequestWithElderId request2 = ElderHealthInfoCreateRequestWithElderId.builder()
+                .elderId(2)
+                .diseaseNames(List.of("당뇨병"))
+                .medicationSchedules(List.of(msReq2))
+                .notes(List.of(ElderHealthNoteType.INSOMNIA))
+                .build();
+
+        BulkElderHealthInfoCreateRequest requestList = BulkElderHealthInfoCreateRequest.builder()
+                .healthInfos(List.of(request1, request2))
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/elders/health-info/bulk")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestList)))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("어르신 건강정보 일괄 등록 실패 - 빈 리스트")
+    void bulkUpsertElderHealthInfo_fail_emptyList() throws Exception {
+        // given
+        BulkElderHealthInfoCreateRequest emptyRequestList = BulkElderHealthInfoCreateRequest.builder()
+                .healthInfos(List.of())
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/elders/health-info/bulk")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(emptyRequestList)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("어르신 건강정보 일괄 등록 실패 - elderId가 null인 경우")
+    void bulkUpsertElderHealthInfo_fail_nullElderId() throws Exception {
+        // given
+        ElderHealthInfoCreateRequestWithElderId request = ElderHealthInfoCreateRequestWithElderId.builder()
+                .elderId(null)
+                .diseaseNames(List.of("당뇨병"))
+                .build();
+
+        BulkElderHealthInfoCreateRequest requestList = BulkElderHealthInfoCreateRequest.builder()
+                .healthInfos(List.of(request))
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/elders/health-info/bulk")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestList)))
+                .andExpect(status().isBadRequest());
     }
 } 

--- a/src/test/java/com/example/medicare_call/global/annotation/ValidationTest.java
+++ b/src/test/java/com/example/medicare_call/global/annotation/ValidationTest.java
@@ -1,9 +1,12 @@
 package com.example.medicare_call.global.annotation;
 
 import com.example.medicare_call.dto.ElderRegisterRequest;
+import com.example.medicare_call.dto.ElderHealthInfoCreateRequest;
+import com.example.medicare_call.dto.ElderHealthInfoCreateRequestWithElderId;
 import com.example.medicare_call.global.enums.ElderRelation;
 import com.example.medicare_call.global.enums.Gender;
 import com.example.medicare_call.global.enums.ResidenceType;
+import com.example.medicare_call.global.enums.ElderHealthNoteType;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -14,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.util.Set;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -151,9 +155,29 @@ class ValidationTest {
 
         // then
         assertThat(violations).isNotEmpty();
-        assertThat(violations).anyMatch(violation -> 
+        assertThat(violations).anyMatch(violation ->
             violation.getPropertyPath().toString().equals("phone") &&
             violation.getMessage().contains("휴대폰 번호가 유효하지 않습니다")
+        );
+    }
+
+    @Test
+    @DisplayName("elderId가 null이면 Validation에 실패한다")
+    void nullElderId_failsValidation() {
+        // given
+        ElderHealthInfoCreateRequestWithElderId request = ElderHealthInfoCreateRequestWithElderId.builder()
+                .elderId(null) // null elderId
+                .diseaseNames(List.of("당뇨병"))
+                .build();
+
+        // when
+        Set<ConstraintViolation<ElderHealthInfoCreateRequestWithElderId>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isNotEmpty();
+        assertThat(violations).anyMatch(violation ->
+            violation.getPropertyPath().toString().equals("elderId") &&
+            violation.getMessage().contains("어르신 ID는 필수입니다")
         );
     }
 } 

--- a/src/test/java/com/example/medicare_call/service/ElderServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/ElderServiceTest.java
@@ -2,6 +2,7 @@ package com.example.medicare_call.service;
 
 import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.dto.ElderRegisterRequest;
+import com.example.medicare_call.dto.ElderRegisterResponse;
 import com.example.medicare_call.global.enums.ElderRelation;
 import com.example.medicare_call.global.enums.ElderStatus;
 import com.example.medicare_call.global.enums.ResidenceType;
@@ -12,6 +13,7 @@ import com.example.medicare_call.domain.Member;
 import com.example.medicare_call.dto.ElderUpdateRequest;
 import com.example.medicare_call.global.exception.CustomException;
 import com.example.medicare_call.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -22,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,33 +43,66 @@ class ElderServiceTest {
     @InjectMocks
     private ElderService elderService;
 
+    private Member testMember;
+    private ElderRegisterRequest testElderRequest1;
+    private ElderRegisterRequest testElderRequest2;
+
+    @BeforeEach
+    void setUp() {
+        testMember = Member.builder()
+                .id(1)
+                .name("테스트보호자")
+                .phone("01000000000")
+                .gender((byte)1)
+                .termsAgreedAt(LocalDateTime.now())
+                .plan((byte)1)
+                .build();
+
+        testElderRequest1 = new ElderRegisterRequest();
+        testElderRequest1.setName("홍길동");
+        testElderRequest1.setBirthDate(LocalDate.of(1940, 5, 1));
+        testElderRequest1.setGender(Gender.MALE);
+        testElderRequest1.setPhone("01012345678");
+        testElderRequest1.setRelationship(ElderRelation.GRANDCHILD);
+        testElderRequest1.setResidenceType(ResidenceType.ALONE);
+
+        testElderRequest2 = new ElderRegisterRequest();
+        testElderRequest2.setName("김영희");
+        testElderRequest2.setBirthDate(LocalDate.of(1945, 3, 15));
+        testElderRequest2.setGender(Gender.FEMALE);
+        testElderRequest2.setPhone("01098765432");
+        testElderRequest2.setRelationship(ElderRelation.CHILD);
+        testElderRequest2.setResidenceType(ResidenceType.WITH_FAMILY);
+    }
+
+    private byte convertGenderToByte(Gender gender) {
+        return (byte) (gender == Gender.MALE ? 0 : 1);
+    }
+
+    private Elder createElderFromRequest(Integer id, ElderRegisterRequest request, Member guardian) {
+        return Elder.builder()
+                .id(id)
+                .name(request.getName())
+                .birthDate(request.getBirthDate())
+                .gender(convertGenderToByte(request.getGender()))
+                .phone(request.getPhone())
+                .relationship(request.getRelationship())
+                .residenceType(request.getResidenceType())
+                .guardian(guardian)
+                .build();
+    }
+
     @Test
     @DisplayName("어르신 등록 성공 - Elder 엔티티 반환")
     void registerElder_success() {
-        Member member = Member.builder()
-            .id(1)
-            .name("테스트보호자")
-            .phone("01000000000")
-            .gender((byte)1)
-            .termsAgreedAt(LocalDateTime.now())
-            .plan((byte)1)
-            .build();
-        when(memberRepository.findById(1)).thenReturn(Optional.of(member));
-
-        ElderRegisterRequest req = new ElderRegisterRequest();
-        req.setName("홍길동");
-        req.setBirthDate(LocalDate.of(1940, 5, 1));
-        req.setGender(Gender.MALE);
-        req.setPhone("01012345678");
-        req.setRelationship(ElderRelation.GRANDCHILD);
-        req.setResidenceType(ResidenceType.ALONE);
+        when(memberRepository.findById(1)).thenReturn(Optional.of(testMember));
 
         Elder saved = Elder.builder()
-            .name(req.getName())
+            .name(testElderRequest1.getName())
             .build();
         when(elderRepository.save(any(Elder.class))).thenReturn(saved);
 
-        Elder result = elderService.registerElder(1, req);
+        Elder result = elderService.registerElder(1, testElderRequest1);
         assertThat(result.getName()).isEqualTo("홍길동");
     }
 
@@ -75,19 +111,11 @@ class ElderServiceTest {
     void registerElder_fail_guardianNotFound() {
         // given
         Integer guardianId = 999;
-        ElderRegisterRequest request = new ElderRegisterRequest();
-        request.setName("홍길동");
-        request.setBirthDate(LocalDate.of(1940, 5, 1));
-        request.setGender(Gender.MALE);
-        request.setPhone("01012345678");
-        request.setRelationship(ElderRelation.GRANDCHILD);
-        request.setResidenceType(ResidenceType.ALONE);
-
         when(memberRepository.findById(guardianId)).thenReturn(Optional.empty());
 
         // when & then
         CustomException exception = assertThrows(CustomException.class, () -> {
-            elderService.registerElder(guardianId, request);
+            elderService.registerElder(guardianId, testElderRequest1);
         });
         assertEquals(ErrorCode.MEMBER_NOT_FOUND, exception.getErrorCode());
     }
@@ -183,4 +211,45 @@ class ElderServiceTest {
         // then
         verify(elderRepository, times(1)).delete(elder);
     }
-} 
+
+    @Test
+    @DisplayName("어르신 일괄 등록 성공")
+    void bulkRegisterElders_success() {
+        // given
+        List<ElderRegisterRequest> requests = List.of(testElderRequest1, testElderRequest2);
+
+        Elder savedElder1 = createElderFromRequest(1, testElderRequest1, testMember);
+        Elder savedElder2 = createElderFromRequest(2, testElderRequest2, testMember);
+
+        when(memberRepository.findById(1)).thenReturn(Optional.of(testMember));
+        when(elderRepository.saveAll(any(List.class))).thenReturn(List.of(savedElder1, savedElder2));
+
+        // when
+        List<ElderRegisterResponse> responses = elderService.bulkRegisterElders(1, requests);
+
+        // then
+        assertThat(responses).hasSize(2);
+        assertThat(responses.get(0).getName()).isEqualTo("홍길동");
+        assertThat(responses.get(0).getGender()).isEqualTo("MALE");
+        assertThat(responses.get(1).getName()).isEqualTo("김영희");
+        assertThat(responses.get(1).getGender()).isEqualTo("FEMALE");
+        verify(memberRepository, times(1)).findById(1);
+        verify(elderRepository, times(1)).saveAll(any(List.class));
+    }
+
+    @Test
+    @DisplayName("어르신 일괄 등록 실패 - 보호자를 찾을 수 없음")
+    void bulkRegisterElders_fail_guardianNotFound() {
+        // given
+        Integer memberId = 999;
+        List<ElderRegisterRequest> requests = List.of(testElderRequest1);
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            elderService.bulkRegisterElders(memberId, requests);
+        });
+        assertEquals(ErrorCode.MEMBER_NOT_FOUND, exception.getErrorCode());
+    }
+}


### PR DESCRIPTION
### Desc
- POST /elders/bulk: 여러 어르신을 한 번 등록하는 일괄 등록 API 추가
- POST /elders/health-info/bulk: 여러 어신의 건강정보를 한 번에 등록/수정하는 API 추가
- Wrapper DTO로 List validation 문제 해결
- All-or-Nothing 트랜잭션 방식으로 데이터 일관성 보장
- 기존 단건 등록 서비스 로직 재사용으로 코드 중복 최소화
- Controller/Service 계층 테스트 구현 및 리팩토링 진행
### Considerations
- IDENTITY 방식의 ID 생성 전략으로 인해 Hibernate Batch 설정이 적용되지 않아 개별 INSERT 쿼리가 실행됩니다.
- Elder 도메인 특성상 대량 등록이 드물어 별도 Bulk 쿼리(JdbcTemplate 등)로 구현하지 않았습니다.