### PR TITLE
feat: 홈 화면/주간 통계 응답 추가 요청 사항 적용

### DIFF
--- a/src/main/java/com/example/medicare_call/controller/HomeController.java
+++ b/src/main/java/com/example/medicare_call/controller/HomeController.java
@@ -1,6 +1,7 @@
 package com.example.medicare_call.controller;
 
 import com.example.medicare_call.dto.report.HomeReportResponse;
+import com.example.medicare_call.global.annotation.AuthUser;
 import com.example.medicare_call.service.report.HomeReportService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -50,12 +51,13 @@ public class HomeController {
     })
     @GetMapping("/{elderId}/home")
     public ResponseEntity<HomeReportResponse> getHomeData(
+        @Parameter(hidden = true) @AuthUser Long memberId,
         @Parameter(description = "조회할 어르신의 식별자", required = true, example = "1")
         @PathVariable("elderId") Integer elderId
     ) {
         log.info("홈 화면 데이터 조회 요청: elderId={}", elderId);
 
-        HomeReportResponse response = homeReportService.getHomeReport(elderId);
+        HomeReportResponse response = homeReportService.getHomeReport(memberId.intValue(), elderId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/example/medicare_call/controller/WeeklyStatsController.java
+++ b/src/main/java/com/example/medicare_call/controller/WeeklyStatsController.java
@@ -1,6 +1,7 @@
 package com.example.medicare_call.controller;
 
 import com.example.medicare_call.dto.report.WeeklyReportResponse;
+import com.example.medicare_call.global.annotation.AuthUser;
 import com.example.medicare_call.service.report.WeeklyReportService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -53,6 +54,7 @@ public class WeeklyStatsController {
     })
     @GetMapping("/{elderId}/weekly-stats")
     public ResponseEntity<WeeklyReportResponse> getWeeklyStats(
+        @Parameter(hidden = true) @AuthUser Long memberId,
         @Parameter(description = "어르신 식별자", required = true, example = "1")
         @PathVariable("elderId") Integer elderId,
 
@@ -61,7 +63,7 @@ public class WeeklyStatsController {
     ) {
         log.info("주간 통계 데이터 조회 요청: elderId={}, startDate={}", elderId, startDate);
 
-        WeeklyReportResponse response = weeklyReportService.getWeeklyReport(elderId, startDate);
+        WeeklyReportResponse response = weeklyReportService.getWeeklyReport(memberId.intValue(), elderId, startDate);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/example/medicare_call/dto/report/HomeReportResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/report/HomeReportResponse.java
@@ -36,6 +36,9 @@ public class HomeReportResponse {
     @Schema(description = "혈당 정보")
     private BloodSugar bloodSugar;
 
+    @Schema(description = "읽지 않은 알림 개수", example = "5")
+    private Integer unreadNotification;
+
     @Getter
     @Builder
     @Schema(description = "식사 여부 상태 정보")

--- a/src/main/java/com/example/medicare_call/dto/report/WeeklyReportResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/report/WeeklyReportResponse.java
@@ -39,6 +39,9 @@ public class WeeklyReportResponse {
     @Schema(description = "회원의 구독 시작 날짜")
     private LocalDate subscriptionStartDate;
 
+    @Schema(description = "읽지 않은 알림 개수", example = "5")
+    private Integer unreadNotification;
+
     @Getter
     @Builder
     @Schema(description = "주간 요약 통계 정보")

--- a/src/main/java/com/example/medicare_call/repository/NotificationRepository.java
+++ b/src/main/java/com/example/medicare_call/repository/NotificationRepository.java
@@ -4,4 +4,6 @@ import com.example.medicare_call.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    int countByMemberIdAndIsReadFalse(Integer memberId);
 }

--- a/src/main/java/com/example/medicare_call/service/notification/NotificationService.java
+++ b/src/main/java/com/example/medicare_call/service/notification/NotificationService.java
@@ -48,4 +48,8 @@ public class NotificationService {
         notification.updateIsRead(isRead);
     }
 
+    @Transactional(readOnly = true)
+    public int getUnreadCount(Integer memberId) {
+        return notificationRepository.countByMemberIdAndIsReadFalse(memberId);
+    }
 }

--- a/src/main/java/com/example/medicare_call/service/report/WeeklyReportService.java
+++ b/src/main/java/com/example/medicare_call/service/report/WeeklyReportService.java
@@ -10,6 +10,7 @@ import com.example.medicare_call.global.exception.ErrorCode;
 import com.example.medicare_call.repository.ElderRepository;
 import com.example.medicare_call.repository.SubscriptionRepository;
 import com.example.medicare_call.repository.WeeklyStatisticsRepository;
+import com.example.medicare_call.service.notification.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,9 +30,10 @@ public class WeeklyReportService {
     private final ElderRepository elderRepository;
     private final WeeklyStatisticsRepository weeklyStatisticsRepository;
     private final SubscriptionRepository subscriptionRepository;
+    private final NotificationService notificationService;
 
     @Transactional(readOnly = true)
-    public WeeklyReportResponse getWeeklyReport(Integer elderId, LocalDate startDate) {
+    public WeeklyReportResponse getWeeklyReport(Integer memberId, Integer elderId, LocalDate startDate) {
         // 구독 정보 조회
         LocalDate subscriptionStartDate = subscriptionRepository.findByElderId(elderId)
                 .map(Subscription::getStartDate)
@@ -48,10 +50,13 @@ public class WeeklyReportService {
         // WeeklyStatistics 조회
         Optional<WeeklyStatistics> weeklyStatsOpt = weeklyStatisticsRepository.findByElderAndStartDate(elder, startDate);
 
+        // 알림 읽지 않은 개수 조회 (빈 응답, 정상 응답 모두 필요하므로 미리 조회)
+        int unreadCount = notificationService.getUnreadCount(memberId);
+
         // 주간 통계 데이터가 없을 때 빈 응답 반환
         if (weeklyStatsOpt.isEmpty()) {
             log.info("주간 통계 데이터가 없어 빈 응답 반환 - elderId: {}, startDate: {}", elderId, startDate);
-            return createEmptyWeeklyReport(elder, subscriptionStartDate);
+            return createEmptyWeeklyReport(elder, subscriptionStartDate, unreadCount);
         }
 
         WeeklyStatistics weeklyStats = weeklyStatsOpt.get();
@@ -96,6 +101,7 @@ public class WeeklyReportService {
                 .psychSummary(psychSummary)
                 .bloodSugar(bloodSugar)
                 .subscriptionStartDate(subscriptionStartDate)
+                .unreadNotification(unreadCount)
                 .build();
     }
     
@@ -152,7 +158,7 @@ public class WeeklyReportService {
                 .build();
     }
 
-    private WeeklyReportResponse createEmptyWeeklyReport(Elder elder, LocalDate subscriptionStartDate) {
+    private WeeklyReportResponse createEmptyWeeklyReport(Elder elder, LocalDate subscriptionStartDate, int unreadCount) {
         return WeeklyReportResponse.builder()
                 .elderName(elder.getName())
                 .summaryStats(null)
@@ -163,6 +169,7 @@ public class WeeklyReportService {
                 .psychSummary(null)
                 .bloodSugar(null)
                 .subscriptionStartDate(subscriptionStartDate)
+                .unreadNotification(unreadCount)
                 .build();
     }
 } 

--- a/src/test/java/com/example/medicare_call/controller/HomeControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/HomeControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.medicare_call.controller;
 
 import com.example.medicare_call.dto.report.HomeReportResponse;
+import com.example.medicare_call.global.annotation.AuthenticationArgumentResolver;
 import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import com.example.medicare_call.global.jwt.JwtProvider;
 import com.example.medicare_call.service.report.HomeReportService;
@@ -8,9 +9,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -18,13 +19,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(HomeController.class)
-@AutoConfigureMockMvc(addFilters = false) // security 필터 비활성화
+@WebMvcTest(controllers = HomeController.class,
+    excludeAutoConfiguration = {org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 class HomeControllerTest {
 
@@ -36,6 +38,9 @@ class HomeControllerTest {
 
     @MockBean
     private JwtProvider jwtProvider;
+
+    @MockBean
+    private AuthenticationArgumentResolver authenticationArgumentResolver;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -103,7 +108,7 @@ class HomeControllerTest {
                 .bloodSugar(bloodSugar)
                 .build();
 
-        when(homeReportService.getHomeReport(eq(elderId)))
+        when(homeReportService.getHomeReport(anyInt(), eq(elderId)))
                 .thenReturn(expectedResponse);
 
         // when & then
@@ -170,7 +175,7 @@ class HomeControllerTest {
                 .bloodSugar(null)
                 .build();
 
-        when(homeReportService.getHomeReport(eq(elderId)))
+        when(homeReportService.getHomeReport(anyInt(), eq(elderId)))
                 .thenReturn(expectedResponse);
 
         // when & then

--- a/src/test/java/com/example/medicare_call/controller/WeeklyStatsControllerTest.java
+++ b/src/test/java/com/example/medicare_call/controller/WeeklyStatsControllerTest.java
@@ -1,15 +1,16 @@
 package com.example.medicare_call.controller;
 
 import com.example.medicare_call.dto.report.WeeklyReportResponse;
+import com.example.medicare_call.global.annotation.AuthenticationArgumentResolver;
 import com.example.medicare_call.global.jwt.JwtProvider;
 import com.example.medicare_call.service.report.WeeklyReportService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -17,13 +18,14 @@ import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(WeeklyStatsController.class)
-@AutoConfigureMockMvc(addFilters = false) // security 필터 비활성화
+@WebMvcTest(controllers = WeeklyStatsController.class,
+    excludeAutoConfiguration = {org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 class WeeklyStatsControllerTest {
 
@@ -35,6 +37,9 @@ class WeeklyStatsControllerTest {
 
     @MockBean
     private JwtProvider jwtProvider;
+
+    @MockBean
+    private AuthenticationArgumentResolver authenticationArgumentResolver;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -108,7 +113,7 @@ class WeeklyStatsControllerTest {
                 .bloodSugar(bloodSugar)
                 .build();
 
-        when(weeklyReportService.getWeeklyReport(eq(elderId), eq(startDate)))
+        when(weeklyReportService.getWeeklyReport(anyInt(), eq(elderId), eq(startDate)))
                 .thenReturn(expectedResponse);
 
         // when & then

--- a/src/test/java/com/example/medicare_call/service/report/HomeReportServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/report/HomeReportServiceTest.java
@@ -3,6 +3,7 @@ package com.example.medicare_call.service.report;
 import com.example.medicare_call.domain.DailyStatistics;
 import com.example.medicare_call.domain.Elder;
 import com.example.medicare_call.domain.MedicationSchedule;
+import com.example.medicare_call.domain.Member;
 import com.example.medicare_call.dto.report.HomeReportResponse;
 import com.example.medicare_call.global.enums.MedicationScheduleTime;
 import com.example.medicare_call.global.exception.CustomException;
@@ -10,6 +11,7 @@ import com.example.medicare_call.global.exception.ErrorCode;
 import com.example.medicare_call.repository.DailyStatisticsRepository;
 import com.example.medicare_call.repository.ElderRepository;
 import com.example.medicare_call.repository.MedicationScheduleRepository;
+import com.example.medicare_call.service.notification.NotificationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,15 +46,28 @@ class HomeReportServiceTest {
     @Mock
     private MedicationScheduleRepository medicationScheduleRepository;
 
+    @Mock
+    private NotificationService notificationService;
+
     @InjectMocks
     private HomeReportService homeReportService;
 
     private Elder testElder;
+    private Member testMember;
+    private Integer testMemberId;
     private LocalDate testDate;
     private LocalDateTime testDateTime;
 
     @BeforeEach
     void setUp() {
+        testMemberId = 1;
+
+        testMember = Member.builder()
+                .id(testMemberId)
+                .name("홍길동")
+                .phone("01012345678")
+                .build();
+
         testElder = Elder.builder()
                 .id(1)
                 .name("김옥자")
@@ -80,9 +95,10 @@ class HomeReportServiceTest {
         when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
         when(dailyStatisticsRepository.findByElderAndDate(testElder, testDate))
                 .thenReturn(Optional.of(dailyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(5);
 
         // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId, testDateTime);
+        HomeReportResponse response = homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
 
         // then
         assertThat(response).isNotNull();
@@ -98,6 +114,7 @@ class HomeReportServiceTest {
         assertThat(response.getBloodSugar().getMeanValue()).isEqualTo(110);
         assertThat(response.getHealthStatus()).isEqualTo("좋음");
         assertThat(response.getMentalStatus()).isEqualTo("좋음");
+        assertThat(response.getUnreadNotification()).isEqualTo(5);
     }
 
     @Test
@@ -109,7 +126,7 @@ class HomeReportServiceTest {
 
         // when & then
         CustomException exception = assertThrows(CustomException.class, () -> {
-            homeReportService.getHomeReport(elderId, testDateTime);
+            homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
         });
         assertEquals(ErrorCode.ELDER_NOT_FOUND, exception.getErrorCode());
     }
@@ -130,9 +147,10 @@ class HomeReportServiceTest {
                 .thenReturn(Optional.empty());
         when(medicationScheduleRepository.findByElder(testElder))
                 .thenReturn(medicationSchedules);
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(5);
 
         // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId, testDateTime);
+        HomeReportResponse response = homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
 
         // then
         assertThat(response).isNotNull();
@@ -177,6 +195,7 @@ class HomeReportServiceTest {
         assertThat(response.getBloodSugar().getMeanValue()).isNull();
         assertThat(response.getHealthStatus()).isNull();
         assertThat(response.getMentalStatus()).isNull();
+        assertThat(response.getUnreadNotification()).isEqualTo(5);
     }
 
     @Test
@@ -192,9 +211,10 @@ class HomeReportServiceTest {
         when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
         when(dailyStatisticsRepository.findByElderAndDate(testElder, testDate))
                 .thenReturn(Optional.of(dailyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId, testDateTime);
+        HomeReportResponse response = homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
 
         // then
         assertThat(response.getMealStatus().getBreakfast()).isTrue();
@@ -217,9 +237,10 @@ class HomeReportServiceTest {
         when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
         when(dailyStatisticsRepository.findByElderAndDate(testElder, testDate))
                 .thenReturn(Optional.of(dailyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId, testDateTime);
+        HomeReportResponse response = homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
 
         // then
         assertThat(response.getSleep().getMeanHours()).isEqualTo(8);
@@ -241,9 +262,10 @@ class HomeReportServiceTest {
         when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
         when(dailyStatisticsRepository.findByElderAndDate(testElder, testDate))
                 .thenReturn(Optional.of(dailyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId, testDateTime);
+        HomeReportResponse response = homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
 
         // then
         assertThat(response.getSleep().getMeanHours()).isNull();
@@ -265,9 +287,10 @@ class HomeReportServiceTest {
         when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
         when(dailyStatisticsRepository.findByElderAndDate(testElder, testDate))
                 .thenReturn(Optional.of(dailyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId, testDateTime);
+        HomeReportResponse response = homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
 
         // then
         assertThat(response.getBloodSugar().getMeanValue()).isEqualTo(120);
@@ -289,9 +312,10 @@ class HomeReportServiceTest {
         when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
         when(dailyStatisticsRepository.findByElderAndDate(testElder, testDate))
                 .thenReturn(Optional.of(dailyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId, testDateTime);
+        HomeReportResponse response = homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
 
         // then
         assertThat(response.getHealthStatus()).isEqualTo("좋음");
@@ -313,9 +337,10 @@ class HomeReportServiceTest {
         when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
         when(dailyStatisticsRepository.findByElderAndDate(testElder, testDate))
                 .thenReturn(Optional.of(dailyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId, testDateTime);
+        HomeReportResponse response = homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
 
         // then
         assertThat(response.getMedicationStatus().getTotalTaken()).isEqualTo(0);
@@ -337,9 +362,10 @@ class HomeReportServiceTest {
 
         when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
         when(dailyStatisticsRepository.findByElderAndDate(testElder, testDate)).thenReturn(Optional.of(dailyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId, testDateTime);
+        HomeReportResponse response = homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
 
         // then
         assertThat(response.getMedicationStatus().getMedicationList().get(0).getNextTime()).isNull();
@@ -363,9 +389,10 @@ class HomeReportServiceTest {
 
         when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
         when(dailyStatisticsRepository.findByElderAndDate(testElder, testDate)).thenReturn(Optional.of(dailyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId, testDateTime);
+        HomeReportResponse response = homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
 
         // then
         assertThat(response.getMedicationStatus().getMedicationList().get(0).getNextTime()).isEqualTo(MedicationScheduleTime.LUNCH);
@@ -389,9 +416,10 @@ class HomeReportServiceTest {
 
         when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
         when(dailyStatisticsRepository.findByElderAndDate(testElder, testDate)).thenReturn(Optional.of(dailyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId, testDateTime);
+        HomeReportResponse response = homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
 
         // then
         assertThat(response.getMedicationStatus().getMedicationList().get(0).getNextTime()).isEqualTo(MedicationScheduleTime.DINNER);
@@ -415,9 +443,10 @@ class HomeReportServiceTest {
 
         when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
         when(dailyStatisticsRepository.findByElderAndDate(testElder, testDate)).thenReturn(Optional.of(dailyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId, testDateTime);
+        HomeReportResponse response = homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
 
         // then
         assertThat(response.getMedicationStatus().getMedicationList().get(0).getNextTime()).isEqualTo(MedicationScheduleTime.MORNING);
@@ -441,9 +470,10 @@ class HomeReportServiceTest {
 
         when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
         when(dailyStatisticsRepository.findByElderAndDate(testElder, testDate)).thenReturn(Optional.of(dailyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId, testDateTime);
+        HomeReportResponse response = homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
 
         // then
         assertThat(response.getMedicationStatus().getMedicationList().get(0).getNextTime()).isEqualTo(MedicationScheduleTime.MORNING);
@@ -467,9 +497,10 @@ class HomeReportServiceTest {
 
         when(elderRepository.findById(elderId)).thenReturn(Optional.of(testElder));
         when(dailyStatisticsRepository.findByElderAndDate(testElder, testDate)).thenReturn(Optional.of(dailyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        HomeReportResponse response = homeReportService.getHomeReport(elderId, testDateTime);
+        HomeReportResponse response = homeReportService.getHomeReport(testMemberId, elderId, testDateTime);
 
         // then
         assertThat(response.getMedicationStatus().getMedicationList().get(0).getNextTime()).isEqualTo(MedicationScheduleTime.MORNING);

--- a/src/test/java/com/example/medicare_call/service/report/WeeklyReportServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/report/WeeklyReportServiceTest.java
@@ -10,6 +10,7 @@ import com.example.medicare_call.global.exception.ErrorCode;
 import com.example.medicare_call.repository.ElderRepository;
 import com.example.medicare_call.repository.SubscriptionRepository;
 import com.example.medicare_call.repository.WeeklyStatisticsRepository;
+import com.example.medicare_call.service.notification.NotificationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,16 +42,22 @@ class WeeklyReportServiceTest {
     @Mock
     private SubscriptionRepository subscriptionRepository;
 
+    @Mock
+    private NotificationService notificationService;
+
     @InjectMocks
     private WeeklyReportService weeklyReportService;
 
     private Elder testElder;
     private Subscription testSubscription;
+    private Integer testMemberId;
     private LocalDate testStartDate;
     private LocalDate testEndDate;
 
     @BeforeEach
     void setUp() {
+        testMemberId = 1;
+
         testElder = Elder.builder()
                 .id(1)
                 .name("김옥자")
@@ -110,9 +117,10 @@ class WeeklyReportServiceTest {
                 .thenReturn(Optional.of(testElder));
         when(weeklyStatisticsRepository.findByElderAndStartDate(testElder, testStartDate))
                 .thenReturn(Optional.of(weeklyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(5);
 
         // when
-        WeeklyReportResponse response = weeklyReportService.getWeeklyReport(elderId, testStartDate);
+        WeeklyReportResponse response = weeklyReportService.getWeeklyReport(testMemberId, elderId, testStartDate);
 
         // then
         assertThat(response).isNotNull();
@@ -140,6 +148,7 @@ class WeeklyReportServiceTest {
         assertThat(response.getBloodSugar().getAfterMeal().getLow()).isEqualTo(1);
         assertThat(response.getHealthSummary()).isEqualTo("이번 주 전반적으로 건강하게 지내셨습니다.");
         assertThat(response.getSubscriptionStartDate()).isEqualTo(LocalDate.of(2025, 1, 1));
+        assertThat(response.getUnreadNotification()).isEqualTo(5);
     }
 
     @Test
@@ -152,7 +161,7 @@ class WeeklyReportServiceTest {
 
         // when & then
         CustomException exception = assertThrows(CustomException.class, () -> {
-            weeklyReportService.getWeeklyReport(elderId, testStartDate);
+            weeklyReportService.getWeeklyReport(testMemberId, elderId, testStartDate);
         });
         assertEquals(ErrorCode.SUBSCRIPTION_NOT_FOUND, exception.getErrorCode());
     }
@@ -169,7 +178,7 @@ class WeeklyReportServiceTest {
 
         // when & then
         CustomException exception = assertThrows(CustomException.class, () -> {
-            weeklyReportService.getWeeklyReport(elderId, testStartDate);
+            weeklyReportService.getWeeklyReport(testMemberId, elderId, testStartDate);
         });
         assertEquals(ErrorCode.ELDER_NOT_FOUND, exception.getErrorCode());
     }
@@ -192,7 +201,7 @@ class WeeklyReportServiceTest {
 
         // when & then
         CustomException exception = assertThrows(CustomException.class, () -> {
-            weeklyReportService.getWeeklyReport(elderId, testStartDate);
+            weeklyReportService.getWeeklyReport(testMemberId, elderId, testStartDate);
         });
         assertEquals(ErrorCode.ELDER_DELETED, exception.getErrorCode());
     }
@@ -208,9 +217,10 @@ class WeeklyReportServiceTest {
                 .thenReturn(Optional.of(testElder));
         when(weeklyStatisticsRepository.findByElderAndStartDate(testElder, testStartDate))
                 .thenReturn(Optional.empty());
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        WeeklyReportResponse response = weeklyReportService.getWeeklyReport(elderId, testStartDate);
+        WeeklyReportResponse response = weeklyReportService.getWeeklyReport(testMemberId, elderId, testStartDate);
 
         // then
         assertThat(response).isNotNull();
@@ -257,9 +267,10 @@ class WeeklyReportServiceTest {
                 .thenReturn(Optional.of(testElder));
         when(weeklyStatisticsRepository.findByElderAndStartDate(testElder, testStartDate))
                 .thenReturn(Optional.of(weeklyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        WeeklyReportResponse response = weeklyReportService.getWeeklyReport(elderId, testStartDate);
+        WeeklyReportResponse response = weeklyReportService.getWeeklyReport(testMemberId, elderId, testStartDate);
 
         // then
         assertThat(response.getMedicationStats()).isEmpty();
@@ -295,9 +306,10 @@ class WeeklyReportServiceTest {
                 .thenReturn(Optional.of(testElder));
         when(weeklyStatisticsRepository.findByElderAndStartDate(testElder, testStartDate))
                 .thenReturn(Optional.of(weeklyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        WeeklyReportResponse response = weeklyReportService.getWeeklyReport(elderId, testStartDate);
+        WeeklyReportResponse response = weeklyReportService.getWeeklyReport(testMemberId, elderId, testStartDate);
 
         // then
         assertThat(response.getBloodSugar()).isNotNull();
@@ -344,9 +356,10 @@ class WeeklyReportServiceTest {
                 .thenReturn(Optional.of(testElder));
         when(weeklyStatisticsRepository.findByElderAndStartDate(testElder, testStartDate))
                 .thenReturn(Optional.of(weeklyStatistics));
+        when(notificationService.getUnreadCount(testMemberId)).thenReturn(0);
 
         // when
-        WeeklyReportResponse response = weeklyReportService.getWeeklyReport(elderId, testStartDate);
+        WeeklyReportResponse response = weeklyReportService.getWeeklyReport(testMemberId, elderId, testStartDate);
 
         // then
         assertThat(response.getBloodSugar()).isNotNull();


### PR DESCRIPTION
### 배경
- 홈 화면 조회 시 당일 전화 데이터가 없을 때 `404`가 아닌 빈 응답을 뱉어달라는 요청
- 홈 화면 조회 시 읽지 않은 알림 개수 반환 요청
### Desc
- HomeReportService: 일간 통계 없을 때 예외 대신 빈 응답 반환
- WeeklyReportService: 주간 통계 없을 때 예외 대신 빈 응답 반환
- 약 복용 정보는 스케줄 기반으로 구성하여 제공
- 홈 화면/주간 통계 데이터 응답에 unreadNotification 포함
- 관련 테스트 로직 수정 및 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 홈 대시보드 및 주간 통계에 읽지 않은 알림 개수 표시
  * 인증 기반 사용자 식별 강화

* **개선 사항**
  * 데이터가 없는 경우에 대한 안정적인 처리로 사용자 경험 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->