### PR TITLE
feat: http.server.requests 히스토그램 메트릭 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,6 +112,10 @@ spring:
       on-profile: prod
 
   datasource:
+    hikari:
+      connectionTimeout: '30000'
+      maximum-pool-size: '10'
+      max-lifetime: '1800000'
     url: ${MYSQL_URL}
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}


### PR DESCRIPTION
### Desc
- 전체 응답시간에서 대해서도 quantile 별 확인을 가능하게 하기 위해 http.server.requests 히스토그램 메트릭 추가
- 간단한 추가 사항이라 approve 되면 바로 병합 진행하겠습니다!
- 추가적으로 prod profile에도 HikariCP 커넥션 풀 설정 추가하였습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 로컬 및 프로덕션 프로필에서 HTTP 서버 요청 메트릭 노출이 활성화되었습니다(퍼센타일 0.5/0.95/0.99 및 퍼센타일 히스토그램 포함). 표준 메트릭 엔드포인트에서 해당 지표가 제공됩니다.
- 작업(Chores)
  - 프로덕션 데이터소스에 커넥션 풀 관련 설정이 추가되었습니다(타임아웃·최대풀크기·최대수명).
  - 프로덕션의 기본 URL 설정이 환경 변수 기반 값으로 변경되었습니다.
  - 기존 애플리케이션 동작이나 공개 인터페이스에는 영향이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->