### PR TITLE
fix: 어르신 건강정보 수정 시 보호자 권한 검증 추가

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/ElderHealthInfoController.java
+++ b/src/main/java/com/example/medicare_call/controller/ElderHealthInfoController.java
@@ -27,8 +27,12 @@ public class ElderHealthInfoController {
 
     @Operation(summary = "어르신 건강정보 등록 및 수정", description = "질환, 복약주기, 특이사항을 등록 및 수정합니다.")
     @PostMapping("/{elderId}/health-info")
-    public ResponseEntity<Void> upsertElderHealthInfo(@PathVariable Integer elderId, @Valid @RequestBody ElderHealthInfoCreateRequest request) {
-        elderHealthInfoService.upsertElderHealthInfo(elderId, request);
+    public ResponseEntity<Void> upsertElderHealthInfo(
+            @Parameter(hidden = true) @AuthUser Long memberId,
+            @PathVariable Integer elderId,
+            @Valid @RequestBody ElderHealthInfoCreateRequest request
+    ) {
+        elderHealthInfoService.upsertElderHealthInfo(memberId.intValue(), elderId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 


### PR DESCRIPTION
### Desc
- upsertElderHealthInfo에 memberId 파라미터 추가
- Guardian 소유권 검증 로직 추가
- bulkUpsertElderHealthInfo의 중복 검증 제거
- 권한 없음 처리에 대한 테스트 케이스 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 건강정보 등록/수정 시 보호자 인증 기반 접근 제어를 도입했습니다. 로그인한 회원이 해당 노인의 보호자인 경우에만 처리되며, 비인가 시 접근 거부가 반환됩니다.
  - 일괄 등록 기능에도 동일한 인증 규칙을 적용했습니다.

- Refactor
  - 검증 로직을 중앙화해 중복을 제거하고 처리 흐름의 일관성을 높였습니다.

- Tests
  - 보호자 미일치 시 접근 거부 테스트를 추가하고, 기존 성공/실패 시나리오를 새로운 검증 흐름에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->