### PR TITLE
refactor: HealthDataTestApi

### DIFF
--- a/src/main/java/com/example/medicare_call/api/HealthDataTestApi.java
+++ b/src/main/java/com/example/medicare_call/api/HealthDataTestApi.java
@@ -4,6 +4,7 @@ import com.example.medicare_call.domain.CareCallRecord;
 import com.example.medicare_call.dto.HealthDataTestRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -13,35 +14,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface HealthDataTestApi {
 
     @Operation(
-        summary = "[개발자용] 건강 데이터 DB 저장 테스트",
-        description = "건강 데이터를 DB에 저장하는 기능을 테스트합니다. (테스트용 엔드포인트)"
+        summary = "[개발자용] 건강 데이터 추출 테스트",
+        description = "건강 데이터를 추출하여 DB에 저장하는 기능을 테스트합니다. (테스트용 엔드포인트)"
     )
     @ApiResponses({
         @ApiResponse(
             responseCode = "200",
-            description = "건강 데이터 DB 저장 성공",
-                content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = CareCallRecord.class)
-                )
-        ),
-        @ApiResponse(
-            responseCode = "500",
-            description = "서버 내부 오류"
-        )
-    })
-    public ResponseEntity<CareCallRecord> saveHealthDataToDatabase(
-            @RequestBody HealthDataTestRequest request
-    );
-
-    @Operation(
-        summary = "[개발자용] 건강 데이터 DB 저장 테스트 (수면 데이터)",
-        description = "수면 데이터가 포함된 건강 데이터를 DB에 저장하는 기능을 테스트합니다. (테스트용 엔드포인트)"
-    )
-    @ApiResponses({
-        @ApiResponse(
-            responseCode = "200",
-            description = "건강 데이터 DB 저장 성공",
+            description = "건강 데이터 추출 및 저장 성공",
             content = @Content(
                 mediaType = "application/json",
                 schema = @Schema(implementation = CareCallRecord.class)
@@ -52,29 +31,45 @@ public interface HealthDataTestApi {
             description = "서버 내부 오류"
         )
     })
-    public ResponseEntity<CareCallRecord> saveSleepDataToDatabase(
-            @RequestBody HealthDataTestRequest request
-    );
-
-    @Operation(
-        summary = "[개발자용] 건강 데이터 DB 저장 테스트 (복약 데이터)",
-        description = "복약 데이터가 포함된 건강 데이터를 DB에 저장하는 기능을 테스트합니다. (테스트용 엔드포인트)"
-    )
-    @ApiResponses({
-        @ApiResponse(
-            responseCode = "200",
-            description = "건강 데이터 DB 저장 성공",
+    public ResponseEntity<CareCallRecord> saveTestHealthData(
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
             content = @Content(
-                mediaType = "application/json",
-                schema = @Schema(implementation = CareCallRecord.class)
+                examples = {
+                    @ExampleObject(
+                        name = "General Health",
+                        value = """
+                            {
+                              "elderId": 1,
+                              "settingId": 1,
+                              "transcriptionText": "오늘 아침에 밥을 먹었고, 혈당을 측정했어요. 120이 나왔어요. 기분도 좋아요.",
+                              "callDate": "2024-01-01"
+                            }
+                        """
+                    ),
+                    @ExampleObject(
+                        name = "Sleep",
+                        value = """
+                            {
+                              "elderId": 1,
+                              "settingId": 1,
+                              "transcriptionText": "어제 밤 10시에 잠들어서 오늘 아침 6시에 일어났어요. 8시간 잘 잤어요.",
+                              "callDate": "2024-01-01"
+                            }
+                        """
+                    ),
+                    @ExampleObject(
+                        name = "Medication",
+                        value = """
+                            {
+                              "elderId": 1,
+                              "settingId": 1,
+                              "transcriptionText": "혈압약을 아침에 복용했어요. 오늘은 머리가 좀 아파요.",
+                              "callDate": "2024-01-01"
+                            }
+                        """
+                    )
+                }
             )
-        ),
-        @ApiResponse(
-            responseCode = "500",
-            description = "서버 내부 오류"
-        )
-    })
-    public ResponseEntity<CareCallRecord> saveMedicationDataToDatabase(
-        @RequestBody HealthDataTestRequest request
+        ) @RequestBody HealthDataTestRequest request
     );
 }

--- a/src/main/java/com/example/medicare_call/controller/HealthDataController.java
+++ b/src/main/java/com/example/medicare_call/controller/HealthDataController.java
@@ -46,10 +46,10 @@ public class HealthDataController implements HealthDataApi, HealthDataTestApi {
     }
 
     @Override
-    @PostMapping("/save-to-database")
-    public ResponseEntity<CareCallRecord> saveHealthDataToDatabase(
+    @PostMapping("/extract/test")
+    public ResponseEntity<CareCallRecord> saveTestHealthData(
             @RequestBody @Schema(
-                    description = "건강 데이터 DB 저장 테스트 요청",
+                    description = "건강 데이터 추출 테스트",
                     example = """
             {
               "elderId": 1,
@@ -60,7 +60,7 @@ public class HealthDataController implements HealthDataApi, HealthDataTestApi {
             """
             ) HealthDataTestRequest request
     ) {
-        log.info("건강 데이터 DB 저장 테스트 요청: {}", request);
+        log.info("건강 데이터 추출 테스트: {}", request);
 
         // 테스트용 CareCallRecord 조회 또는 생성
         CareCallRecord savedCallRecord = testDataGenerator.createOrGetTestCallRecord(
@@ -82,81 +82,4 @@ public class HealthDataController implements HealthDataApi, HealthDataTestApi {
 
         return ResponseEntity.ok(savedCallRecord);
     }
-
-    @Override
-    @PostMapping("/save-sleep-data")
-    public ResponseEntity<CareCallRecord> saveSleepDataToDatabase(
-            @RequestBody @Schema(
-                    description = "수면 데이터 DB 저장 테스트 요청",
-                    example = """
-            {
-              "elderId": 1,
-              "settingId": 1,
-              "transcriptionText": "어제 밤 10시에 잠들어서 오늘 아침 6시에 일어났어요. 8시간 잘 잤어요.",
-              "callDate": "2024-01-01"
-            }
-            """
-            ) HealthDataTestRequest request
-    ) {
-        log.info("수면 데이터 DB 저장 테스트 요청: {}", request);
-
-        // 테스트용 CareCallRecord 조회 또는 생성
-        CareCallRecord savedCallRecord = testDataGenerator.createOrGetTestCallRecord(
-                request.getElderId(),
-                request.getSettingId(),
-                request.getTranscriptionText()
-        );
-
-        // OpenAI를 통한 건강 데이터 추출
-        HealthDataExtractionRequest extractionRequest = HealthDataExtractionRequest.builder()
-                .transcriptionText(request.getTranscriptionText())
-                .callDate(request.getCallDate())
-                .build();
-
-        HealthDataExtractionResponse healthData = aiHealthDataExtractorService.extractHealthData(extractionRequest);
-
-        // 건강 데이터를 DB에 저장
-        careCallDataProcessingService.saveHealthDataToDatabase(savedCallRecord, healthData);
-
-        return ResponseEntity.ok(savedCallRecord);
-    }
-
-    @Override
-    @PostMapping("/save-medication-data")
-    public ResponseEntity<CareCallRecord> saveMedicationDataToDatabase(
-            @RequestBody @Schema(
-                    description = "복약 데이터 DB 저장 테스트 요청",
-                    example = """
-            {
-              "elderId": 1,
-              "settingId": 1,
-              "transcriptionText": "혈압약을 아침에 복용했어요. 오늘은 머리가 좀 아파요.",
-              "callDate": "2024-01-01"
-            }
-            """
-            ) HealthDataTestRequest request
-    ) {
-        log.info("복약 데이터 DB 저장 테스트 요청: {}", request);
-
-        // 테스트용 CareCallRecord 조회 또는 생성
-        CareCallRecord savedCallRecord = testDataGenerator.createOrGetTestCallRecord(
-                request.getElderId(),
-                request.getSettingId(),
-                request.getTranscriptionText()
-        );
-
-        // OpenAI를 통한 건강 데이터 추출
-        HealthDataExtractionRequest extractionRequest = HealthDataExtractionRequest.builder()
-                .transcriptionText(request.getTranscriptionText())
-                .callDate(request.getCallDate())
-                .build();
-
-        HealthDataExtractionResponse healthData = aiHealthDataExtractorService.extractHealthData(extractionRequest);
-
-        // 건강 데이터를 DB에 저장
-        careCallDataProcessingService.saveHealthDataToDatabase(savedCallRecord, healthData);
-
-        return ResponseEntity.ok(savedCallRecord);
-    }
-
 }


### PR DESCRIPTION
### Desc
- 건강정보 추출 테스트 API에 대해 기존에는 편의를 위해 Schema가 다른 `HealthDataTestRequest`를 받는 엔드포인트를 중복 정의하여 사용하고 있었다.
  - 하나의 테스트 API로 통일하고, 여러 `ExampleObject` 옵션을 사용할 수 있도록 변경
- 엔드포인트 수정
  - `/save-to-database` -> `/extract/test`
  - 기존의 건강정보 추출 API인 `/extract`와 통일