### PR TITLE
feat: 건강 데이터 추출에 식사 섭취 여부 필드 추가

### DIFF
--- a/src/main/java/com/example/medicare_call/dto/data_processor/HealthDataExtractionResponse.java
+++ b/src/main/java/com/example/medicare_call/dto/data_processor/HealthDataExtractionResponse.java
@@ -63,7 +63,14 @@ public class HealthDataExtractionResponse {
             allowableValues = {"아침", "점심", "저녁"}
         )
         private String mealType;
-        
+
+        @Schema(
+                description = "식사 여부",
+                example = "섭취함",
+                allowableValues = {"섭취함", "섭취하지 않음"}
+        )
+        private String mealEatenStatus;
+
         @Schema(description = "식사 요약", example = "아침 식사를 하였음")
         private String mealSummary;
     }

--- a/src/main/java/com/example/medicare_call/global/enums/MealEatenStatus.java
+++ b/src/main/java/com/example/medicare_call/global/enums/MealEatenStatus.java
@@ -23,4 +23,13 @@ public enum MealEatenStatus {
         }
         return null;
     }
+
+    public static MealEatenStatus fromDescription(String description) {
+        for (MealEatenStatus status : values()) {
+            if (status.getDescription().equals(description)) {
+                return status;
+            }
+        }
+        return null;
+    }
 } 

--- a/src/main/java/com/example/medicare_call/service/ai/AiHealthDataExtractorService.java
+++ b/src/main/java/com/example/medicare_call/service/ai/AiHealthDataExtractorService.java
@@ -110,6 +110,7 @@ public class AiHealthDataExtractorService {
             1. 금일의 날짜
             2. 식사 데이터
                - 식사의 종류 (아침/점심/저녁)
+               - 식사 여부 (반드시 "섭취함" 또는 "섭취하지 않음"으로 응답)
                - 식사 간단 요약
             3. 수면 데이터
                - 취침 시작 시각 (HH:mm 형식, 예: 22:00)
@@ -139,6 +140,7 @@ public class AiHealthDataExtractorService {
               "mealData": [
                   {
                     "mealType": "아침/점심/저녁",
+                    "mealEatenStatus": "섭취함/섭취하지 않음",
                     "mealSummary": "식사 요약"
                   }
               ],

--- a/src/main/java/com/example/medicare_call/service/statistics/DailyStatisticsService.java
+++ b/src/main/java/com/example/medicare_call/service/statistics/DailyStatisticsService.java
@@ -153,13 +153,13 @@ public class DailyStatisticsService {
                 if (mealType != null) {
                     switch (mealType) {
                         case BREAKFAST:
-                            breakfast = meal.getEatenStatus() == (byte) 1;
+                            breakfast = meal.getEatenStatus() != null ? meal.getEatenStatus() == (byte) 1 : null;
                             break;
                         case LUNCH:
-                            lunch = meal.getEatenStatus() == (byte) 1;
+                            lunch = meal.getEatenStatus() != null ? meal.getEatenStatus() == (byte) 1 : null;
                             break;
                         case DINNER:
-                            dinner = meal.getEatenStatus() == (byte) 1;
+                            dinner = meal.getEatenStatus() != null ? meal.getEatenStatus() == (byte) 1 : null;
                             break;
                     }
                 }

--- a/src/test/java/com/example/medicare_call/service/ai/AiHealthDataExtractorServiceTest.java
+++ b/src/test/java/com/example/medicare_call/service/ai/AiHealthDataExtractorServiceTest.java
@@ -55,19 +55,20 @@ class AiHealthDataExtractorServiceTest {
         String mockOpenAiResponse = """
             {
               "date": "2024-01-01",
-              "mealData": {
+              "mealData": [{
                 "mealType": "아침",
+                "mealEatenStatus": "섭취함",
                 "mealSummary": "아침 식사를 하였음"
-              },
+              }],
               "sleepData": null,
               "psychologicalState": ["기분이 좋음"],
-              "bloodSugarData": {
+              "bloodSugarData": [{
                 "measurementTime": "아침",
                 "mealTime": "식후",
                 "bloodSugarValue": 120,
                 "status": "NORMAL"
-              },
-              "medicationData": null,
+              }],
+              "medicationData": [],
               "healthSigns": ["혈당이 정상 범위"]
             }
             """;
@@ -85,7 +86,7 @@ class AiHealthDataExtractorServiceTest {
         HealthDataExtractionResponse.BloodSugarData bloodSugar = HealthDataExtractionResponse.BloodSugarData.builder()
                 .measurementTime("아침").mealTime("식후").bloodSugarValue(120).status("NORMAL").build();
         HealthDataExtractionResponse.MealData meal = HealthDataExtractionResponse.MealData.builder()
-                .mealType("아침").mealSummary("아침 식사를 하였음").build();
+                .mealType("아침").mealEatenStatus("섭취함").mealSummary("아침 식사를 하였음").build();
         HealthDataExtractionResponse expectedResponse = HealthDataExtractionResponse.builder()
                 .date("2024-01-01")
                 .mealData(List.of(meal))
@@ -124,7 +125,11 @@ class AiHealthDataExtractorServiceTest {
         String mockOpenAiResponse = """
                 {
                    "date": "2024-01-01",
-                   "mealData": { "mealType": "아침", "mealSummary": "아침 식사를 하였음" },
+                   "mealData": [{
+                     "mealType": "아침",
+                     "mealEatenStatus": "섭취함",
+                     "mealSummary": "아침 식사를 하였음"
+                   }],
                    "sleepData": null,
                    "psychologicalState": ["기분이 좋음"],
                    "bloodSugarData": [{
@@ -151,7 +156,7 @@ class AiHealthDataExtractorServiceTest {
         HealthDataExtractionResponse.BloodSugarData bloodSugar = HealthDataExtractionResponse.BloodSugarData.builder()
                 .measurementTime("아침").mealTime("식후").bloodSugarValue(120).status("NORMAL").build();
         HealthDataExtractionResponse.MealData meal = HealthDataExtractionResponse.MealData.builder()
-                .mealType("아침").mealSummary("아침 식사를 하였음").build();
+                .mealType("아침").mealEatenStatus("섭취함").mealSummary("아침 식사를 하였음").build();
 
         HealthDataExtractionResponse expectedResponse = HealthDataExtractionResponse.builder()
                 .date("2024-01-01")

--- a/src/test/java/com/example/medicare_call/service/data_processor/HealthDataExtractionIntegrationTest.java
+++ b/src/test/java/com/example/medicare_call/service/data_processor/HealthDataExtractionIntegrationTest.java
@@ -70,6 +70,7 @@ class HealthDataExtractionIntegrationTest {
                   "date": "2024-01-01",
                   "mealData": [{
                     "mealType": "아침",
+                    "mealEatenStatus": "섭취함",
                     "mealSummary": "김치찌개와 밥을 먹었음"
                   }],
                   "sleepData": null,


### PR DESCRIPTION
### Desc
- HealthDataExtractionResponse.MealData에 mealEatenStatus 필드 추가
- mealEatenStatus가 null일 때 responseSummary를 고정 메시지로 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 끼니 섭취 여부 추적 기능 추가: 아침, 점심, 저녁 각 끼니별로 섭취 여부를 명확히 기록합니다.

## 개선 사항
* 섭취 여부를 알 수 없는 경우 사용자에게 명확한 안내 메시지 제공으로 건강 데이터 수집의 정확성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->