### PR TITLE
feat: 홈 화면 API 복약 현황 리스트

### DIFF
--- a/src/main/java/com/example/medicare_call/dto/report/HomeReportResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/report/HomeReportResponse.java
@@ -60,9 +60,6 @@ public class HomeReportResponse {
         @Schema(description = "하루 복약 목표 횟수 총합", example = "5")
         private Integer totalGoal;
 
-        @Schema(description = "다음 복약 예정 시간", example = "LUNCH")
-        private MedicationScheduleTime nextMedicationTime;
-
         @Schema(description = "약 종류별 복약 정보 목록")
         private List<MedicationInfo> medicationList;
     }
@@ -82,6 +79,19 @@ public class HomeReportResponse {
 
         @Schema(description = "해당 약의 다음 복약 예정 시간", example = "LUNCH")
         private MedicationScheduleTime nextTime;
+        @Schema(description = "약 시간대별 복용 상태 목록")
+        private List<DoseStatus> doseStatusList;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "약 시간대별 복용 상태")
+    public static class DoseStatus {
+        @Schema(description = "복약 예정 시간", example = "MORNING")
+        private MedicationScheduleTime time;
+
+        @Schema(description = "복약 여부", example = "true")
+        private Boolean taken;
     }
 
     @Getter

--- a/src/test/java/com/example/medicare_call/controller/HomeControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/HomeControllerTest.java
@@ -14,7 +14,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -50,11 +52,35 @@ class HomeControllerTest {
                 .dinner(false)
                 .build();
 
+        // doseStatusList 생성
+        HomeReportResponse.DoseStatus morningDose = HomeReportResponse.DoseStatus.builder().time(MedicationScheduleTime.MORNING).taken(true).build();
+        HomeReportResponse.DoseStatus lunchDose = HomeReportResponse.DoseStatus.builder().time(MedicationScheduleTime.LUNCH).taken(null).build();
+        HomeReportResponse.DoseStatus dinnerDose = HomeReportResponse.DoseStatus.builder().time(MedicationScheduleTime.DINNER).taken(true).build();
+        List<HomeReportResponse.DoseStatus> doseStatusList1 = Arrays.asList(morningDose, lunchDose, dinnerDose);
+
+        HomeReportResponse.MedicationInfo medicationInfo1 = HomeReportResponse.MedicationInfo.builder()
+                .type("당뇨약")
+                .taken(2)
+                .goal(3)
+                .doseStatusList(doseStatusList1)
+                .build();
+
+        HomeReportResponse.DoseStatus morningDose2 = HomeReportResponse.DoseStatus.builder().time(MedicationScheduleTime.MORNING).taken(true).build();
+        HomeReportResponse.DoseStatus lunchDose2 = HomeReportResponse.DoseStatus.builder().time(MedicationScheduleTime.LUNCH).taken(null).build();
+        HomeReportResponse.DoseStatus dinnerDose2 = HomeReportResponse.DoseStatus.builder().time(MedicationScheduleTime.DINNER).taken(null).build();
+        List<HomeReportResponse.DoseStatus> doseStatusList2 = Arrays.asList(morningDose2, lunchDose2, dinnerDose2);
+
+        HomeReportResponse.MedicationInfo medicationInfo2 = HomeReportResponse.MedicationInfo.builder()
+                .type("혈압약")
+                .taken(1)
+                .goal(3)
+                .doseStatusList(doseStatusList2)
+                .build();
+
         HomeReportResponse.MedicationStatus medicationStatus = HomeReportResponse.MedicationStatus.builder()
-                .totalTaken(2)
-                .totalGoal(3)
-                .nextMedicationTime(MedicationScheduleTime.DINNER)
-                .medicationList(Collections.emptyList())
+                .totalTaken(3) // 2 (당뇨약) + 1 (혈압약)
+                .totalGoal(6)  // 3 (당뇨약) + 3 (혈압약)
+                .medicationList(Arrays.asList(medicationInfo1, medicationInfo2))
                 .build();
 
         HomeReportResponse.Sleep sleep = HomeReportResponse.Sleep.builder()
@@ -88,9 +114,26 @@ class HomeControllerTest {
                 .andExpect(jsonPath("$.mealStatus.breakfast").value(true))
                 .andExpect(jsonPath("$.mealStatus.lunch").value(true))
                 .andExpect(jsonPath("$.mealStatus.dinner").value(false))
-                .andExpect(jsonPath("$.medicationStatus.totalTaken").value(2))
-                .andExpect(jsonPath("$.medicationStatus.totalGoal").value(3))
-                .andExpect(jsonPath("$.medicationStatus.nextMedicationTime").value("DINNER"))
+                .andExpect(jsonPath("$.medicationStatus.totalTaken").value(3))
+                .andExpect(jsonPath("$.medicationStatus.totalGoal").value(6))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[0].type").value("당뇨약"))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[0].taken").value(2))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[0].goal").value(3))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[0].doseStatusList[0].time").value("MORNING"))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[0].doseStatusList[0].taken").value(true))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[0].doseStatusList[1].time").value("LUNCH"))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[0].doseStatusList[1].taken").doesNotExist())
+                .andExpect(jsonPath("$.medicationStatus.medicationList[0].doseStatusList[2].time").value("DINNER"))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[0].doseStatusList[2].taken").value(true))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[1].type").value("혈압약"))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[1].taken").value(1))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[1].goal").value(3))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[1].doseStatusList[0].time").value("MORNING"))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[1].doseStatusList[0].taken").value(true))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[1].doseStatusList[1].time").value("LUNCH"))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[1].doseStatusList[1].taken").doesNotExist())
+                .andExpect(jsonPath("$.medicationStatus.medicationList[1].doseStatusList[2].time").value("DINNER"))
+                .andExpect(jsonPath("$.medicationStatus.medicationList[1].doseStatusList[2].taken").doesNotExist())
                 .andExpect(jsonPath("$.sleep.meanHours").value(7))
                 .andExpect(jsonPath("$.sleep.meanMinutes").value(30))
                 .andExpect(jsonPath("$.healthStatus").value("좋음"))
