### PR TITLE
feat: AI 건강 데이터 응답 JSON 저장

### DIFF
--- a/src/main/java/com/example/medicare_call/domain/CareCallRecord.java
+++ b/src/main/java/com/example/medicare_call/domain/CareCallRecord.java
@@ -67,9 +67,13 @@ public class CareCallRecord {
     @Column(name = "ai_health_analysis_comment", columnDefinition = "TEXT")
     private String aiHealthAnalysisComment; // AI 건강 분석 코멘트
 
+    @Column(name = "ai_extracted_data_json", columnDefinition = "TEXT")
+    private String aiExtractedDataJson; // AI 로부터 추출된 건강 데이터 전체 JSON
+
     @Builder
     public CareCallRecord(Integer id, Elder elder, CareCallSetting setting, LocalDateTime calledAt, Byte responded, LocalDateTime sleepStart, LocalDateTime sleepEnd, Byte healthStatus, Byte psychStatus,
-                          LocalDateTime startTime, LocalDateTime endTime, String callStatus, String transcriptionText, String psychologicalDetails, String healthDetails, String aiHealthAnalysisComment) {
+                          LocalDateTime startTime, LocalDateTime endTime, String callStatus, String transcriptionText, String psychologicalDetails, String healthDetails, String aiHealthAnalysisComment,
+                          String aiExtractedDataJson) {
         this.id = id;
         this.elder = elder;
         this.setting = setting;
@@ -86,5 +90,6 @@ public class CareCallRecord {
         this.psychologicalDetails = psychologicalDetails;
         this.healthDetails = healthDetails;
         this.aiHealthAnalysisComment = aiHealthAnalysisComment;
+        this.aiExtractedDataJson = aiExtractedDataJson;
     }
 } 

--- a/src/main/resources/db/migration/V29__add_ai_extracted_data_json_to_care_call_record.sql
+++ b/src/main/resources/db/migration/V29__add_ai_extracted_data_json_to_care_call_record.sql
@@ -1,0 +1,2 @@
+ALTER TABLE CareCallRecord
+ADD COLUMN ai_extracted_data_json TEXT COMMENT 'AI로부터 추출된 건강 데이터 전체 JSON';


### PR DESCRIPTION
### 배경
- 사용성 테스트를 위해 HealthDataExtractionResponse의 내용을 PM과 AI 개발자가 확인하고자 함
- AI가 뱉어낸 JSON 전문을 CareCallRecord의 새로운 속성을 추가하여 저장해달라는 요청
### Desc
- CareCallRecord에 aiExtractedDataJson 필드 추가하여 JSON 문자열 저장

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * AI로부터 추출된 건강 데이터가 이제 JSON 형식으로 진료 통화 기록에 저장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->