@@ -113,7 +156,6 @@ class HomeControllerTest {
         HomeReportResponse.MedicationStatus medicationStatus = HomeReportResponse.MedicationStatus.builder()
                 .totalTaken(0)
                 .totalGoal(3)
-                .nextMedicationTime(MedicationScheduleTime.MORNING)
                 .medicationList(Collections.emptyList())
                 .build();
 
@@ -141,7 +183,7 @@ class HomeControllerTest {
                 .andExpect(jsonPath("$.mealStatus.dinner").value(false))
                 .andExpect(jsonPath("$.medicationStatus.totalTaken").value(0))
                 .andExpect(jsonPath("$.medicationStatus.totalGoal").value(3))
-                .andExpect(jsonPath("$.medicationStatus.nextMedicationTime").value("MORNING"))
+                .andExpect(jsonPath("$.medicationStatus.medicationList").isEmpty())
                 .andExpect(jsonPath("$.healthStatus").value("나쁨"))
                 .andExpect(jsonPath("$.mentalStatus").value("나쁨"))
                 .andExpect(jsonPath("$.sleep").doesNotExist())


### PR DESCRIPTION
### Desc
API 요청사항
- nextMedicationTime 필드 제거
- medicationList에 doseStatusList 필드 추가

| **이름** | **타입** | **설명** |
| --- | --- | --- |
| **`doseStatusList`** | array of object | 해당 약의 시간대별 상세 복용 상태 목록 |
| **`┗━━ time`** | enum | 해당 약의 복약시간대(MORNING / LUNCH / DINNER) |
| **`┗━━ taken`** | boolean | (`true`: 복용, `false`: 건너뜀, `null`: 미기록) |

```
"doseStatusList": [
  {
    "time": "MORNING",
    "taken": true
  },
  {
    "time": "LUNCH",
    "taken": null
  },
  {
    "time": "DINNER",
    "taken": null
  }
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 홈 리포트에 약품별 복용 상태를 아침/점심/저녁 단위로 확인할 수 있는 목록이 추가되었습니다. 각 시간대별 복용 여부(예: 복용함/미복용/미지정)가 표시됩니다.
- Refactor
  - “다음 복약 시간” 표시가 제거되어, 약품별 시간대 기반 정보로 통합되었습니다.
- Tests
  - 신규 시간대별 복용 상태에 맞춰 테스트 케이스가 보강되고 기대값이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->